### PR TITLE
20628: Fixes detail name used in a test

### DIFF
--- a/howso/client/tests/test_client.py
+++ b/howso/client/tests/test_client.py
@@ -698,7 +698,7 @@ class TestClient:
                 ['influential_cases', ]
             ),
             (
-                {'num_boundary_cases': 1, 'boundary_cases_familiarity_conviction': True, },
+                {'num_boundary_cases': 1, 'boundary_cases_familiarity_convictions': True, },
                 ['boundary_cases', ]
             ),
             (


### PR DESCRIPTION
One test has a slightly incorrect detail name, fixing it.