### PR TITLE
17794: Updates internal version checks to use new versioning scheme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,9 @@ jobs:
           sudo echo "" > /etc/pip.conf
 
           echo "Installing Howso Engine..."
-          pip install howso_engine-*-py3-none-any.whl
+          # This environment is considered "externally managed," so use --break-system-packages to bypass
+          # (safe in this use case)
+          pip install howso_engine-*-py3-none-any.whl --break-system-packages
 
           # amalgam binaries need this under QEMU
           PATH=$PATH:/usr/aarch64-linux-gnu
@@ -237,7 +239,9 @@ jobs:
           sudo echo "" > /etc/pip.conf
 
           echo "Installing Howso Engine..."
-          pip install howso_engine-*-py3-none-any.whl
+          # This environment is considered "externally managed," so use --break-system-packages to bypass
+          # (safe in this use case)
+          pip install howso_engine-*-py3-none-any.whl --break-system-packages
 
           # Set local config to use single threaded because arm64_8a doesn't support multi-threading and set
           # arm64_8a arch since that is not auto selected by the package currently:

--- a/howso/__main__.py
+++ b/howso/__main__.py
@@ -1,9 +1,9 @@
 import argparse
 from argparse import RawTextHelpFormatter
 from datetime import date
+import importlib.metadata
 import sys
 
-from howso.client import __version__ as version_string
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=None,
@@ -21,6 +21,6 @@ if __name__ == '__main__':
         args = parser.parse_args()
         if args.version:
             print(f"""
-Howso (tm) client version: {version_string}
+Howso (tm) client version: {importlib.metadata.version('howso-engine')}
 Copyright (c) 2018-{date.today().year}, Howso Incorporated. All rights reserved.
 """)

--- a/howso/client/__init__.py
+++ b/howso/client/__init__.py
@@ -30,7 +30,6 @@ from .pandas.client import (  # noqa: F401
 )
 
 __all__ = [
-    "__version__",
     "AbstractHowsoClient",
     "CONFIG_FILE_ENV_VAR",
     "DEFAULT_CONFIG_FILE_ALT",
@@ -40,10 +39,3 @@ __all__ = [
     "HowsoClient",
     "HowsoPandasClient",
 ]
-
-
-# The version number is automatically incremented by the pipeline
-# It should not be manually changed.
-# To change the major/minor number change the number in azure-pipelines.yml
-
-__version__ = "7.1.0"

--- a/howso/client/tests/test_client.py
+++ b/howso/client/tests/test_client.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import json
 import os
 from pathlib import Path
@@ -590,7 +591,7 @@ class TestClient:
         """Test get_version()."""
         version = self.client.get_version()
         assert version.api is not None
-        assert version.client == howso.client.__version__
+        assert version.client == importlib.metadata.version('howso-engine')
 
     def test_doublemax_to_infinity_translation(self):
         """Test the translation from Double.MAX_VALUE to Infinity."""


### PR DESCRIPTION
Fixes version update suggestions for `howso-engine` to no longer use the legacy hardcoded `__version__`.

Also adds the `--break-system-packages` flag for arm64(_8a) verification install workflow jobs. This will fix the "externally managed environment" error seen on recent branch builds.