### PR TITLE
17686: Print help for the user informing when no config was found

### DIFF
--- a/howso/client/client.py
+++ b/howso/client/client.py
@@ -352,8 +352,8 @@ def get_howso_client_class(**kwargs) -> Tuple[type, dict]:  # noqa: C901
         # Warn when running with out a configuration.
         no_config_msg = client_extra_params.pop(
             "no_config_msg",
-            "No configuration file was found; operating with the "
-            "HowsDirectClient and default parameters. To more about "
+            "No configuration file was found. Operating with the "
+            "HowsDirectClient and default parameters. To learn more about "
             "'howso.yml' configuration files, see documentation at: "
             f"{HOWSO_CONFIG_DOCS}."
         )

--- a/howso/client/client.py
+++ b/howso/client/client.py
@@ -352,10 +352,9 @@ def get_howso_client_class(**kwargs) -> Tuple[type, dict]:  # noqa: C901
         # Warn when running with out a configuration.
         no_config_msg = client_extra_params.pop(
             "no_config_msg",
-            "No configuration file was found. Operating with the "
-            "HowsDirectClient and default parameters. To learn more about "
-            "'howso.yml' configuration files, see documentation at: "
-            f"{HOWSO_CONFIG_DOCS}."
+            f"No configuration file was found. Operating with HowsDirectClient "
+            f"and default parameters. To learn more about 'howso.yml' "
+            f"configuration files, see documentation at: {HOWSO_CONFIG_DOCS}."
         )
         print(no_config_msg)
 

--- a/howso/client/configuration.py
+++ b/howso/client/configuration.py
@@ -78,7 +78,7 @@ class HowsoConfiguration:
         1. An explicitly set `max_wait_time` parameter value;
         2. An environment variable `HOWSO_CLIENT_CREATE_MAX_WAIT_TIME;
         3. A setting in the config.yaml file:
-           Howso > options > create_max_wait_time; or
+           howso > options > create_max_wait_time; or
         4. the final default of 30 seconds.
 
         Parameters

--- a/howso/client/tests/test_client.py
+++ b/howso/client/tests/test_client.py
@@ -9,7 +9,7 @@ import howso
 from howso.client import HowsoClient
 from howso.client.client import (
     _check_isfile,
-    DEFAULT_LEGACY_CONFIG_FILENAMES,
+    LEGACY_CONFIG_FILENAMES,
     get_configuration_path,
     get_howso_client_class,
 )
@@ -103,7 +103,7 @@ def test_check_isfile(mocker, existing_files, result):
     """Test that `_check_isfile` works as expected."""
 
     def _is_file(filepath):
-        if str(filepath) in DEFAULT_LEGACY_CONFIG_FILENAMES:
+        if str(filepath) in LEGACY_CONFIG_FILENAMES:
             return True
         return False
 

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -205,8 +205,6 @@ class HowsoDirectClient(AbstractHowsoClient):
                         f"Version {latest_version} of Howso Engine™ is "
                         f"available. You are using version {local_version}. "
                         f"This is a pre-release version.")
-            else:
-                logger.warning("You're using the latest version of Howso Engine™!")
 
     @property
     def active_session(self) -> Session:

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -205,6 +205,8 @@ class HowsoDirectClient(AbstractHowsoClient):
                         f"Version {latest_version} of Howso Engine™ is "
                         f"available. You are using version {local_version}. "
                         f"This is a pre-release version.")
+            else:
+                logger.warning("You're using the latest version of Howso Engine™!")
 
     @property
     def active_session(self) -> Session:


### PR DESCRIPTION
This PR adds support for printing a helpful message when howso-engine is run without a configuration file.

This is the message that is displayed when there is no configuration file found.

![image](https://github.com/howsoai/howso-engine-py/assets/615759/31f67d6c-e0cd-4e19-ba07-3aeae3441765)
