### PR TITLE
19739: Adds boolean flag, "skip_auto_analyze" to `train`, MINOR

### DIFF
--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -1186,7 +1186,7 @@ class HowsoDirectClient(AbstractHowsoClient):
         train_weights_only: bool = False,
         validate: bool = True,
         skip_auto_analyze: bool = False,
-    ):
+    ) -> dict:
         """
         Train one or more cases into a trainee (model).
 
@@ -1249,6 +1249,12 @@ class HowsoDirectClient(AbstractHowsoClient):
             When true, the Trainee will not auto-analyze when appropriate.
             Instead, the response object will contain an "analyze" status when
             the set auto-analyze parameters indicate that an analyze is needed.
+
+        Returns
+        -------
+        bool
+            Flag indicating if the Trainee needs to analyze. Only true if
+            auto-analyze is enabled and the conditions are met.
         """
         self._auto_resolve_trainee(trainee_id)
         feature_attributes = self.trainee_cache.get(trainee_id).features
@@ -1344,13 +1350,11 @@ class HowsoDirectClient(AbstractHowsoClient):
 
         self._auto_persist_trainee(trainee_id)
 
-        # kick off auto-analyze if the train response requests it
+        # update needs_analyze flag if the engine indicates it is necessary
         if needs_analyze:
-            print((
-                "The auto-analyze conditions of the Trainee have been met. "
-                "Either call `analyze` manually, or `train` without the "
-                "'skip_auto_analyze' flag enabled."
-            ))
+            self._needs_analyze = True
+
+        return needs_analyze
 
     def impute(
         self,

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -1186,7 +1186,7 @@ class HowsoDirectClient(AbstractHowsoClient):
         train_weights_only: bool = False,
         validate: bool = True,
         skip_auto_analyze: bool = False,
-    ) -> dict:
+    ) -> bool:
         """
         Train one or more cases into a trainee (model).
 
@@ -1247,8 +1247,7 @@ class HowsoDirectClient(AbstractHowsoClient):
             the data and the features dictionary.
         skip_auto_analyze : bool, default False
             When true, the Trainee will not auto-analyze when appropriate.
-            Instead, the response object will contain an "analyze" status when
-            the set auto-analyze parameters indicate that an analyze is needed.
+            Instead, the boolean response will be True if an analyze is needed.
 
         Returns
         -------
@@ -1349,10 +1348,6 @@ class HowsoDirectClient(AbstractHowsoClient):
         )
 
         self._auto_persist_trainee(trainee_id)
-
-        # update needs_analyze flag if the engine indicates it is necessary
-        if needs_analyze:
-            self._needs_analyze = True
 
         return needs_analyze
 

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -1324,8 +1324,8 @@ class HowsoDirectClient(AbstractHowsoClient):
                     input_is_substituted=input_is_substituted,
                     series=series,
                     session=self.active_session.id,
-                    train_weights_only=train_weights_only,
                     skip_auto_analyze=skip_auto_analyze,
+                    train_weights_only=train_weights_only,
                 )
                 if response and response.get('status') == 'analyze':
                     needs_analyze = True

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -1183,9 +1183,9 @@ class HowsoDirectClient(AbstractHowsoClient):
         input_is_substituted: bool = False,
         progress_callback: Optional[Callable] = None,
         series: Optional[str] = None,
+        skip_auto_analyze: bool = False,
         train_weights_only: bool = False,
         validate: bool = True,
-        skip_auto_analyze: bool = False,
     ) -> bool:
         """
         Train one or more cases into a trainee (model).
@@ -1237,6 +1237,9 @@ class HowsoDirectClient(AbstractHowsoClient):
             the value(s) of this case are appended to all cases in the series.
             If cases is the same length as the series, the value of each case
             in cases is applied in order to each of the cases in the series.
+        skip_auto_analyze : bool, default False
+            When true, the Trainee will not auto-analyze when appropriate.
+            Instead, the boolean response will be True if an analyze is needed.
         train_weights_only : bool, default False
             When true, and accumulate_weight_feature is provided,
             will accumulate all of the cases' neighbor weights instead of
@@ -1245,9 +1248,6 @@ class HowsoDirectClient(AbstractHowsoClient):
             Whether to validate the data against the provided feature
             attributes. Issues warnings if there are any discrepancies between
             the data and the features dictionary.
-        skip_auto_analyze : bool, default False
-            When true, the Trainee will not auto-analyze when appropriate.
-            Instead, the boolean response will be True if an analyze is needed.
 
         Returns
         -------

--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -1138,6 +1138,7 @@ class HowsoCore:
         series: Optional[str] = None,
         session: Optional[str] = None,
         train_weights_only: bool = False,
