### PR TITLE
21036: Adds version information to installation verification output and stacktrace

### DIFF
--- a/howso/utilities/installation_verification.py
+++ b/howso/utilities/installation_verification.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import IntEnum
 from functools import cached_property, partial
-import importlib
+import importlib.metadata
 import inspect
 from io import StringIO
 import logging
@@ -274,6 +274,12 @@ class InstallationCheckRegistry:
         if not self.logger:
             self.logger = StringIO()
         start_time = datetime.now()
+
+        versions = {
+            "python": "Could not get Python version.",
+            "client_type": "Could not get client type.",
+            "client": "Could not get client version.",
+        }
 
         try:
             versions = get_versions()

--- a/howso/utilities/installation_verification.py
+++ b/howso/utilities/installation_verification.py
@@ -497,8 +497,6 @@ def generate_dataframe(*, client: AbstractHowsoClient,
         }
     }
     feature_names = list(features.keys())
-    context_features = list(feature_names)[:-1]
-    action_features = [list(feature_names)[-1]]
 
     trainee_obj = Trainee(
         f"installation_verification generated dataframe ({get_nonce()})",


### PR DESCRIPTION
Adds version information to the output of the installation verification script, and ensures that versioning information is put in the output stack trace in the case of an error.