### PR TITLE
17692: Fixes order of parameters passed into auto_analyze_params

### DIFF
--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -4842,10 +4842,10 @@ class HowsoDirectClient(AbstractHowsoClient):
 
         self.howso.auto_analyze_params(
             trainee_id=trainee_id,
-			auto_analyze_enabled=auto_analyze_enabled,
+            auto_analyze_enabled=auto_analyze_enabled,
             analyze_threshold=analyze_threshold,
-			auto_analyze_limit_size=auto_analyze_limit_size,
-			analyze_growth_factor=analyze_growth_factor,
+            auto_analyze_limit_size=auto_analyze_limit_size,
+            analyze_growth_factor=analyze_growth_factor,
             **parameters,
             **kwargs
         )

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -4841,11 +4841,11 @@ class HowsoDirectClient(AbstractHowsoClient):
                 'have an effect.', UserWarning)
 
         self.howso.auto_analyze_params(
-            trainee_id,
-            auto_analyze_enabled,
-            analyze_threshold,
-            analyze_growth_factor,
-            auto_analyze_limit_size,
+            trainee_id=trainee_id,
+			auto_analyze_enabled=auto_analyze_enabled,
+            analyze_threshold=analyze_threshold,
+			auto_analyze_limit_size=auto_analyze_limit_size,
+			analyze_growth_factor=analyze_growth_factor,
             **parameters,
             **kwargs
         )


### PR DESCRIPTION
the order of analyze_growth_factor and auto_analyze_limit_size was flipped in the method being called, so when the TS RL recipe was intending to set the analyze limit size, it was instead setting the growth factor.