### PR TITLE
17716: Ignore future warnings for pandas to_pydatetime method.

### DIFF
--- a/howso/utilities/features.py
+++ b/howso/utilities/features.py
@@ -14,7 +14,7 @@ from pandas.core.dtypes.common import (
 )
 import pytz
 
-from .internals import deserialize_to_dataframe, to_pandas_datetime_format
+from .internals import deserialize_to_dataframe, IgnoreFutureWarnings, to_pandas_datetime_format
 from .utilities import (
     DATETIME_TIMEZONE_PATTERN,
     LocaleOverride,
@@ -117,8 +117,11 @@ class FeatureSerializer:
                         "names. All column names must be unique.")
                 dtype = col_data.dtype
                 if is_datetime64_any_dtype(dtype):
-                    # Make sure datetimes are returned as python datetimes
-                    data_columns.append(np.array(col_data.dt.to_pydatetime()))
+                    # `to_pydatetime` emits a FutureWarning even when the issue
+                    # is fixed.
+                    with IgnoreFutureWarnings():
+                        # Make sure datetimes are returned as python datetimes
+                        data_columns.append(np.array(col_data.dt.to_pydatetime()))
                 elif is_timedelta64_dtype(dtype):
                     # Make sure timedeltas are returned as python timedeltas
                     data_columns.append(col_data.dt.to_pytimedelta())

