### PR TITLE
20491: Fixes experimental arguments being passed to reduce_data with kwargs

### DIFF
--- a/howso/direct/core.py
+++ b/howso/direct/core.py
@@ -1,7 +1,6 @@
 import logging
 from pathlib import Path
 import platform
-import typing as t
 from typing import (
     Any,
     Dict,
@@ -13,14 +12,19 @@ from typing import (
     Tuple,
     Union,
 )
+import typing as t
 import uuid
 import warnings
 
 from amalgam.api import Amalgam
-from howso.client.exceptions import HowsoError, HowsoWarning
+import six
+
+from howso.client.exceptions import (
+    HowsoError,
+    HowsoWarning,
+)
 from howso.utilities.internals import sanitize_for_json
 import howso.utilities.json_wrapper as json
-import six
 
 _logger = logging.getLogger('howso.direct')
 
@@ -986,6 +990,7 @@ class HowsoCore:
                 "distribute_weight_feature": distribute_weight_feature,
                 "influence_weight_entropy_threshold": influence_weight_entropy_threshold,
                 "skip_auto_analyze": skip_auto_analyze,
+                **kwargs,
             }
         )
 

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
-import typing as t
 from typing import (
     Any,
     Callable,
@@ -14,6 +13,7 @@ from typing import (
     Tuple,
     Union,
 )
+import typing as t
 import uuid
 import warnings
 
@@ -929,6 +929,7 @@ class Trainee(BaseTrainee):
                 distribute_weight_feature=distribute_weight_feature,
                 influence_weight_entropy_threshold=influence_weight_entropy_threshold,
                 skip_auto_analyze=skip_auto_analyze,
+                **kwargs,
             )
         else:
             raise ValueError("Client must have the 'reduce_data' method.")


### PR DESCRIPTION
Not an API change, as `**kwargs` was technically in the API already, just not passed through all levels.