### PR TITLE
20035: Updates error message on `load` to reflect previous message and updates Engine version

### DIFF
--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -361,7 +361,7 @@ class HowsoCore:
             escape_contained_filenames=False,
         )
         if not status.loaded:
-            raise HowsoError("Error loading the Trainee.")
+            raise HowsoError("Failed to load trainee.")
         return {"name": trainee_id}
 
     def persist(

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "howso-engine": "79.0.1"
+    "howso-engine": "79.0.2"
   }
 }


### PR DESCRIPTION
The error message on `load` was changed in previous commits. This broke a downstream test, this change reverts the message to be more similar to what it was before, fixing the aforementioned broken test.