### PR TITLE
16846: Adds parameters to `get_marginal_stats` to support conditioned stats, MINOR

### DIFF
--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -201,7 +201,13 @@ class AbstractHowsoClient(ABC):
         """Get cached feature prediction stats."""
 
     @abstractmethod
-    def get_marginal_stats(self, trainee_id, *, weight_feature=None):
+    def get_marginal_stats(
+        self, trainee_id, *,
+        condition=None,
+        num_cases=None,
+        precision=None,
+        weight_feature=None,
+    ):
         """Get marginal stats for all features."""
 
     @abstractmethod

--- a/howso/client/tests/test_client.py
+++ b/howso/client/tests/test_client.py
@@ -1114,6 +1114,7 @@ class TestBaseClient:
         assert first_params['hyperparameter_map'] == second_params['hyperparameter_map']
 
     def test_get_specific_hyperparameters(self, trainee):
+        """Test to verify parameters of get_params are functional"""
         param_map = {"hyperparameter_map": {
             "petal_length": {
                 "sepal_length.sepal_width.": {
@@ -1353,6 +1354,28 @@ class TestBaseClient:
             "Improper shape of `new_cases` values passed. "
             "`new_cases` must be a 3d list of object."
         ) in str(exc.value)
+
+    def test_marginal_stats(self, trainee):
+        """Test for get_marginal_stats and its parameters."""
+        new_cases = [[1, 2, 3, 4, 0],
+                     [4, 6, 6, 7, 1],
+                     [6, 8, 9, 9, 1],
+                     [1, 2, 3, 4, 2]]
+        features = ['sepal_length', 'sepal_width', 'petal_length',
+                    'petal_width', 'class']
+        self.client.train(trainee.id, new_cases, features=features)
+
+        marginal_stats = self.client.get_marginal_stats(trainee.id)
+        assert marginal_stats['sepal_length']['mean'] == 3.0
+        assert marginal_stats['sepal_width']['mean'] == 4.5
+        assert marginal_stats['sepal_width']['count'] == 4
+
+        conditional_marginal_stats = self.client.get_marginal_stats(
+            trainee.id,
+            condition={"class": '1'},
+        )
+        assert conditional_marginal_stats['class']['count'] == 2
+        assert conditional_marginal_stats['petal_width']['mean'] == 8
 
     def test_remove_feature_verbose(self, trainee, capsys):
         """Test for expected verbose output when remove_feature is called."""

--- a/howso/client/tests/test_client.py
+++ b/howso/client/tests/test_client.py
@@ -1046,6 +1046,7 @@ class TestBaseClient:
                 f'id: {trainee.id}') in out
 
     def test_set_and_get_params(self, trainee, trainee_builder):
+        """Test for set_params and get_params functionality."""
         param_map = {"hyperparameter_map": {
             "petal_length": {
                 "sepal_length.sepal_width.": {
@@ -1114,7 +1115,7 @@ class TestBaseClient:
         assert first_params['hyperparameter_map'] == second_params['hyperparameter_map']
 
     def test_get_specific_hyperparameters(self, trainee):
-        """Test to verify parameters of get_params are functional"""
+        """Test to verify parameters of get_params are functional."""
         param_map = {"hyperparameter_map": {
             "petal_length": {
                 "sepal_length.sepal_width.": {

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -114,6 +114,14 @@ class HowsoDirectClient(AbstractHowsoClient):
     #: The characters which are disallowed from being a part of a Trainee name or ID.
     BAD_TRAINEE_NAME_CHARS = {'..', '\\', '/', ':'}
 
+    #: The supported values of precision for methods that accept it
+    SUPPORTED_PRECISION_VALUES = ["exact", "similar"]
+    INCORRECT_PRECISION_VALUE_WARNING = (
+        "Supported values for 'precision' are \"exact\" and \"similar\". The "
+        "operation will be completed as if the value of 'precision' is "
+        "\"exact\"."
+    )
+
     def __init__(
         self,
         howso_core: Optional[HowsoCore] = None,
@@ -1412,6 +1420,10 @@ class HowsoDirectClient(AbstractHowsoClient):
         if self.verbose:
             print(f'Removing case(s) in trainee with id: {trainee_id}')
 
+        if isinstance(precision, str):
+            if precision not in self.SUPPORTED_PRECISION_VALUES:
+                warnings.warn(self.INCORRECT_PRECISION_VALUE_WARNING)
+
         # Convert session instance to id
         if (
             isinstance(condition, dict) and
@@ -1497,6 +1509,10 @@ class HowsoDirectClient(AbstractHowsoClient):
         """
         self._auto_resolve_trainee(trainee_id)
         cached_trainee = self.trainee_cache.get(trainee_id)
+
+        if isinstance(precision, str):
+            if precision not in self.SUPPORTED_PRECISION_VALUES:
+                warnings.warn(self.INCORRECT_PRECISION_VALUE_WARNING)
 
         # Validate case_indices if provided
         if case_indices is not None:
@@ -3319,6 +3335,10 @@ class HowsoDirectClient(AbstractHowsoClient):
         if case_indices is not None:
             validate_case_indices(case_indices)
 
+        if isinstance(precision, str):
+            if precision not in self.SUPPORTED_PRECISION_VALUES:
+                warnings.warn(self.INCORRECT_PRECISION_VALUE_WARNING)
+
         self._auto_resolve_trainee(trainee_id)
         validate_list_shape(features, 1, "features", "str")
         if session is None and case_indices is None:
@@ -3981,6 +4001,10 @@ class HowsoDirectClient(AbstractHowsoClient):
         """
         self._auto_resolve_trainee(trainee_id)
 
+        if isinstance(precision, str):
+            if precision not in self.SUPPORTED_PRECISION_VALUES:
+                warnings.warn(self.INCORRECT_PRECISION_VALUE_WARNING)
+
         if self.verbose:
             print('Getting feature prediction stats for trainee with '
                   f'id: {trainee_id}')
@@ -4061,6 +4085,10 @@ class HowsoDirectClient(AbstractHowsoClient):
             A map of feature names to map of stat type to stat values.
         """
         self._auto_resolve_trainee(trainee_id)
+
+        if isinstance(precision, str):
+            if precision not in self.SUPPORTED_PRECISION_VALUES:
+                warnings.warn(self.INCORRECT_PRECISION_VALUE_WARNING)
 
         if self.verbose:
             print('Getting feature marginal stats for trainee with '
@@ -4464,6 +4492,10 @@ class HowsoDirectClient(AbstractHowsoClient):
         self._auto_resolve_trainee(target_trainee_id)
         if num_cases < 1:
             raise ValueError('num_cases must be a value greater than 0')
+
+        if isinstance(precision, str):
+            if precision not in self.SUPPORTED_PRECISION_VALUES:
+                warnings.warn(self.INCORRECT_PRECISION_VALUE_WARNING)
 
         if self.verbose:
             print(f'Moving case from trainee with id: {trainee_id} to trainee '

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -3872,7 +3872,7 @@ class HowsoDirectClient(AbstractHowsoClient):
         condition: Optional[Dict[str, Any]] = None,
         num_cases: Optional[int] = None,
         num_robust_influence_samples_per_case=None,
-        precision: Optional[str] = None,
+        precision: Optional[Literal["exact", "similar"]] = None,
         robust: Optional[bool] = None,
         robust_hyperparameters: Optional[bool] = None,
         stats: Optional[Iterable[str]] = None,
@@ -4016,6 +4016,9 @@ class HowsoDirectClient(AbstractHowsoClient):
         self,
         trainee_id: str,
         *,
+        condition: Optional[Dict[str, Any]] = None,
+        num_cases: Optional[int] = None,
+        precision: Optional[Literal["exact", "similar"]] = None,
         weight_feature: Optional[str] = None
     ) -> Dict[str, Dict[str, float]]:
         """
@@ -4025,6 +4028,29 @@ class HowsoDirectClient(AbstractHowsoClient):
         ----------
         trainee_id : str
             The ID of the Trainee to retrieve marginal stats for.
+        condition : dict or None, optional
+            A condition map to select which cases to compute marginal stats
+            for.
+
+            .. NOTE::
+                The dictionary keys are the feature name and values are one of:
+
+                    - None
+                    - A value, must match exactly.
+                    - An array of two numeric values, specifying an inclusive
+                      range. Only applicable to continuous and numeric ordinal
+                      features.
+                    - An array of string values, must match any of these values
+                      exactly. Only applicable to nominal and string ordinal
+                      features.
+        num_cases : int, default None
+            The maximum amount of cases to use to calculate marginal stats.
+            If not specified, the limit will be k cases if precision is
+            "similar". Only used if `condition` is not None.
+        precision : str, default None
+            The precision to use when selecting cases with the condition.
+            Options are 'exact' or 'similar'. If not specified "exact" will be
+            used. Only used if `condition` is not None.
         weight_feature : str, optional
             When specified, will attempt to return stats that were computed
             using this weight_feature.
@@ -4042,6 +4068,9 @@ class HowsoDirectClient(AbstractHowsoClient):
 
         stats = self.howso.get_marginal_stats(
             trainee_id,
+            condition=condition,
+            num_cases=num_cases,
+            precision=precision,
             weight_feature=weight_feature)
         return stats
 

--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -2437,6 +2437,9 @@ class HowsoCore:
         self,
         trainee_id: str,
         *,
+        condition: Optional[Dict[str, Any]] = None,
+        num_cases: Optional[int] = None,
+        precision: Optional[Literal["exact", "similar"]] = None,
         weight_feature: Optional[str] = None
     ) -> Dict[str, Dict[str, float]]:
         """
@@ -2446,6 +2449,29 @@ class HowsoCore:
         ----------
         trainee_id : str
             The identifier of the Trainee.
+        condition : dict or None, optional
+            A condition map to select which cases to compute marginal stats
+            for.
+
+            .. NOTE::
+                The dictionary keys are the feature name and values are one of:
+
+                    - None
+                    - A value, must match exactly.
+                    - An array of two numeric values, specifying an inclusive
+                      range. Only applicable to continuous and numeric ordinal
+                      features.
+                    - An array of string values, must match any of these values
+                      exactly. Only applicable to nominal and string ordinal
+                      features.
+        num_cases : int, default None
+            The maximum amount of cases to use to calculate marginal stats.
+            If not specified, the limit will be k cases if precision is
+            "similar". Only used if `condition` is not None.
+        precision : str, default None
+            The precision to use when selecting cases with the condition.
+            Options are 'exact' or 'similar'. If not specified "exact" will be
+            used. Only used if `condition` is not None.
         weight_feature : str, optional
             When specified, will attempt to return stats that were computed
             using this weight_feature.
@@ -2457,6 +2483,9 @@ class HowsoCore:
         """
         return self._execute("get_marginal_stats", {
             "trainee": trainee_id,
+            "condition": condition,
+            "num_cases": num_cases,
+            "precision": precision,
             "weight_feature": weight_feature,
         })
 

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -2717,13 +2717,40 @@ class Trainee(BaseTrainee):
         )
 
     def get_marginal_stats(
-        self, *, weight_feature: Optional[str] = None,
+        self, *,
+        condition: Optional[Dict[str, Any]] = None,
+        num_cases: Optional[int] = None,
+        precision: Optional[Literal["exact", "similar"]] = None,
+        weight_feature: Optional[str] = None,
     ) -> "DataFrame":
         """
         Get marginal stats for all features.
 
         Parameters
         ----------
+        condition : dict or None, optional
+            A condition map to select which cases to compute marginal stats
+            for.
+
+            .. NOTE::
+                The dictionary keys are the feature name and values are one of:
+
+                    - None
+                    - A value, must match exactly.
+                    - An array of two numeric values, specifying an inclusive
+                      range. Only applicable to continuous and numeric ordinal
+                      features.
+                    - An array of string values, must match any of these values
+                      exactly. Only applicable to nominal and string ordinal
+                      features.
+        num_cases : int, default None
+            The maximum amount of cases to use to calculate marginal stats.
+            If not specified, the limit will be k cases if precision is
+            "similar". Only used if `condition` is not None.
+        precision : str, default None
+            The precision to use when selecting cases with the condition.
+            Options are 'exact' or 'similar'. If not specified "exact" will be
+            used. Only used if `condition` is not None.
         weight_feature : str, optional
             When specified, will attempt to return stats that were computed
             using this weight_feature.
@@ -2736,6 +2763,9 @@ class Trainee(BaseTrainee):
         """
         return self.client.get_marginal_stats(
             trainee_id=self.id,
+            condition=condition,
+            num_cases=num_cases,
+            precision=precision,
             weight_feature=weight_feature
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
    "semantic-version>=2.8.5,<3",
    "typing-extensions>=4.1.0,<5.0",
    "urllib3>=1.26.2,<=2",
-   "howso-openapi-client==25.0.0",
+   "howso-openapi-client==25.0.6",
    "amalgam-lang==3.0.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
    "typing-extensions>=4.1.0,<5.0",
    "urllib3>=1.26.2,<=2",
    "howso-openapi-client==25.0.0",
-   "amalgam-lang==3.0.1",
+   "amalgam-lang==3.0.2",
 ]
 
 [project.optional-dependencies]

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "howso-engine": "68.1.0"
+    "howso-engine": "68.2.0"
   }
 }


### PR DESCRIPTION
Adding our usual condition parameters ('condition', 'num_cases', and 'precision') to get_marginal_stats, which lets users find marginal stats on subsets of the data matching their condition.