### PR TITLE
17498: Add catch for ISO8601 in validate_dtype

### DIFF
--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -193,8 +193,10 @@ class FeatureAttributesBase(dict):
                 pass
         elif expected_dtype == 'datetime64':
             try:
-                series = pd.to_datetime(coerced_df[feature],
-                                        format=self[feature]['date_time_format'])
+                format = self[feature]['date_time_format']
+                if ".%f" in format:
+                    format = "ISO8601"
+                series = pd.to_datetime(coerced_df[feature], format=format)
                 if coerce:
                     if localize_datetimes and not isinstance(series, pd.DatetimeTZDtype):
                         series = series.dt.tz_localize('UTC', ambiguous='infer',


### PR DESCRIPTION
- Add catch which fixes an inability to validate the data type of ISO8601 string date-times.