### PR TITLE
17489: Adds support for a `no_config_msg_verbose_only` option

### DIFF
--- a/howso/client/client.py
+++ b/howso/client/client.py
@@ -356,7 +356,7 @@ def get_howso_client_class(**kwargs) -> Tuple[type, dict]:  # noqa: C901
             no_config_msg = client_extra_params.pop(
                 "no_config_msg",
                 f"No configuration file was found. Operating with "
-                f"HowsDirectClient and default parameters. To learn more "
+                f"HowsoDirectClient and default parameters. To learn more "
                 f"about 'howso.yml' configuration files, see documentation "
                 f"at: {HOWSO_CONFIG_DOCS}.\n"
             )


### PR DESCRIPTION
By default, only show the no-configuration messages when the verbose flag is set.