### PR TITLE
17874: Adds check for non-numeric continuous features when 'data_type' is unspecified

### DIFF
--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -322,6 +322,15 @@ class FeatureAttributesBase(dict):
                     # Check type (int)
                     errors.extend(self._validate_dtype(data, feature, 'int64',
                                                        coerced_df, coerce=coerce))
+                elif 'data_type' not in attributes:
+                    # If feature is continuous with no data type, it should be numeric
+                    # if it cannot be casted to a float, then add an error
+                    if len(self._validate_dtype(data, feature, 'float64',
+                                                coerced_df, coerce=True)):
+                        errors.extend([f"Feature '{feature}' should be numeric"
+                                       " when 'type' is 'continuous' and "
+                                       "'data_type' is undefined."])
+
             # Check feature bounds
             if validate_bounds:
                 errors.extend(self._validate_bounds(data, feature, attributes))


### PR DESCRIPTION
If the attributes for a feature have "type"="continuous" and "data_type" is unspecified, then we expect those values to be numeric.

Here I add a check so that we catch if the values for a feature like this are not numeric. This was specifically raised when a user trained strings in a continuous feature without the "data_type"="string" attribute. Which broke a lot of stuff downstream.