### PR TITLE
19187: Rounds feature bounds to same precision as feature values

### DIFF
--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -199,6 +199,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
         output = None
         allow_null = True
         column = self.data[feature_name]
+        decimal_places = feature_attributes[feature_name].get('decimal_places')
         # only integers by default do not allow nulls
         if is_integer_dtype(column.dtype):
             allow_null = False
@@ -379,6 +380,12 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
         else:  # Ordinals
             if not allow_null:
                 output = {'allow_null': False}
+
+        if decimal_places:
+            if 'max' in output:
+                output['max'] = round(output['max'], decimal_places)
+            if 'min' in output:
+                output['min'] = round(output['min'], decimal_places)
 
         return output
 

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -381,7 +381,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
             if not allow_null:
                 output = {'allow_null': False}
 
-        if decimal_places:
+        if decimal_places is not None:
             if 'max' in output:
                 output['max'] = round(output['max'], decimal_places)
             if 'min' in output:

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -889,7 +889,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
             if not allow_null:
                 output = {'allow_null': False}
 
-        if decimal_places:
+        if decimal_places is not None:
             if 'max' in output:
                 output['max'] = round(output['max'], decimal_places)
             if 'min' in output:

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -757,6 +757,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
         output = None
         allow_null = True
         original_type = feature_attributes[feature_name]['original_type']
+        decimal_places = feature_attributes[feature_name].get('decimal_places')
 
         # Only integers by default do no allow nulls.
         if original_type.get('data_type') == FeatureType.INTEGER.value:
@@ -887,6 +888,12 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
         else:
             if not allow_null:
                 output = {'allow_null': False}
+
+        if decimal_places:
+            if 'max' in output:
+                output['max'] = round(output['max'], decimal_places)
+            if 'min' in output:
+                output['min'] = round(output['min'], decimal_places)
 
         return output
 

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
@@ -283,12 +283,12 @@ def test_dependent_features(should_include, base_features, dependent_features):
 
 
 @pytest.mark.parametrize('tight_bounds, data, expected_bounds', [
-    (None, [2, 3, 4, 5, 6, 7], {'min': 1, 'max': 7.38905609893065, 'allow_null': False}),
+    (None, [2, 3, 4, 5, 6, 7], {'min': 1, 'max': 7, 'allow_null': False}),
     (None, [2, 3, 4, 4, 5, 6, 6, 6, 6], {'min': 1, 'max': 6, 'allow_null': False}),
     (None, [2, 3, 4, 4, 4, 4, 6, 6, 6, 6], {'min': 1, 'max': 6, 'allow_null': False}),
     (None, [2, 2, 2, 2, 4, 5, 6, 6, 6, 6], {'min': 2, 'max': 6, 'allow_null': False}),
     (None, [2, 2, 2, 2, 4, 5, 6, 6, 6, 6, 6], {'min': 1, 'max': 6, 'allow_null': False}),
-    (None, [2, 2, 2, 2, 4, 5, 6, 7], {'min': 2, 'max': 7.38905609893065, 'allow_null': False}),
+    (None, [2, 2, 2, 2, 4, 5, 6, 7], {'min': 2, 'max': 7, 'allow_null': False}),
     (['a'], [2, 3, 4, 5, 6, 7], {'min': 2, 'max': 7, 'allow_null': False}),
     (['a'], [2, 3, 4, None, 6, 7], {'min': 2, 'max': 7}),
     (


### PR DESCRIPTION
Round the feature bounds to the same amount of decimal places that the feature values have.

This should prevent any issues where the bound has higher precision than the feature values allow. In this context, we sometimes see React returning values over the bound where they were synthed under, but rounding pushed them over.