### PR TITLE
20773: Removes 'separate_files' parameters from `export_trainee`

### DIFF
--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -576,7 +576,6 @@ class HowsoDirectClient(AbstractHowsoClient):
         trainee_id: str,
         path_to_trainee: Optional[Union[Path, str]] = None,
         decode_cases: bool = False,
-        separate_files: bool = False
     ):
         """
         Export a saved Trainee's data to json files for migration.
@@ -589,14 +588,11 @@ class HowsoDirectClient(AbstractHowsoClient):
             The path to where the saved trainee file is located.
         decoded_cases : bool, default False.
             Whether to export decoded cases.
-        separate_files : bool, default False
-            Whether to load each case from its individual file.
         """
         if self.verbose:
             print(f'Export trainee with id: {trainee_id}')
 
-        self.howso.export_trainee(trainee_id, path_to_trainee, decode_cases,
-                                  separate_files)
+        self.howso.export_trainee(trainee_id, path_to_trainee, decode_cases)
 
     def upgrade_trainee(
         self,

--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -2490,7 +2490,6 @@ class HowsoCore:
         trainee_id: str,
         path_to_trainee: Optional[Union[Path, str]] = None,
         decode_cases: bool = False,
-        separate_files: bool = False
     ) -> None:
         """
         Export a saved Trainee's data to json files for migration.
@@ -2503,8 +2502,6 @@ class HowsoCore:
             The path to where the saved trainee file is located.
         decoded_cases : bool, default False.
             Whether to export decoded cases.
-        separate_files : bool, default False
-            Whether to load each case from its individual file.
         """
         if path_to_trainee is None:
             path_to_trainee = self.default_save_path
@@ -2514,7 +2511,6 @@ class HowsoCore:
             "trainee": f"{trainee_id}",
             "root_filepath": f"{self.howso_path}/",
             "decode_cases": decode_cases,
-            "separate_files": separate_files,
         })
 
     def upgrade_trainee(

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "howso-engine": "84.0.0"
+    "howso-engine": "84.0.1"
   }
 }


### PR DESCRIPTION
Removes parameters that are no longer used by the Engine (and are consequently rejected).