### PR TITLE
19143: Rename 'series' to 'action'

### DIFF
--- a/howso/client/pandas/client.py
+++ b/howso/client/pandas/client.py
@@ -234,7 +234,7 @@ class HowsoPandasClientMixin:
         feature_attributes = self.trainee_cache.get(trainee_id).features
         response = super().react_series(trainee_id, *args, series_index=series_index, **kwargs)
 
-        response['series'] = format_dataframe(response.get("series"), feature_attributes)
+        response['action'] = format_dataframe(response.get("action"), feature_attributes)
 
         return response
 

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -1916,7 +1916,7 @@ class HowsoDirectClient(AbstractHowsoClient):
         Aggregates rows of data corresponding to the specified context, action,
         derived_context and derived_action features, utilizing previous rows to
         derive values as necessary. Outputs a dict of "action_features" and
-        corresponding "series" where "series" is the completed 'matrix' for the
+        corresponding "action" where "action" is the completed 'matrix' for the
         corresponding `action_features` and `derived_action_features`.
 
         Parameters
@@ -2326,13 +2326,13 @@ class HowsoDirectClient(AbstractHowsoClient):
                 progress_callback(progress, response)
 
         # put all details under the 'details' key
-        series = response.pop('series')
-        response = {'series': series, 'details': response}
+        action = response.pop('action')
+        response = {'action': action, 'details': response}
 
         # If the number of series generated is less then requested, raise
         # warning, for generative reacts
         if desired_conviction is not None:
-            len_action = len(response['series'])
+            len_action = len(response['action'])
             internals.insufficient_generation_check(
                 num_series_to_generate, len_action,
                 suppress_warning=suppress_warning
@@ -2469,7 +2469,7 @@ class HowsoDirectClient(AbstractHowsoClient):
         batch_result = replace_doublemax_with_infinity(batch_result)
 
         ret['action_features'] = batch_result.pop('action_features') or []
-        ret['series'] = batch_result.pop('series')
+        ret['action'] = batch_result.pop('series')
 
         # ensure all the details items are output as well
         for k, v in batch_result.items():

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -1749,7 +1749,7 @@ class Trainee(BaseTrainee):
         Aggregates rows of data corresponding to the specified context, action,
         derived_context and derived_action features, utilizing previous rows to
         derive values as necessary. Outputs an dict of "action_features" and
-        corresponding "series" where "series" is the completed 'matrix' for
+        corresponding "action" where "action" is the completed 'matrix' for
         the corresponding action_features and derived_action_features.
 
         Parameters

--- a/howso/utilities/tests/test_utilities.py
+++ b/howso/utilities/tests/test_utilities.py
@@ -252,7 +252,7 @@ def test_build_react_series_df():
     """
     test_react_series_response = {
         'details': {'action_features': ['id', 'x', 'y']},
-        'series': [
+        'action': [
             [["A", 1, 2], ["A", 2, 2]],
             [["B", 4, 4], ["B", 6, 7], ["B", 8, 9]]
         ]

--- a/howso/utilities/utilities.py
+++ b/howso/utilities/utilities.py
@@ -1141,7 +1141,7 @@ def build_react_series_df(react_series_response, series_index=None):
     # Columns are defined by action_features
     columns = react_series_response['details']['action_features']
     # Series data from the response
-    series = react_series_response['series']
+    series = react_series_response['action']
 
     if series_index:
         # If series_index is specified, include it as a feature


### PR DESCRIPTION
New `Reaction` output type uses 'action' instead of 'series'. This renames all internal occurances