### PR TITLE
20446: Fixes a test with an invalid train request

### DIFF
--- a/howso/client/tests/test_client.py
+++ b/howso/client/tests/test_client.py
@@ -751,7 +751,7 @@ class TestClient:
     def test_number_overflow(self, trainee):
         """Test an exception is raised for a number that is too large."""
         # Should not raise
-        self.client.train(trainee.id, [[1.8e307]], features=['penguin', 'play'])
+        self.client.train(trainee.id, [[1.8e307]], features=['penguin'])
 
         # Training with a number that is > 64bit should raise
         with pytest.raises(HowsoError):


### PR DESCRIPTION
One test trains a single case with a single feature value but specifies two feature names. A new check in the Engine triggers an error on this invalid request. Fixing the test to avoid the error.