### PR TITLE
19320: Fixes tests by specifying features parameter as the desired order of features

### DIFF
--- a/howso/client/tests/test_client.py
+++ b/howso/client/tests/test_client.py
@@ -230,7 +230,8 @@ class TestDatetimeSerialization:
         self.client.train(trainee.id, cases=df.values.tolist(),
                           features=df.columns.tolist())
         case_response = self.client.get_cases(
-            trainee.id, session=self.client.active_session.id)
+            trainee.id, session=self.client.active_session.id,
+            features=['nom', 'datetime'])
         for case in case_response.cases:
             print(case)
         assert len(case_response.cases) == 4
@@ -264,7 +265,8 @@ class TestDatetimeSerialization:
                 for warning in warning_list])
 
         case_response = self.client.get_cases(
-            trainee.id, session=self.client.active_session.id)
+            trainee.id, session=self.client.active_session.id,
+            features=['nom', 'datetime'])
         for case in case_response.cases:
             print(case)
         assert len(case_response.cases) == 4


### PR DESCRIPTION
Recent howso-engine changes alter the order of the default features when features parameters are not specified. This causes a few tests to fail now.

The solution is to specify the desired order of features as a parameter, fixing the test.