### PR TITLE
17617: Adjust release builds for PyPi trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,6 +391,11 @@ jobs:
 
   release:
     if: inputs.build-type == 'release'
+    environment:
+      name: pypi
+    permissions:
+      contents: write
+      id-token: write
     needs:
       - unit-test-3-8
       - unit-test-3-9


### PR DESCRIPTION
Adds the correct deployment and permissions settings to the release job so that PyPi recognizes this repository as a trusted publisher.