### PR TITLE
20170: Adds sample and .to_dataframe() method to InferFeatureAttributesBase

### DIFF
--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -452,8 +452,9 @@ class SingleTableFeatureAttributes(FeatureAttributesBase):
         Parameters
         ----------
         include_all: bool, default False
-            If True, also include include internal meta fields such as
-            `original_type` in the output.
+            If True, also include include internal meta fields. Currently,
+            this includes `original_type` and its sub-keys but may include
+            other, internal meta keys in the future.
 
         Returns
         -------
@@ -470,6 +471,7 @@ class SingleTableFeatureAttributes(FeatureAttributesBase):
             "type",
             "date_time_format",
             "decimal_places",
+            "significant_digits",
             "bounds",
             "data_type",
             "non_sensitive",
@@ -482,7 +484,7 @@ class SingleTableFeatureAttributes(FeatureAttributesBase):
         all_keys = [k for a in self.values() for k in a.keys()]
         key_order = [k for k in key_order if k in all_keys]
 
-        # Ensure we acknowledge extra keys not in the above list.
+        # Ensure we include extra keys not in the above list.
         extra_keys = [
             k for a in self.values() for k in a.keys()
             if k not in key_order and k not in internal_meta_fields

--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -442,74 +442,6 @@ class SingleTableFeatureAttributes(FeatureAttributesBase):
         """
         return feature_name in self.unsupported
 
-    def to_dataframe(self) -> pd.DataFrame:
-        """
-        Return a DataFrame of the feature attributes.
-
-        Among other reasons, this is useful for presenting feature attributes
-        in a Jupyter notebook or other medium.
-
-        Returns
-        -------
-        pandas.DataFrame
-            A DataFrame representation of the inferred feature attributes.
-        """
-        sep = '|'
-        key_order = [
-            "sample",
-            "type",
-            "date_time_format",
-            "decimal_places",
-            "bounds",
-            "data_type",
-            "non_sensitive",
-            "original_type",
-        ]
-
-        # Ensure that these keys are available
-        all_keys = [k for a in self.values() for k in a.keys()]
-        key_order = [k for k in key_order if k in all_keys]
-
-        # Ensure we acknowledge extra keys not in the above list.
-        extra_keys = [
-            k for a in self.values() for k in a.keys()
-            if k not in key_order
-        ]
-        key_order.extend(sorted(extra_keys))
-
-        frames = []
-        for feature, attributes in self.items():
-            # Create a DataFrame from the nested dictionary
-            df = pd.json_normalize(attributes, sep=sep)
-            # Update the column names to create a MultiIndex
-            df.columns = pd.MultiIndex.from_tuples([
-                tuple(c.split(sep)) if sep in c else (c, '')
-                for c in df.columns
-            ])
-            # Set the outer key (e.g., 'f0') as the index
-            df.index = [feature]
-            frames.append(df)
-
-        # Concatenate all the DataFrames along the index
-        df = pd.concat(frames)
-
-        # Create tuples for the desired order and include sub-keys
-        desired_order_tuples = []
-        for col in key_order:
-            # Get all sub-keys for this column
-            sub_keys = df.columns.get_level_values(1)[
-                df.columns.get_level_values(0) == col].unique()
-            # Create a tuple for each potential sub-key
-            if not len(sub_keys):
-                # Just the main column key if no sub-keys
-                desired_order_tuples.append((col, ""))
-            else:
-                for sub_key in sub_keys:
-                    desired_order_tuples.append((col, sub_key))
-
-        # Reorder the columns based on the desired order tuples
-        return df.loc[:, desired_order_tuples]
-
 
 class InferFeatureAttributesBase(ABC):
     """
@@ -530,6 +462,7 @@ class InferFeatureAttributesBase(ABC):
                  datetime_feature_formats: Optional[Dict] = None,
                  ordinal_feature_values: Optional[Dict[str, List[str]]] = None,
                  dependent_features: Optional[Dict[str, List[str]]] = None,
+                 include_sample: bool = False,
                  ) -> Dict:
         """
         Get inferred feature attributes for the parameters.
@@ -776,11 +709,6 @@ class InferFeatureAttributesBase(ABC):
                             nominal_default_subtype)
             except ImportError:
                 warnings.warn('Cannot infer extended nominals: not supported')
-
-        # Insert a ``sample`` for each feature, if possible.
-        for feature_name in feature_attributes.keys():
-            sample = self._get_random_value(feature_name, no_nulls=True)
-            feature_attributes[feature_name]['sample'] = sample
 
         # Re-insert any partial features provided as an argument
         if features:

--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -449,22 +449,11 @@ class SingleTableFeatureAttributes(FeatureAttributesBase):
         Among other reasons, this is useful for presenting feature attributes
         in a Jupyter notebook or other medium.
 
-        Parameters
-        ----------
-        include_all: bool, default False
-            If True, also include include internal meta fields. Currently,
-            this includes `original_type` and its sub-keys but may include
-            other, internal meta keys in the future.
-
         Returns
         -------
         pandas.DataFrame
             A DataFrame representation of the inferred feature attributes.
         """
