### PR TITLE
20615: Removes "preserve_session_data" and "session" parameters from `remove_cases`, MAJOR

### DIFF
--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -138,8 +138,9 @@ class AbstractHowsoClient(ABC):
 
     @abstractmethod
     def remove_cases(self, trainee_id, num_cases, *,
-                     case_indices=None, condition_session=None,
-                     distribute_weight_feature=None, precision=None) -> int:
+                     case_indices=None, condition=None,
+                     condition_session=None, distribute_weight_feature=None,
+                     precision=None) -> int:
         """Remove training cases from a trainee."""
 
     @abstractmethod

--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -138,10 +138,8 @@ class AbstractHowsoClient(ABC):
 
     @abstractmethod
     def remove_cases(self, trainee_id, num_cases, *,
-                     case_indices=None,
-                     condition=None, condition_session=None,
-                     distribute_weight_feature=None, precision=None,
-                     preserve_session_data=False) -> int:
+                     case_indices=None, condition_session=None,
+                     distribute_weight_feature=None, precision=None) -> int:
         """Remove training cases from a trainee."""
 
     @abstractmethod

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -1482,7 +1482,6 @@ class HowsoDirectClient(AbstractHowsoClient):
         condition_session: Optional[str] = None,
         distribute_weight_feature: Optional[str] = None,
         precision: Optional[Literal["exact", "similar"]] = None,
-        preserve_session_data: bool = False
     ) -> int:
         """
         Removes training cases from a Trainee.
@@ -1542,8 +1541,6 @@ class HowsoDirectClient(AbstractHowsoClient):
         precision : {"exact", "similar"}, optional
             The precision to use when moving the cases, defaults to "exact".
             Ignored if case_indices is specified.
-        preserve_session_data : bool, default False
-            When True, will remove cases without cleaning up session data.
 
         Returns
         -------
@@ -1580,8 +1577,6 @@ class HowsoDirectClient(AbstractHowsoClient):
             distribute_weight_feature=distribute_weight_feature,
             num_cases=num_cases,
             precision=precision,
-            preserve_session_data=preserve_session_data,
-            session=self.active_session.id
         )
         self._auto_persist_trainee(trainee_id)
         return result.get('count', 0)
@@ -4369,7 +4364,7 @@ class HowsoDirectClient(AbstractHowsoClient):
             If not specified "exact" will be used. Only used if ``action_condition``
             is not None.
         context_condition : map of str -> any, optional
-            A condition map to select the context set, which is the set being queried to make 
+            A condition map to select the context set, which is the set being queried to make
             to make predictions on the action set. If both ``action_condition`` and ``context_condition``
             are provided,  then all of the cases from the action set, which is the dataset for which the
             prediction stats are for, will be excluded from the context set, effectively holding them out.

--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -2868,8 +2868,6 @@ class HowsoCore:
         condition_session: Optional[str] = None,
         distribute_weight_feature: Optional[str] = None,
         precision: Optional[Literal["exact", "similar"]] = None,
-        preserve_session_data: bool = False,
-        session: Optional[str] = None
     ) -> Dict:
         """
         Removes cases from a Trainee.
@@ -2896,10 +2894,6 @@ class HowsoCore:
         precision : {"exact", "similar"}, optional
             The precision to use when moving the cases, defaults to "exact".
             Ignored if case_indices is specified.
-        preserve_session_data : bool, default False
-            When True, will remove cases without cleaning up session data.
-        session : str, optional
-            The identifier of the Trainee session to associate the removal with.
 
         Returns
         -------
@@ -2912,8 +2906,6 @@ class HowsoCore:
             "condition_session": condition_session,
             "precision": precision,
             "num_cases": num_cases,
-            "preserve_session_data": preserve_session_data,
-            "session": session,
             "distribute_weight_feature": distribute_weight_feature,
         })
         if not result:

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -1906,7 +1906,6 @@ class Trainee(BaseTrainee):
         condition_session: Optional[str | BaseSession] = None,
         distribute_weight_feature: Optional[str] = None,
         precision: Optional[Precision] = None,
-        preserve_session_data: bool = False
     ) -> int:
         """
         Remove training cases from the trainee.
@@ -1965,8 +1964,6 @@ class Trainee(BaseTrainee):
         precision : {"exact", "similar"}, optional
             The precision to use when removing the cases.If not specified
             "exact" will be used. Ignored if case_indices is specified.
-        preserve_session_data : bool, default False
-            When True, will remove cases without cleaning up session data.
 
         Returns
         -------
@@ -1986,7 +1983,6 @@ class Trainee(BaseTrainee):
                 condition_session=condition_session_id,
                 distribute_weight_feature=distribute_weight_feature,
                 precision=precision,
-                preserve_session_data=preserve_session_data,
             )
         else:
             raise ValueError("Client must have 'remove_cases' method")
@@ -2830,7 +2826,7 @@ class Trainee(BaseTrainee):
             If not specified "exact" will be used. Only used if ``action_condition``
             is not None.
         context_condition : map of str -> any, optional
-            A condition map to select the context set, which is the set being queried to make 
+            A condition map to select the context set, which is the set being queried to make
             to make predictions on the action set. If both ``action_condition`` and ``context_condition``
             are provided,  then all of the cases from the action set, which is the dataset for which the
             prediction stats are for, will be excluded from the context set, effectively holding them out.


### PR DESCRIPTION
These parameters are unused in the Engine so this PR removes them from the clients.