### PR TITLE
20358: Specifies formatted_date_time data_type in IFA for ISO string features

### DIFF
--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -553,7 +553,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                 fmt = determine_iso_format(first_non_null, feature_name)
                 return {
                     'type': 'continuous',
-                    'data_type': 'string',
+                    'data_type': 'formatted_date_time',
                     'date_time_format': fmt
                 }
             else:

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -745,7 +745,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
             fmt = determine_iso_format(sample, feature_name)
             return {
                 'type': 'continuous',
-                'data_type': 'string',
+                'data_type': 'formatted_date_time',
                 'date_time_format': fmt
             }
         else:


### PR DESCRIPTION
Follow-up to #187 