### PR TITLE
19234: Adds order_by to IFA relational queries

### DIFF
--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -328,12 +328,14 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
                         session.query(self.data.c[feature_name])
                                .filter(self.data.c[feature_name].is_not(None))
                                .offset(idx)
-                               .first()
-                    )
+                               .order_by(feature_name)  # 19234: using order_by here is necessary for MSSQL,
+                               .first()                 # however, this should ultimately be re-written to
+                    )                                   # avoid the performance pentalty this imposes.
                 else:
                     random_value = (
                         session.query(self.data.c[feature_name])
                                .offset(idx)
+                               .order_by(feature_name)  # See above
                                .first()
                     )
 


### PR DESCRIPTION
MSSQL requires an `order_by` when using an `OFFSET` or a non-simple `LIMIT` clause.