### PR TITLE
19241: Fixes bad Analyze test

### DIFF
--- a/howso/client/tests/test_client.py
+++ b/howso/client/tests/test_client.py
@@ -876,6 +876,7 @@ class TestBaseClient:
     def test_analyze_verbose(self, trainee, capsys):
         """Test for verbose output expected when analyze is called."""
         context_features = ['class']
+        self.client.train(trainee.id, [['iris-setosa']], context_features)
         self.client.analyze(trainee.id, context_features)
         out, _ = capsys.readouterr()
         assert f'Analyzing trainee with id: {trainee.id}' in out


### PR DESCRIPTION
This specific test calls Analyze on a Trainee that has never been trained with any cases. A new parameter validation in howso-engine now raises an error in this case.

I train a single value case into the Trainee so that the analyze is valid (more valid, at least) now.