### PR TITLE
18014: Drops the limit on generative reacts with details

### DIFF
--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -2926,9 +2926,6 @@ class HowsoDirectClient(AbstractHowsoClient):
                 raise HowsoError("`num_cases_to_generate` must be an integer "
                                  "greater than 0.")
             total_size = num_cases_to_generate
-            if total_size > self._react_generative_batch_threshold:
-                # Do not send details for generative reacts over threshold
-                details = None
 
             context_features, contexts = \
                 self._preprocess_generate_parameters(


### PR DESCRIPTION
Removing the direct client limit on the amount of generative reacts that can be made with details requested.