### PR TITLE
19238: Improved batch scaling to account for memory

### DIFF
--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -3107,7 +3107,7 @@ class HowsoCore:
             return None
         return self._deserialize(result)
 
-    def _execute_sized(self, label: str, payload: Any) -> Any:
+    def _execute_sized(self, label: str, payload: Any) -> Tuple[Any, int, int]:
         """
         Execute label in core and return payload sizes.
 

--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -764,7 +764,7 @@ class HowsoCore:
         return self._execute(
             "get_auto_ablation_params", {"trainee": trainee_id}
         )
-    
+
     def set_auto_ablation_params(
         self,
         trainee_id: str,
@@ -1131,7 +1131,7 @@ class HowsoCore:
         series: Optional[str] = None,
         session: Optional[str] = None,
         train_weights_only: bool = False,
-    ) -> Dict:
+    ) -> Tuple[Dict, int, int]:
         """
         Train one or more cases into a trainee (model).
 
@@ -1167,8 +1167,12 @@ class HowsoCore:
         -------
         dict
             A dictionary containing the trained details.
+        int
+            The request payload size.
+        int
+            The result payload size.
         """
-        return self._execute("train", {
+        return self._execute_sized("train", {
             "trainee": trainee_id,
             "input_cases": input_cases,
             "accumulate_weight_feature": accumulate_weight_feature,
@@ -1531,7 +1535,7 @@ class HowsoCore:
         use_case_weights: bool = False,
         use_regional_model_residuals: bool = True,
         weight_feature: Optional[str] = None
-    ) -> Dict:
+    ) -> Tuple[Dict, int, int]:
         """
         Multiple case react.
 
@@ -1637,8 +1641,12 @@ class HowsoCore:
         -------
         dict
             The react result including audit details.
+        int
+            The request payload size.
+        int
+            The result payload size.
         """
-        return self._execute("batch_react", {
+        return self._execute_sized("batch_react", {
             "trainee": trainee_id,
             "context_features": context_features,
             "context_values": context_values,
@@ -1709,7 +1717,7 @@ class HowsoCore:
         use_case_weights: bool = False,
         use_regional_model_residuals: bool = True,
         weight_feature: Optional[str] = None
-    ) -> Dict:
+    ) -> Tuple[Dict, int, int]:
         """
         React in a series until a series_stop_map condition is met.
 
@@ -1830,8 +1838,12 @@ class HowsoCore:
             `series` is a 2d list of values (rows of data per series), and
             `action_features` is the list of all action features
             (specified and derived).
+        int
+            The request payload size.
+        int
+            The result payload size.
         """
-        return self._execute("batch_react_series", {
+        return self._execute_sized("batch_react_series", {
             "trainee": trainee_id,
             "context_features": context_features,
             "context_values": context_values,
@@ -3026,7 +3038,7 @@ class HowsoCore:
             "reset_parameter_defaults", {"trainee": trainee_id})
 
     @classmethod
-    def _deserialize(cls, payload):
+    def _deserialize(cls, payload: Union[str, bytes]):
         """Deserialize core response."""
         try:
             deserialized_payload = json.loads(payload)
@@ -3094,6 +3106,41 @@ class HowsoCore:
         if result is None or len(result) == 0:
             return None
         return self._deserialize(result)
+
+    def _execute_sized(self, label: str, payload: Any) -> Any:
+        """
+        Execute label in core and return payload sizes.
+
+        Parameters
+        ----------
+        label : str
+            The label to execute.
+        payload : Any
+            The payload to send to label.
+
+        Returns
+        -------
+        Any
+            The label's response.
+        int
+            The request payload size.
+        int
+            The response payload size.
+        """
+        payload = sanitize_for_json(payload)
+        payload = self._remove_null_entries(payload)
+        raw_payload = json.dumps(payload)
+        try:
+            result = self.amlg.execute_entity_json(
+                self.handle, label, raw_payload)
+        except ValueError as err:
+            raise HowsoError(
+                'Invalid payload - please check for infinity or NaN '
+                f'values: {err}')
+
+        if result is None or len(result) == 0:
+            return None, len(raw_payload), 0
+        return self._deserialize(result), len(raw_payload), len(result)
 
     @staticmethod
     def _remove_null_entries(payload) -> Dict:

--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -3129,18 +3129,18 @@ class HowsoCore:
         """
         payload = sanitize_for_json(payload)
         payload = self._remove_null_entries(payload)
-        raw_payload = json.dumps(payload)
         try:
+            json_payload = json.dumps(payload)
             result = self.amlg.execute_entity_json(
-                self.handle, label, raw_payload)
+                self.handle, label, json_payload)
         except ValueError as err:
             raise HowsoError(
                 'Invalid payload - please check for infinity or NaN '
                 f'values: {err}')
 
         if result is None or len(result) == 0:
-            return None, len(raw_payload), 0
-        return self._deserialize(result), len(raw_payload), len(result)
+            return None, len(json_payload), 0
+        return self._deserialize(result), len(json_payload), len(result)
 
     @staticmethod
     def _remove_null_entries(payload) -> Dict:

--- a/howso/utilities/monitors.py
+++ b/howso/utilities/monitors.py
@@ -181,3 +181,7 @@ class ProgressTimer(Timer):
         super().start()
         self.last_tick_time = self.start_time
         return self
+
+    def __enter__(self) -> "ProgressTimer":
+        """Context entrance."""
+        return self.start()


### PR DESCRIPTION
Added memory limits for the request and response payload sizes when using batch scaling in react, react_series, and train. If the request or response size exceeds their respective limit, the batch size will be scaled down. If the size is within a threshold close to the limit (default 10%), the batch size will be prevented from scaling up, but may still scale down based on duration of the request.