### PR TITLE
20992: Fixes upgrade trainee

### DIFF
--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -891,7 +891,7 @@ class HowsoDirectClient(AbstractHowsoClient):
             The base name of the exported Trainee json files. If not specified,
             uses the value of `trainee_id`. (e.g., [filename].meta.json)
         filepath : Path or str, optional
-            The directory where the `.exp.json` and `.meta.json` files exist.
+            The directory where the exported Trainee `.exp.json` and `.meta.json` files exist.
 
         Returns
         -------


### PR DESCRIPTION
- Updated parameters to upgrade/export to be more consistent
- Upgrade now initializes an empty trainee before executing the upgrade
- An error message from load_entity is now exposed in the raised error