### PR TITLE
20332: Fix JSON serialization of `sample`s in feature attributes

### DIFF
--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -783,7 +783,8 @@ class InferFeatureAttributesBase(ABC):
         # Insert a ``sample`` value (as string) for each feature, if possible.
         if include_sample:
             for feature_name in feature_attributes.keys():
-                if sample := self._get_random_value(feature_name, no_nulls=True) is not None:
+                sample = self._get_random_value(feature_name, no_nulls=True)
+                if sample is not None:
                     sample = str(sample)
                 feature_attributes[feature_name]['sample'] = sample
 

--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -780,10 +780,10 @@ class InferFeatureAttributesBase(ABC):
             except ImportError:
                 warnings.warn('Cannot infer extended nominals: not supported')
 
-        # Insert a ``sample`` for each feature, if possible.
+        # Insert a ``sample`` value (as string) for each feature, if possible.
         if include_sample:
             for feature_name in feature_attributes.keys():
-                sample = self._get_random_value(feature_name, no_nulls=True)
+                sample = str(self._get_random_value(feature_name, no_nulls=True))
                 feature_attributes[feature_name]['sample'] = sample
 
         # Re-insert any partial features provided as an argument

--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -783,7 +783,8 @@ class InferFeatureAttributesBase(ABC):
         # Insert a ``sample`` value (as string) for each feature, if possible.
         if include_sample:
             for feature_name in feature_attributes.keys():
-                sample = str(self._get_random_value(feature_name, no_nulls=True))
+                if sample := self._get_random_value(feature_name, no_nulls=True) is not None:
+                    sample = str(sample)
                 feature_attributes[feature_name]['sample'] = sample
 
         # Re-insert any partial features provided as an argument

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -187,7 +187,10 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
             cases = cases.loc[~self.data[feature_name].isnull()]
         if len(cases) < 1:
             return None
-        return cases.iloc[1 + np.random.randint(len(cases) - 1)]
+        elif len(cases) == 1:
+            return cases[0]
+        else:
+            return cases.iloc[1 + np.random.randint(len(cases) - 1)]
 
     def _infer_feature_bounds(  # noqa: C901
         self,

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -188,7 +188,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
         if len(cases) < 1:
             return None
         elif len(cases) == 1:
-            return cases[0]
+            return cases.iloc[0]
         else:
             return cases.iloc[1 + np.random.randint(len(cases) - 1)]
 

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -185,7 +185,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
         cases = self.data[feature_name]
         if no_nulls:
             cases = cases.loc[~self.data[feature_name].isnull()]
-        if len(cases) <= 1:
+        if len(cases) < 1:
             return None
         return cases.iloc[1 + np.random.randint(len(cases) - 1)]
 


### PR DESCRIPTION
In cases where a Numpy dtype is returned for the `sample` of a feature's attributes, we need to make sure it is JSON serializable. After some discussion, it was agreed that this is for display only, so, a string representation is desired.

I considered all the available datatypes here:

![Numpy dtypes graph](https://docs.scipy.org/doc/numpy-1.13.0/_images/dtype-hierarchy.png)

Each have a solid `str()` implementation.