--- a/howso/utilities/features.py
+++ b/howso/utilities/features.py
@@ -16,7 +16,7 @@ import pytz
 
 from .internals import (
     deserialize_to_dataframe,
-    IgnoreFutureWarnings,
+    IgnoreWarnings,
     to_pandas_datetime_format
 )
 from .utilities import (
@@ -123,7 +123,7 @@ class FeatureSerializer:
                 if is_datetime64_any_dtype(dtype):
                     # `to_pydatetime` emits a FutureWarning even when the issue
                     # is fixed.
-                    with IgnoreFutureWarnings():
+                    with IgnoreWarnings(FutureWarning):
                         # Make sure datetimes are returned as python datetimes
                         data_columns.append(np.array(col_data.dt.to_pydatetime()))
                 elif is_timedelta64_dtype(dtype):

--- a/howso/utilities/features.py
+++ b/howso/utilities/features.py
@@ -14,7 +14,11 @@ from pandas.core.dtypes.common import (
 )
 import pytz
 
-from .internals import deserialize_to_dataframe, IgnoreFutureWarnings, to_pandas_datetime_format
+from .internals import (
+    deserialize_to_dataframe,
+    IgnoreFutureWarnings,
+    to_pandas_datetime_format
+)
 from .utilities import (
     DATETIME_TIMEZONE_PATTERN,
     LocaleOverride,

--- a/howso/utilities/internals.py
+++ b/howso/utilities/internals.py
@@ -815,8 +815,8 @@ class IgnoreWarnings:
 
     Parameters
     ----------
-    warning_type : Warning or Iterable of Warnings
-        The warning class to ignore.
+    warning_types : Warning or Iterable of Warnings
+        The warning classes to ignore.
     """
 
     def __init__(

--- a/howso/utilities/internals.py
+++ b/howso/utilities/internals.py
@@ -821,15 +821,15 @@ class IgnoreWarnings:
 
     def __init__(
         self,
-        warning_type: Union[Warning, Iterable[Warning]]
+        warning_types: Union[Warning, Iterable[Warning]]
     ):
         """Initialize a new `catch_warnings` instance."""
         self._catch_warnings = warnings.catch_warnings()
-        self._warning_type = warning_type
+        self._warning_types = warning_types
 
-        if not isinstance(self._warning_type, Iterable):
-            self._warning_type = [self._warning_type]
-        for warning_type in self._warning_type:
+        if not isinstance(self._warning_types, Iterable):
+            self._warning_types = [self._warning_types]
+        for warning_type in self._warning_types:
             self._check_warning_class(warning_type)
 
     @staticmethod
@@ -845,7 +845,7 @@ class IgnoreWarnings:
         """Context entrance."""
         # Enters the  `catch_warnings` instance.
         self._catch_warnings.__enter__()
-        for warning_type in self._warning_type:
+        for warning_type in self._warning_types:
             warnings.filterwarnings("ignore", category=warning_type)
         return self
 

--- a/howso/utilities/internals.py
+++ b/howso/utilities/internals.py
@@ -806,3 +806,23 @@ def to_pandas_datetime_format(f):
             # Failed to check pandas version
             pass
     return f
+
+
+class IgnoreFutureWarnings:
+    """Simple context manager to ignore Future Warnings."""
+
+    def __init__(self):
+        """Initialize a new `catch_warnings` instance."""
+        self._catch_warnings = warnings.catch_warnings()
+
+    def __enter__(self):
+        """Context entrance."""
+        # Enters the  `catch_warnings` instance.
+        self._catch_warnings.__enter__()
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Context exit."""
+        self._catch_warnings.__exit__(exc_type, exc_value, traceback)
+        return False

--- a/howso/utilities/internals.py
+++ b/howso/utilities/internals.py
@@ -808,18 +808,31 @@ def to_pandas_datetime_format(f):
     return f
 
 
-class IgnoreFutureWarnings:
-    """Simple context manager to ignore Future Warnings."""
+class IgnoreWarnings:
+    """
+    Simple context manager to ignore Warnings.
 
-    def __init__(self):
+    Parameters
+    ----------
+    warning_type : Warning
+        The warning class to ignore.
+    """
+
+    def __init__(self, warning_type):
         """Initialize a new `catch_warnings` instance."""
         self._catch_warnings = warnings.catch_warnings()
+        self._warning_type = warning_type
+        if not issubclass(self._warning_type, Warning):
+            warnings.warn(
+                f"{self._warning_type} is not a valid subclass of `Warning`. "
+                "Warnings will not be ignored."
+            )
 
     def __enter__(self):
         """Context entrance."""
         # Enters the  `catch_warnings` instance.
         self._catch_warnings.__enter__()
-        warnings.filterwarnings("ignore", category=FutureWarning)
+        warnings.filterwarnings("ignore", category=self._warning_type)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/howso/utilities/tests/test_internals.py
+++ b/howso/utilities/tests/test_internals.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 import warnings
 from howso.utilities import internals
 import pytest
@@ -216,12 +217,18 @@ def test_to_pandas_datetime_format(mocker, pandas_ver, format_str, is_iso):
         assert fmt == format_str
 
 
-@pytest.mark.parametrize('warning_type', (DeprecationWarning, FutureWarning, UserWarning))
+@pytest.mark.parametrize(
+    'warning_type', (DeprecationWarning, FutureWarning, UserWarning, [FutureWarning, UserWarning])
+)
 def test_ignore_warnings(warning_type):
     """Test that warnings are ignored."""
+    if not isinstance(warning_type, Iterable):
+        warning_type = [warning_type]
+
     def raise_future_warning(a, b):
         """Simple function that raises a Warning."""
-        warnings.warn("Test Warning", warning_type)
+        for warning in warning_type:
+            warnings.warn("Test Warning", warning)
         return a + b
 
     with pytest.warns(None) as warnings_list:

--- a/howso/utilities/tests/test_internals.py
+++ b/howso/utilities/tests/test_internals.py
@@ -218,13 +218,27 @@ def test_to_pandas_datetime_format(mocker, pandas_ver, format_str, is_iso):
 
 
 @pytest.mark.parametrize(
-    'warning_type', (DeprecationWarning, FutureWarning, UserWarning, [FutureWarning, UserWarning])
+    'warning_type', (DeprecationWarning, FutureWarning, UserWarning)
 )
-def test_ignore_warnings(warning_type):
-    """Test that warnings are ignored."""
-    if not isinstance(warning_type, Iterable):
-        warning_type = [warning_type]
+def test_ignore_warnings_individual(warning_type):
+    """Test that individual warnings are ignored."""
 
+    def raise_future_warning(a, b):
+        """Simple function that raises a Warning."""
+        warnings.warn("Test Warning", warning_type)
+        return a + b
+
+    with pytest.warns(None) as warnings_list:
+        with internals.IgnoreWarnings(warning_type):
+            c = raise_future_warning(1, 2)
+
+    assert len(warnings_list) == 0
+    assert c == 3
+
+
+def test_ignore_warnings_iterable(warning_type=[FutureWarning, UserWarning]):
+    """Test that an iterable of warnings are ignored."""
+    
     def raise_future_warning(a, b):
         """Simple function that raises a Warning."""
         for warning in warning_type:

--- a/howso/utilities/tests/test_internals.py
+++ b/howso/utilities/tests/test_internals.py
@@ -217,7 +217,7 @@ def test_to_pandas_datetime_format(mocker, pandas_ver, format_str, is_iso):
         assert fmt == format_str
 
 
-def test_suppress_future_warnings():
+def test_ignore_future_warnings():
     """Test that future warnings are ignored."""
     def raise_future_warning(a, b):
         """Simple function that raises a FutureWarning."""

--- a/howso/utilities/tests/test_internals.py
+++ b/howso/utilities/tests/test_internals.py
@@ -238,7 +238,7 @@ def test_ignore_warnings_individual(warning_type):
 
 def test_ignore_warnings_iterable(warning_type=[FutureWarning, UserWarning]):
     """Test that an iterable of warnings are ignored."""
-    
+
     def raise_future_warning(a, b):
         """Simple function that raises a Warning."""
         for warning in warning_type:

--- a/howso/utilities/tests/test_internals.py
+++ b/howso/utilities/tests/test_internals.py
@@ -1,5 +1,4 @@
 import warnings
-
 from howso.utilities import internals
 import pytest
 from semantic_version import Version
@@ -217,15 +216,16 @@ def test_to_pandas_datetime_format(mocker, pandas_ver, format_str, is_iso):
         assert fmt == format_str
 
 
-def test_ignore_future_warnings():
-    """Test that future warnings are ignored."""
+@pytest.mark.parametrize('warning_type', (DeprecationWarning, FutureWarning, UserWarning))
+def test_ignore_warnings(warning_type):
+    """Test that warnings are ignored."""
     def raise_future_warning(a, b):
-        """Simple function that raises a FutureWarning."""
-        warnings.warn("Future Warning", FutureWarning)
+        """Simple function that raises a Warning."""
+        warnings.warn("Test Warning", warning_type)
         return a + b
 
     with pytest.warns(None) as warnings_list:
-        with internals.IgnoreFutureWarnings():
+        with internals.IgnoreWarnings(warning_type):
             c = raise_future_warning(1, 2)
 
     assert len(warnings_list) == 0

--- a/howso/utilities/tests/test_internals.py
+++ b/howso/utilities/tests/test_internals.py
@@ -59,7 +59,7 @@ from semantic_version import Version
     ),
 ))
 def test_preprocess_feature_attributes(features, result):
