### PR TITLE
18601: Fixes an issue where continue_series flag is needed when continue_series_values are specified for discriminative forecasting

### DIFF
--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -2090,6 +2090,9 @@ class HowsoDirectClient(AbstractHowsoClient):
                 "Improper shape of `series_context_values` values passed. "
                 "`series_context_values` must be a 3d list of object.")
 
+        if continue_series_values is not None:
+            continue_series = True
+
         action_features, actions, context_features, contexts = (
             self._preprocess_react_parameters(
                 action_features=action_features,


### PR DESCRIPTION
The docstring for continue_series_value states that when these values are specified, continue_series (the flag) would be treated as if it was true, but this logic wasn't properly captured in the code.