-        internal_meta_fields = [
-            "original_type",
-        ]
-
         sep = '|'
         key_order = [
             "sample",
@@ -477,18 +466,17 @@ class SingleTableFeatureAttributes(FeatureAttributesBase):
             "non_sensitive",
         ]
 
-        if include_all:
-            key_order.extend(internal_meta_fields)
-
-        # Ensure that these keys are available
-        all_keys = [k for a in self.values() for k in a.keys()]
+        # Ensure that these keys are available and reduced to an iterable of
+        # only the unique values.
+        all_keys = {k: None for a in self.values() for k in a.keys()}.keys()
         key_order = [k for k in key_order if k in all_keys]
 
-        # Ensure we include extra keys not in the above list.
-        extra_keys = [
-            k for a in self.values() for k in a.keys()
-            if k not in key_order and k not in internal_meta_fields
-        ]
+        # Ensure we include extra keys not in the above list, also maintained as
+        # only the unique values.
+        extra_keys = {
+            k: None for a in self.values() for k in a.keys()
+            if k not in key_order
+        }.keys()
         key_order.extend(sorted(extra_keys))
 
         frames = []

--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -790,15 +790,12 @@ class InferFeatureAttributesBase(ABC):
             except ImportError:
                 warnings.warn('Cannot infer extended nominals: not supported')
 
-<<<<<<< Updated upstream
-=======
         # Insert a ``sample`` for each feature, if possible.
         if include_sample:
             for feature_name in feature_attributes.keys():
                 sample = self._get_random_value(feature_name, no_nulls=True)
                 feature_attributes[feature_name]['sample'] = sample
 
->>>>>>> Stashed changes
         # Re-insert any partial features provided as an argument
         if features:
             for feature in features.keys():

--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -442,6 +442,86 @@ class SingleTableFeatureAttributes(FeatureAttributesBase):
         """
         return feature_name in self.unsupported
 
+    def to_dataframe(self, *, include_all: bool = False) -> pd.DataFrame:
+        """
+        Return a DataFrame of the feature attributes.
+
+        Among other reasons, this is useful for presenting feature attributes
+        in a Jupyter notebook or other medium.
+
+        Parameters
+        ----------
+        include_all: bool, default False
+            If True, also include include internal meta fields such as
+            `original_type` in the output.
+
+        Returns
+        -------
+        pandas.DataFrame
+            A DataFrame representation of the inferred feature attributes.
+        """
+        internal_meta_fields = [
+            "original_type",
+        ]
+
+        sep = '|'
+        key_order = [
+            "sample",
+            "type",
+            "date_time_format",
+            "decimal_places",
+            "bounds",
+            "data_type",
+            "non_sensitive",
+        ]
+
+        if include_all:
+            key_order.extend(internal_meta_fields)
+
+        # Ensure that these keys are available
+        all_keys = [k for a in self.values() for k in a.keys()]
+        key_order = [k for k in key_order if k in all_keys]
+
+        # Ensure we acknowledge extra keys not in the above list.
+        extra_keys = [
+            k for a in self.values() for k in a.keys()
+            if k not in key_order and k not in internal_meta_fields
+        ]
+        key_order.extend(sorted(extra_keys))
+
+        frames = []
+        for feature, attributes in self.items():
+            # Create a DataFrame from the nested dictionary
+            df = pd.json_normalize(attributes, sep=sep)
+            # Update the column names to create a MultiIndex
+            df.columns = pd.MultiIndex.from_tuples([
+                tuple(c.split(sep)) if sep in c else (c, '')
+                for c in df.columns
+            ])
+            # Set the outer key (e.g., 'f0') as the index
+            df.index = [feature]
+            frames.append(df)
+
+        # Concatenate all the DataFrames along the index
+        df = pd.concat(frames)
+
+        # Create tuples for the desired order and include sub-keys
+        desired_order_tuples = []
+        for col in key_order:
+            # Get all sub-keys for this column
+            sub_keys = df.columns.get_level_values(1)[
+                df.columns.get_level_values(0) == col].unique()
+            # Create a tuple for each potential sub-key
+            if not len(sub_keys):
+                # Just the main column key if no sub-keys
+                desired_order_tuples.append((col, ""))
+            else:
+                for sub_key in sub_keys:
+                    desired_order_tuples.append((col, sub_key))
+
+        # Reorder the columns based on the desired order tuples
+        return df.loc[:, desired_order_tuples]
+
 
 class InferFeatureAttributesBase(ABC):
     """
