### PR TITLE
18538 Fixes the "action_feature" description in the docstring of `react_into_trainee`

### DIFF
--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -4214,7 +4214,7 @@ class HowsoDirectClient(AbstractHowsoClient):
             The ID of the Trainee to react to.
         action_feature : str, optional
             Name of target feature for which to do computations. Default is
-            whatever the model was analyzed for, i.e., action feature for MDA
+            whatever the model was analyzed for, e.g., action feature for MDA
             and contributions, or ".targetless" if analyzed for targetless.
             This parameter is required for MDA or contributions computations.
         context_features : iterable of str, optional

--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -1936,7 +1936,7 @@ class HowsoCore:
             The identifier of the Trainee.
         action_feature : str, optional
             Name of target feature for which to do computations. Default is
-            whatever the model was analyzed for, i.e., action feature for MDA
+            whatever the model was analyzed for, e.g., action feature for MDA
             and contributions, or ".targetless" if analyzed for targetless.
             This parameter is required for MDA or contributions computations.
         context_features : iterable of str, optional

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -2911,10 +2911,10 @@ class Trainee(BaseTrainee):
         Parameters
         ----------
         action_feature : str, optional
-            Name of target feature whose hyperparameters to use
-            for computations.  Default is whatever the model was analyzed for,
-            or the mda_action_features for MDA, or ".targetless" if analyzed
-            for targetless.
+            Name of target feature for which to do computations. Default is
+            whatever the model was analyzed for, i.e., action feature for MDA
+            and contributions, or ".targetless" if analyzed for targetless.
+            This parameter is required for MDA or contributions computations.
         context_features : list of str, optional
             List of features names to use as contexts for
             computations. Default is all trained non-unique features if

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -2912,7 +2912,7 @@ class Trainee(BaseTrainee):
         ----------
         action_feature : str, optional
             Name of target feature for which to do computations. Default is
-            whatever the model was analyzed for, i.e., action feature for MDA
+            whatever the model was analyzed for, e.g., action feature for MDA
             and contributions, or ".targetless" if analyzed for targetless.
             This parameter is required for MDA or contributions computations.
         context_features : list of str, optional


### PR DESCRIPTION
Fixing an incorrect parameter description for "action_feature" in the docstring of `Trainee.react_into_trainee`

All of the other instances of `react_into_trainee` had the correct description, so that version was copied here.