-    """Test preprocess_feature_attributes returns expected result"""
+    """Test preprocess_feature_attributes returns expected result."""
     output = internals.preprocess_feature_attributes(features)
     assert output == result
 
@@ -137,7 +137,7 @@ def test_preprocess_feature_attributes(features, result):
     ),
 ))
 def test_postprocess_feature_attributes(features, result):
-    """Test postprocess_feature_attributes returns expected result"""
+    """Test postprocess_feature_attributes returns expected result."""
     output = internals.postprocess_feature_attributes(features)
     assert output == result
 
@@ -215,3 +215,18 @@ def test_to_pandas_datetime_format(mocker, pandas_ver, format_str, is_iso):
             assert fmt == format_str
     else:
         assert fmt == format_str
+
+
+def test_suppress_future_warnings():
+    """Test that future warnings are ignored."""
+    def raise_future_warning(a, b):
+        """Simple function that raises a FutureWarning."""
+        warnings.warn("Future Warning", FutureWarning)
+        return a + b
+
+    with pytest.warns(None) as warnings_list:
+        with internals.IgnoreFutureWarnings():
+            c = raise_future_warning(1, 2)
+
+    assert len(warnings_list) == 0
+    assert c == 3


### PR DESCRIPTION
When using the to_pydatetime() method from pandas, emits a FutureWarning. There is no fix for this, as using the suggested alternative method still results in this FutureWarning being emitted. PR creates a subclass to reduce code clutter for this and future situations where Warnings need to be ignored