### PR TITLE
21108: Filter out unrelated partial features when multiprocessing

### DIFF
--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -42,7 +42,15 @@ SMALLEST_TIME_DELTA = 0.001
 def _shard(data: pd.DataFrame, *, kwargs: dict[str, t.Any]):
     """Internal function to aid multiprocessing of feature attributes."""
     ifr_inst = InferFeatureAttributesDataFrame(data)
-    feature_attributes = ifr_inst._process(**kwargs)  # type: ignore reportPrivateUsage
+    # Filter out features that are not related to this shard.
+    _kwargs = kwargs.copy()
+    if "features" in _kwargs:
+        _kwargs['features'] = {
+            k: v for k, v in _kwargs["features"].items()
+            if k in data.columns
+        }
+
+    feature_attributes = ifr_inst._process(**_kwargs)  # type: ignore reportPrivateUsage
     return feature_attributes, ifr_inst.unsupported
 
 

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
@@ -89,12 +89,27 @@ def test_infer_features_attributes():
 
 
 @pytest.mark.parametrize(
-    "features",
-    [features_1, features_2, features_3, features_4]
+    "features, max_workers",
+    [
+        (features_1, 0),
+        (features_2, 0),
+        (features_3, 0),
+        (features_4, 0),
+        (features_1, 2),
+        (features_2, 2),
+        (features_3, 2),
+        (features_4, 2),
+    ]
 )
-def test_partially_filled_feature_types(features: dict) -> None:
+def test_partially_filled_feature_types(features: dict, max_workers: int) -> None:
     """
     Make sure the partially filled feature types remain intact.
+
+    Note:
+        max_workers: 0 - Forces the non-multi-processing path which would
+                         be normal for this dataset anyway.
+        max_workers: 2 - Forces the multi-processing path which would otherwise
+                         be unnatural for this dataset.
 
     Parameters
     ----------
@@ -106,7 +121,8 @@ def test_partially_filled_feature_types(features: dict) -> None:
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        inferred_features = infer_feature_attributes(df, features=features)
+        inferred_features = infer_feature_attributes(
+            df, features=features, max_workers=max_workers)
 
     for k, v in pre_inferred_features.items():
         assert v['type'] == inferred_features[k]['type']


### PR DESCRIPTION
When using multi-processing, a subset of the columns are processed in other processes. This PR filters the partial features passed in the `features` parameter to only those partial features relevant to the subset used in each process.