### PR TITLE
19225: Implements devcontainers release automation as part of release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -658,6 +658,17 @@ jobs:
       run: |
         cat howso_stacktrace.txt || true
 
+  init-devcontainers-release:
+    if: inputs.build-type == 'release'
+    needs: ["metadata", "build"]
+    uses: "howsoai/.github/.github/workflows/run-external.yml@main"
+    secrets: inherit
+    with:
+      repo: howso-devcontainers
+      check-cache: false
+      workflow-name: build.yml
+      payload: '{"howso-engine-version": "${{ needs.metadata.outputs.version }}", "build-type": "release"}'
+
   release:
     if: inputs.build-type == 'release'
     environment:


### PR DESCRIPTION
Releasing `howso-engine-py` will now automatically trigger (1) a `howso-devcontainers` release of the same version, and (2) and PR to `howso-engine-recipes` that updates the `.devcontainer` folder with the new release version.