### PR TITLE
21586: Bumps howso-engine version

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "howso-engine": "86.0.14"
+    "howso-engine": "86.0.15"
   }
 }


### PR DESCRIPTION
There was a bugfix in howso-engine, bringing it into the python package.