@@ -710,6 +790,15 @@ class InferFeatureAttributesBase(ABC):
             except ImportError:
                 warnings.warn('Cannot infer extended nominals: not supported')
 
+<<<<<<< Updated upstream
+=======
+        # Insert a ``sample`` for each feature, if possible.
+        if include_sample:
+            for feature_name in feature_attributes.keys():
+                sample = self._get_random_value(feature_name, no_nulls=True)
+                feature_attributes[feature_name]['sample'] = sample
+
+>>>>>>> Stashed changes
         # Re-insert any partial features provided as an argument
         if features:
             for feature in features.keys():

--- a/howso/utilities/feature_attributes/infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/infer_feature_attributes.py
@@ -153,6 +153,9 @@ def infer_feature_attributes(data: Union[pd.DataFrame, SQLRelationalDatastorePro
         to 2 will synthesize the 3rd order derivative value, and then use
         that synthed value to derive the 2nd and 1st order.
 
+    include_sample : bool, default False
+        Set to True to include a sample of each feature's data in the output.
+
     lags : list or dict, default None
         (Optional) A list containing the specific indices of the desired lag
         features to derive for each feature (not including the series time

--- a/howso/utilities/feature_attributes/infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/infer_feature_attributes.py
@@ -329,6 +329,10 @@ def infer_feature_attributes(data: Union[pd.DataFrame, SQLRelationalDatastorePro
                     "measurement_amount": [ "measurement" ]
                 }
 
+    include_sample: bool, default False
+        If True, include a ``sample`` field containing a sample of the data
+        from each feature in the output feature attributes dictionary.
+
     Returns
     -------
     FeatureAttributesBase

--- a/howso/utilities/feature_attributes/infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/infer_feature_attributes.py
@@ -69,32 +69,37 @@ def infer_feature_attributes(data: Union[pd.DataFrame, SQLRelationalDatastorePro
             ...         'bounds': {
             ...             'allow_null': True, 'max': 3, 'min': 2.72
             ...         },
-            ...         'type': 'continuous'
+            ...         'type': 'continuous',
+            ...         'sample': 2.86
             ...     },
             ...     'sepal-width', {
             ...         'bounds': {
             ...             'allow_null': True, 'max': 7.38905609893065,
             ...             'min': 1.0
             ...         },
-            ...         'type': 'continuous'
+            ...         'type': 'continuous',
+            ...         'sample': 4.56
             ...     },
             ...     'petal-length', {
             ...         'bounds': {
             ...             'allow_null': True, 'max': 7.38905609893065,
             ...             'min': 1.0
             ...         },
-            ...         'type': 'continuous'
+            ...         'type': 'continuous',
+            ...         'sample': 5.52
             ...     },
             ...     'petal-width', {
             ...         'bounds': {
             ...             'allow_null': True, 'max': 2.718281828459045,
             ...             'min': 0.049787068367863944
             ...         },
-            ...         'type': 'continuous'
+            ...         'type': 'continuous',
+            ...         'sample': 1.33
             ...     },
             ...     'target', {
             ...         'bounds': {'allow_null': True},
             ...         'type': 'nominal'
+            ...         'sample': 1
             ...     }
             ... }
 


### PR DESCRIPTION
- When `infer_feature_attributes` include the parameter `include_sample=True`, adds a "sample" key for each feature that includes a random sample of that feature, excluding nulls where possible.
- Adds `to_dataframe()` as a method. This allows one to see the feature attributes as a nicely presented table rather than a dictionary dump.

For example, below is the presentation of the resulting dataframe for the PMLB:iris dataset but with a random "datestamp" and "json" field added. This was called with `infer_feature_attributes()` and the dataframe was produced with `feature_attributes.to_dataframe()`.

The width of the dataframe's cells can easily be restricted in a notebook by using:

> pd.set_option('display.max_colwidth', 40)

This will auto-truncate long values such as the JSON string in the last feature here:

![image](https://github.com/howsoai/howso-engine-py/assets/615759/2af2e428-215c-4356-b487-6b47117afa14)

And, for timeseries:

![image](https://github.com/howsoai/howso-engine-py/assets/615759/065280f0-ff62-4d03-a106-d35e9b412062)

