### PR TITLE
18910: Fixes an issue in passing init_time_steps and final_time_steps to the Engine during discriminative react_series calls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -655,7 +655,7 @@ jobs:
       with:
         tag: ${{ needs.metadata.outputs.version }}
         commit: ${{ github.sha }}
-        name: ${{ github.event.repository.name }} ${{ needs.metadata.outputs.version }}"
+        name: ${{ github.event.repository.name }} ${{ needs.metadata.outputs.version }}
         artifactErrorsFailBuild: true
         generateReleaseNotes: true
         makeLatest: legacy

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -2242,6 +2242,8 @@ class HowsoDirectClient(AbstractHowsoClient):
                 "continue_series_values": serialized_continue_series_values,
                 "initial_features": initial_features,
                 "initial_values": initial_values,
+                "final_time_steps": final_time_steps,
+                "init_time_steps": init_time_steps,
                 "series_stop_maps": series_stop_maps,
                 "max_series_lengths": max_series_lengths,
                 "derived_context_features": derived_context_features,


### PR DESCRIPTION
Fixes a bug where init/final_time_steps parameters were not being passed to the Howso Engine from the client when doing react_series with desired_conviction=None.