### PR TITLE
20725: Add multiprocessing to infer_feature_attributes for dataframes

### DIFF
--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -533,6 +533,7 @@ class InferFeatureAttributesBase(ABC):
                  ordinal_feature_values: Optional[Dict[str, List[str]]] = None,
                  dependent_features: Optional[Dict[str, List[str]]] = None,
                  include_sample: bool = False,
+                 max_workers: Optional[int] = None,
                  ) -> Dict:
         """
         Get inferred feature attributes for the parameters.

--- a/howso/utilities/feature_attributes/infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/infer_feature_attributes.py
@@ -1,4 +1,7 @@
-from typing import Iterable, Union
+from __future__ import annotations
+
+from collections.abc import Iterable
+import typing as t
 
 import pandas as pd
 
@@ -9,9 +12,11 @@ from .relational import InferFeatureAttributesSQLDatastore
 from .time_series import InferFeatureAttributesTimeSeries
 
 
-def infer_feature_attributes(data: Union[pd.DataFrame, SQLRelationalDatastoreProtocol], *,
-                             tables: Iterable[TableNameProtocol] = None,
-                             time_feature_name: str = None, **kwargs) -> FeatureAttributesBase:
+def infer_feature_attributes(data: pd.DataFrame | SQLRelationalDatastoreProtocol, *,
+                             tables: t.Optional[Iterable[TableNameProtocol]] = None,
+                             time_feature_name: t.Optional[str] = None,
+                             **kwargs
+                             ) -> FeatureAttributesBase:
     """
     Return a dict-like feature attributes object with useful accessor methods.
 
@@ -332,6 +337,16 @@ def infer_feature_attributes(data: Union[pd.DataFrame, SQLRelationalDatastorePro
     include_sample: bool, default False
         If True, include a ``sample`` field containing a sample of the data
         from each feature in the output feature attributes dictionary.
+
+    max_workers: int, optional
+        If unset or set to None (recommended), let the ProcessPoolExecutor
+        choose the best maximum number of process pool workers to process
+        columns in a multi-process fashion. In this case, if the product of the
+        data's rows and columns < 25,000,000, multiprocessing will not be used.
+
+        If defined with an integer > 0, manually set the number of max workers.
+        Otherwise, the feature attributes will be calculated serially. Setting
+        this parameter to zero (0) will disable multiprocessing.
 
     Returns
     -------

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -75,7 +75,6 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
             futures: dict[Future, str] = dict()
 
             with ProcessPoolExecutor(max_workers=max_workers, mp_context=mp_context) as pool:
-                print(f"Using process pool with {pool._max_workers} workers.")  # type: ignore reportPrivateUsage
                 for f in self.data.columns:
                     future = pool.submit(_shard, self.data[[f]], kwargs=kwargs)
                     futures[future] = f
@@ -88,7 +87,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                         feature_attributes.update(response[0])
                         unsupported.extend(response[1])
                     except Exception as e:
-                        print(
+                        warnings.warn(
                             f"Infer_feature_attributes raised an exception "
                             f"while processing '{futures[future]}' ({str(e)})."
                         )

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -32,7 +32,7 @@ from ..utilities import (
 
 logger = logging.getLogger(__name__)
 
-# Import sqlalchemy only if it's available. Not all users of this package will have or need
+# Import SQLAlchemy only if it's available. Not all users of this package will have or need
 # this installed.
 try:
     import sqlalchemy as db
@@ -255,12 +255,12 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
         column_types : DatastoreColumnTypes
             The datastore column types.
         session_cls : SessionProtocol
-            The sqlalchemy Session object associated with this SQL table.
+            The SQLAlchemy Session object associated with this SQL table.
         parent_datastore : SQLRelationalDatastoreProtocol
             The datastore to which this SQL table belongs.
         """
         if not db:
-            raise ImportError('Must have sqlalchemy installed to instantiate '
+            raise ImportError('Must have SQLAlchemy installed to instantiate '
                               'FeatureAttributesSQLTable. See synthesizer-data-services/'
                               'requirements.in for versioning.')
         self.data = data

--- a/howso/utilities/feature_attributes/time_series.py
+++ b/howso/utilities/feature_attributes/time_series.py
@@ -269,6 +269,7 @@ class InferFeatureAttributesTimeSeries:
         num_lags: Optional[Union[int, dict]] = None,
         rate_boundaries: Optional[Dict] = None,
         delta_boundaries: Optional[Dict] = None,
+        max_workers: Optional[int] = None,
     ) -> Dict:
         """
         Infer time series attributes.


### PR DESCRIPTION
This PR improves `infer_feature_attributes` performance for large, dataframe-based datasets. In addition to reduced time to calculate, the memory overhead can also be reduced. The largest performance gains and memory reduction come from larger datasets.

For example:
A dataset with 27 columns and 69M rows:

- `0h52m27.8s / 12,781 MiB RAM` - without multiprocessing: 
- `0h09m01.5s /    793 MiB RAM` - with multiprocessing

This represents a performance _boost_ of 5.8X and a memory _reduction_ of 16X.

By default, IFR will automatically determine whether to use multi-processing. If the product of the dataset's  rows and columns is smaller than 25M cells, IFR will automatically _not_ use multi-processing as it is unlikely to be faster.

Multiprocessing can be forced `ON`, regardless of datasize by including the new kwarg `max_workers` with a value of `1` or greater (take care to not set it much higher than the available CPU cores). Old, non-multi-processing behavior can be enforced by setting `max_workers` to `0`. Leaving `max_workers` undefined will use the automatic behavior described above.