### PR TITLE
20276: Eliminates most NaNs from infer_feature_attributes output

### DIFF
--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -322,9 +322,9 @@ class FeatureAttributesBase(dict):
                     # Check type (int)
                     errors.extend(self._validate_dtype(data, feature, 'int64',
                                                        coerced_df, coerce=coerce))
-                elif 'data_type' not in attributes:
-                    # If feature is continuous with no data type, it should be numeric
-                    # if it cannot be casted to a float, then add an error
+                elif attributes.get('data_type') == 'number':
+                    # If feature is continuous and not a datetime, it should have a numeric data_type.
+                    # If it cannot be casted to a float, then add an error.
                     if len(self._validate_dtype(data, feature, 'float64',
                                                 coerced_df, coerce=True)):
                         errors.extend([f"Feature '{feature}' should be numeric"

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -366,9 +366,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                                 elif actual_max_f == mode_f:
                                     max_f = actual_max_f
 
-                output = {'min': min_f, 'max': max_f}
-                if not allow_null:
-                    output['allow_null'] = False
+                output = {'min': min_f, 'max': max_f, 'allow_null': allow_null}
             else:
                 # If no min/max were found from the data, use min/max size of
                 # the data type.
@@ -378,8 +376,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                     output = {'min': min_value, 'max': max_value}
 
         else:  # Ordinals
-            if not allow_null:
-                output = {'allow_null': False}
+            output = {'allow_null': allow_null}
 
         if decimal_places is not None:
             if 'max' in output:
@@ -390,7 +387,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
         return output
 
     def _infer_floating_point_attributes(self, feature_name: str) -> Dict:
-        attributes: Dict[str, Any] = {"type": "continuous"}
+        attributes: Dict[str, Any] = {"type": "continuous", "data_type": "number"}
 
         n_cases = self.data[feature_name].shape[0]
 
@@ -476,23 +473,27 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                     dt_format += "%z"
         return {
             'type': 'continuous',
+            'data_type': 'string',
             'date_time_format': dt_format,
         }
 
     def _infer_date_attributes(self, feature_name: str) -> Dict:
         return {
             "type": "continuous",
-            "date_time_format": ISO_8601_DATE_FORMAT
+            "data_type": "string",
+            "date_time_format": ISO_8601_DATE_FORMAT,
         }
 
     def _infer_time_attributes(self, feature_name: str) -> Dict:
         return {
-            'type': 'continuous'
+            'type': 'continuous',
+            'data_type': 'string',
         }
 
     def _infer_timedelta_attributes(self, feature_name: str) -> Dict:
         return {
-            "type": "continuous"
+            "type": "continuous",
+            "data_type": "string",
         }
 
     def _infer_boolean_attributes(self, feature_name: str) -> Dict:
@@ -537,6 +538,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
         else:
             attributes = {
                 "type": "continuous",
+                "data_type": "number",
                 "decimal_places": 0,
             }
 
@@ -551,6 +553,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                 fmt = determine_iso_format(first_non_null, feature_name)
                 return {
                     "type": "continuous",
+                    "data_type": "string",
                     "date_time_format": fmt
                 }
             else:
@@ -574,5 +577,5 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
 
     def _infer_unknown_attributes(self, feature_name: str) -> Dict:
         return {
-            "type": "nominal"
+            "type": "nominal",
         }

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -558,7 +558,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
                 'data_type': 'number',
             }
 
-        attributes = {"type": "continuous"}
+        attributes = {"type": "continuous", "data_type": "number"}
         num_cases = self._get_num_cases()
 
         column = self.data.c[feature_name]
@@ -623,6 +623,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
 
         return {
             'type': 'continuous',
+            'data_type': 'string',
             'date_time_format': dt_format,
         }
 
@@ -639,12 +640,14 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
 
         return {
             'type': 'continuous',
+            'data_type': 'string',
             'date_time_format': ISO_8601_DATE_FORMAT,
         }
 
     def _infer_time_attributes(self, feature_name: str) -> Dict:
         return {
             'type': 'continuous',
+            'data_type': 'string',
         }
 
     def _infer_timedelta_attributes(self, feature_name: str) -> Dict:
@@ -659,7 +662,8 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
             }
 
         return {
-            'type': 'continuous'
+            'type': 'continuous',
+            'data_type': 'string',
         }
 
     def _infer_boolean_attributes(self, feature_name: str) -> Dict:
@@ -718,6 +722,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
         else:
             attributes = {
                 'type': 'continuous',
+                'data_type': 'number',
                 'decimal_places': 0,
             }
 
@@ -740,6 +745,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
             fmt = determine_iso_format(sample, feature_name)
             return {
                 'type': 'continuous',
+                'data_type': 'string',
                 'date_time_format': fmt
             }
         else:
@@ -876,9 +882,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
                 if format_dt is not None:
                     min_value = epoch_to_date(min_value, format_dt, min_date_tz)
                     max_value = epoch_to_date(max_value, format_dt, max_date_tz)
-                output = {'min': min_value, 'max': max_value}
-                if not allow_null:
-                    output['allow_null'] = False
+                output = {'min': min_value, 'max': max_value, 'allow_null': allow_null}
             else:
                 # If no min/max were found from the data, use min/max size of
                 # the data type.
@@ -888,8 +892,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
                     output = {'min': min_value, 'max': max_value}
 
         else:
-            if not allow_null:
-                output = {'allow_null': False}
+            output = {'allow_null': allow_null}
 
         if decimal_places is not None:
             if 'max' in output:

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
@@ -290,7 +290,7 @@ def test_dependent_features(should_include, base_features, dependent_features):
     (None, [2, 2, 2, 2, 4, 5, 6, 6, 6, 6, 6], {'min': 1, 'max': 6, 'allow_null': False}),
     (None, [2, 2, 2, 2, 4, 5, 6, 7], {'min': 2, 'max': 7, 'allow_null': False}),
     (['a'], [2, 3, 4, 5, 6, 7], {'min': 2, 'max': 7, 'allow_null': False}),
-    (['a'], [2, 3, 4, None, 6, 7], {'min': 2, 'max': 7}),
+    (['a'], [2, 3, 4, None, 6, 7], {'min': 2, 'max': 7, 'allow_null': True}),
     (
         ['a'],
         ['1905-01-01', '1904-05-03', '2020-01-15', '2000-04-26', '2000-04-24'],
@@ -371,7 +371,7 @@ def test_dependent_features(should_include, base_features, dependent_features):
         [datetime.timedelta(days=1), datetime.timedelta(days=1),
          datetime.timedelta(seconds=5), datetime.timedelta(days=1, seconds=30),
          datetime.timedelta(minutes=50), datetime.timedelta(days=5)],
-        {'min': 5, 'max': 5 * 24 * 60 * 60}
+        {'min': 5, 'max': 5 * 24 * 60 * 60, 'allow_null': True}
     ),
     (
         None,
@@ -380,7 +380,7 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.timedelta(minutes=50), datetime.timedelta(days=5),
          datetime.timedelta(days=5), datetime.timedelta(days=5),
          datetime.timedelta(days=5)],
-        {'min': 2.718281828459045, 'max': 5 * 24 * 60 * 60}
+        {'min': 2.718281828459045, 'max': 5 * 24 * 60 * 60, 'allow_null': True}
     ),
     (
         None,
@@ -388,7 +388,7 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.time(minute=1, second=30), datetime.time(minute=10),
          datetime.time(second=15), datetime.time(second=15),
          datetime.time(second=15), datetime.time(second=15)],
-        {'min': 15, 'max': 22026.465794806718}
+        {'min': 15, 'max': 22026.465794806718, 'allow_null': True}
     ),
 ])
 def test_infer_feature_bounds(data, tight_bounds, expected_bounds):


### PR DESCRIPTION
`infer_feature_attributes` now specifies `data_type` for continuous features, and `allow_nulls=True` when before it would be left out entirely. This is so that the `to_dataframe()` function does not display these "missing" feature attributes as NaNs.