### PR TITLE
18643: Fixes an issue where `continue_series_values` is a list of DataFrames with differing lengths

### DIFF
--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -120,12 +120,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 astroid
-3.0.1
+3.0.2
 GNU Lesser General Public License v2 (LGPLv2)
 UNKNOWN
 https://github.com/pylint-dev/astroid/issues
 An abstract syntax tree for Python with inference support.
-/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/astroid-3.0.1.dist-info/LICENSE
+/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/astroid-3.0.2.dist-info/LICENSE
 
                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 2.1, February 1999
@@ -1707,12 +1707,12 @@ brain-dead simple config-ini parsing
 
 
 isort
-5.12.0
+5.13.1
 MIT License
 Timothy Crosley
 https://pycqa.github.io/isort/
 A Python utility / library to sort Python imports.
-/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/isort-5.12.0.dist-info/LICENSE
+/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/isort-5.13.1.dist-info/LICENSE
 The MIT License (MIT)
 
 Copyright (c) 2013 Timothy Edmund Crosley
@@ -3162,12 +3162,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 pylint
-3.0.2
+3.0.3
 GNU General Public License v2 (GPLv2)
 Python Code Quality Authority <code-quality@python.org>
 https://github.com/pylint-dev/pylint
 python code static checker
-/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/pylint-3.0.2.dist-info/LICENSE
+/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/pylint-3.0.3.dist-info/LICENSE
 		    GNU GENERAL PUBLIC LICENSE
 		       Version 2, June 1991
 
@@ -4058,12 +4058,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 typing_extensions
-4.8.0
+4.9.0
 Python Software Foundation License
 "Guido van Rossum, Jukka Lehtosalo, Łukasz Langa, Michael Lee" <levkivskyi@gmail.com>
 https://github.com/python/typing_extensions
 Backported and Experimental Type Hints for Python 3.8+
-/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/typing_extensions-4.8.0.dist-info/LICENSE
+/opt/hostedtoolcache/Python/3.11.7/x64/lib/python3.11/site-packages/typing_extensions-4.9.0.dist-info/LICENSE
 A. HISTORY OF THE SOFTWARE
 ==========================
 

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -2082,9 +2082,13 @@ class HowsoDirectClient(AbstractHowsoClient):
                             "list of object")
         validate_list_shape(initial_features, 1, "max_series_lengths", "num")
         validate_list_shape(series_stop_maps, 1, "series_stop_maps", "dict")
-        validate_list_shape(continue_series_values, 3, 'continue_series_values', "feature values")
 
         validate_list_shape(series_context_features, 1, "series_context_features", "str")
+
+        if continue_series_values and num_list_dimensions(continue_series_values) != 3:
+            raise ValueError(
+                "Improper shape of `continue_series_values` values passed. "
+                "`continue_series_values` must be a 3d list of object.")
         if series_context_values and num_list_dimensions(series_context_values) != 3:
             raise ValueError(
                 "Improper shape of `series_context_values` values passed. "

--- a/requirements-3.10.txt
+++ b/requirements-3.10.txt
@@ -345,9 +345,9 @@ six==1.16.0 \
     # via
     #   howso-openapi-client
     #   python-dateutil
-typing-extensions==4.8.0 \
-    --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0 \
-    --hash=sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
+typing-extensions==4.9.0 \
+    --hash=sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783 \
+    --hash=sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd
     # via howso-engine (pyproject.toml)
 tzdata==2023.3 \
     --hash=sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a \

--- a/requirements-3.11.txt
+++ b/requirements-3.11.txt
@@ -345,9 +345,9 @@ six==1.16.0 \
     # via
     #   howso-openapi-client
     #   python-dateutil
-typing-extensions==4.8.0 \
-    --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0 \
-    --hash=sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
+typing-extensions==4.9.0 \
+    --hash=sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783 \
+    --hash=sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd
     # via howso-engine (pyproject.toml)
 tzdata==2023.3 \
     --hash=sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a \

--- a/requirements-3.8.txt
+++ b/requirements-3.8.txt
@@ -337,9 +337,9 @@ six==1.16.0 \
     # via
     #   howso-openapi-client
     #   python-dateutil
-typing-extensions==4.8.0 \
-    --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0 \
-    --hash=sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
+typing-extensions==4.9.0 \
+    --hash=sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783 \
+    --hash=sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd
     # via
     #   faker
     #   howso-engine (pyproject.toml)

--- a/requirements-3.9.txt
+++ b/requirements-3.9.txt
@@ -345,9 +345,9 @@ six==1.16.0 \
     # via
     #   howso-openapi-client
     #   python-dateutil
-typing-extensions==4.8.0 \
-    --hash=sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0 \
-    --hash=sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
+typing-extensions==4.9.0 \
+    --hash=sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783 \
+    --hash=sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd
     # via howso-engine (pyproject.toml)
 tzdata==2023.3 \
     --hash=sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a \


### PR DESCRIPTION
Using `validate_list_shape` raises a ValueError if the elements of `continue_series_values` have differing lengths, but this is acceptable input. I make the shift to instead use `num_list_dimensions`, which will not run into this problem.