### PR TITLE
17371: Change a key of the passed JSON to the Engine on get_internal_parameters

### DIFF
--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -2520,7 +2520,7 @@ class HowsoCore:
         """
         return self._execute("get_internal_parameters", {
             "trainee": trainee_id,
-            "feature": action_feature,
+            "action_feature": action_feature,
             "context_features": context_features,
             "mode": mode,
             "weight_feature": weight_feature,


### PR DESCRIPTION
Renaming the parameter on get_internal_parameters to `action_feature` rather than `feature`. Reflecting that change here.