+        skip_auto_analyze: bool = False,
     ) -> Tuple[Dict, int, int]:
         """
         Train one or more cases into a trainee (model).
@@ -1169,6 +1170,10 @@ class HowsoCore:
             When true, and accumulate_weight_feature is provided,
             will accumulate all of the cases' neighbor weights instead of
             training the cases into the model.
+        skip_auto_analyze : bool, default False
+            When true, the Trainee will not auto-analyze when appropriate.
+            Instead, the response object will contain an "analyze" status when
+            the set auto-analyze parameters indicate that an analyze is needed.
 
         Returns
         -------
@@ -1189,6 +1194,7 @@ class HowsoCore:
             "series": series,
             "session": session,
             "train_weights_only": train_weights_only,
+            "skip_auto_analyze": skip_auto_analyze,
         })
 
     def impute(

--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -1193,8 +1193,8 @@ class HowsoCore:
             "input_is_substituted": input_is_substituted,
             "series": series,
             "session": session,
-            "train_weights_only": train_weights_only,
             "skip_auto_analyze": skip_auto_analyze,
+            "train_weights_only": train_weights_only,
         })
 
     def impute(

--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -1137,8 +1137,8 @@ class HowsoCore:
         input_is_substituted: bool = False,
         series: Optional[str] = None,
         session: Optional[str] = None,
-        train_weights_only: bool = False,
         skip_auto_analyze: bool = False,
+        train_weights_only: bool = False,
     ) -> Tuple[Dict, int, int]:
         """
         Train one or more cases into a trainee (model).
@@ -1166,14 +1166,14 @@ class HowsoCore:
             from internal series storage.
         session : str, optional
             The identifier of the Trainee session to associate the cases with.
-        train_weights_only : bool, default False
-            When true, and accumulate_weight_feature is provided,
-            will accumulate all of the cases' neighbor weights instead of
-            training the cases into the model.
         skip_auto_analyze : bool, default False
             When true, the Trainee will not auto-analyze when appropriate.
             Instead, the response object will contain an "analyze" status when
             the set auto-analyze parameters indicate that an analyze is needed.
+        train_weights_only : bool, default False
+            When true, and accumulate_weight_feature is provided,
+            will accumulate all of the cases' neighbor weights instead of
+            training the cases into the model.
 
         Returns
         -------

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -757,9 +757,9 @@ class Trainee(BaseTrainee):
         input_is_substituted: bool = False,
         progress_callback: Optional[Callable] = None,
         series: Optional[str] = None,
+        skip_auto_analyze: bool = False,
         train_weights_only: bool = False,
         validate: bool = True,
-        skip_auto_analyze: bool = False,
     ) -> None:
         """
         Train one or more cases into the trainee (model).
@@ -809,6 +809,10 @@ class Trainee(BaseTrainee):
             this case are appended to all cases in the series. If cases is the
             same length as the series, the value of each case in cases is
             applied in order to each of the cases in the series.
+        skip_auto_analyze : bool, default False
+            When true, the Trainee will not auto-analyze when appropriate.
+            Instead, the 'needs_analyze' property of the Trainee will be
+            updated.
         train_weights_only:  bool, default False
             When true, and accumulate_weight_feature is provided,
             will accumulate all of the cases' neighbor weights instead of
@@ -817,10 +821,6 @@ class Trainee(BaseTrainee):
             Whether to validate the data against the provided feature
             attributes. Issues warnings if there are any discrepancies between
             the data and the features dictionary.
-        skip_auto_analyze : bool, default False
-            When true, the Trainee will not auto-analyze when appropriate.
-            Instead, the 'needs_analyze' property of the Trainee will be
-            updated.
 
         Returns
         -------

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -344,7 +344,7 @@ class Trainee(BaseTrainee):
     @property
     def needs_analyze(self) -> bool:
         """
-        The flag indicating of the Trainee needs to analyze.
+        The flag indicating if the Trainee needs to analyze.
 
         Returns
         -------

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -746,6 +746,7 @@ class Trainee(BaseTrainee):
         series: Optional[str] = None,
         train_weights_only: bool = False,
         validate: bool = True,
+        skip_auto_analyze: bool = False,
     ) -> None:
         """
         Train one or more cases into the trainee (model).
@@ -803,6 +804,10 @@ class Trainee(BaseTrainee):
             Whether to validate the data against the provided feature
             attributes. Issues warnings if there are any discrepancies between
             the data and the features dictionary.
+        skip_auto_analyze : bool, default False
+            When true, the Trainee will not auto-analyze when appropriate.
+            Instead, the response object will contain an "analyze" status when
+            the set auto-analyze parameters indicate that an analyze is needed.
 
         Returns
         -------
@@ -821,6 +826,7 @@ class Trainee(BaseTrainee):
                 series=series,
                 train_weights_only=train_weights_only,
                 validate=validate,
+                skip_auto_analyze=skip_auto_analyze,
             )
         else:
             raise ValueError("Client must have the 'train' method.")

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -838,9 +838,9 @@ class Trainee(BaseTrainee):
                 input_is_substituted=input_is_substituted,
                 progress_callback=progress_callback,
                 series=series,
+                skip_auto_analyze=skip_auto_analyze,
                 train_weights_only=train_weights_only,
                 validate=validate,
-                skip_auto_analyze=skip_auto_analyze,
             )
             self._needs_analyze = needs_analyze
         else:


### PR DESCRIPTION
This PR adds a new boolean flag to train named: "skip_auto_analyze"

When "skip_auto_analyze" is True, HSE may return a `"status": "analyze"` within the Train response. 

Client side, I have made the following changes:
- The direct client `train` method returns a boolean that indicates if the Trainee needs to analyze
- The Trainee object has a new property, 'needs_analyze' in which the response from the client is stored (also reset each call to train)

*This change makes it so that the client will not trigger any analyze calls automatically*.