### PR TITLE
21291: Improve datetime handling in infer_feature_attributes

### DIFF
--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -628,6 +628,7 @@ class InferFeatureAttributesBase(ABC):
                     # User passed only the format string
                     feature_attributes[feature_name] = {
                         'type': 'continuous',
+                        'data_type': 'formatted_date_time',
                         'date_time_format': user_dt_format,
                     }
                 elif (
@@ -638,6 +639,7 @@ class InferFeatureAttributesBase(ABC):
                     dt_format, dt_locale = user_dt_format
                     feature_attributes[feature_name] = {
                         'type': 'continuous',
+                        'data_type': 'formatted_date_time',
                         'date_time_format': dt_format,
                         'locale': dt_locale,
                     }

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
@@ -408,7 +408,7 @@ def test_dependent_features(should_include, base_features, dependent_features):
 ])
 def test_infer_feature_bounds(data, tight_bounds, expected_bounds):
     """Test the infer_feature_bounds() method."""
-    df = pd.DataFrame([[cell] for cell in data], columns=['a'])
+    df = pd.DataFrame(pd.Series(data), columns=['a'])
     features = infer_feature_attributes(df, tight_bounds=tight_bounds)
     assert features['a']['type'] == 'continuous'
     assert 'bounds' in features['a']


### PR DESCRIPTION
- Correctly assign `"data_type": "formatted_date_time"` when a datetime feature format is supplied.
- Correctly determine the bounds of a Pandas data frame datetime feature
- Significantly improve the performance of discovering bounds of Pandas data frame datetime features