### PR TITLE
22144: Renames "session" parameter of `delete_session()` to "target_session", MAJOR

### DIFF
--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -1289,7 +1289,7 @@ class AbstractHowsoClient(ABC):
             return []
         return result
 
-    def delete_session(self, trainee_id: str, session: str | Session):
+    def delete_session(self, trainee_id: str, target_session: str | Session):
         """
         Delete a session from a Trainee.
 
@@ -1297,15 +1297,15 @@ class AbstractHowsoClient(ABC):
         ----------
         trainee_id : str
             The ID of the Trainee to delete the session from.
-        session : str
+        target_session : str
             The session or session identifier to delete.
         """
         trainee_id = self._resolve_trainee(trainee_id).id
-        if isinstance(session, Session):
-            session = session.id
+        if isinstance(target_session, Session):
+            target_session = target_session.id
         if self.configuration.verbose:
-            print(f'Deleting session {session} from Trainee with id: {trainee_id}')
-        self.execute(trainee_id, "delete_session", {"session": session})
+            print(f'Deleting session {target_session} from Trainee with id: {trainee_id}')
+        self.execute(trainee_id, "delete_session", {"target_session": target_session})
         self._auto_persist_trainee(trainee_id)
 
     def get_session_indices(self, trainee_id: str, session: str | Session) -> list[int]:

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -2143,21 +2143,21 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the 'get_sessions' method.")
 
-    def delete_session(self, session: str | BaseSession):
+    def delete_session(self, target_session: str | BaseSession):
         """
         Delete a session from the trainee.
 
         Parameters
         ----------
-        session : str or Session
+        target_session : str or Session
             The id or instance of the session to remove from the model.
         """
-        if isinstance(session, BaseSession):
-            session_id = session.id
+        if isinstance(target_session, BaseSession):
+            session_id = target_session.id
         else:
-            session_id = session
+            session_id = target_session
         if isinstance(self.client, AbstractHowsoClient):
-            self.client.delete_session(trainee_id=self.id, session=session_id)
+            self.client.delete_session(trainee_id=self.id, target_session=session_id)
         else:
             raise AssertionError("Client must have the 'delete_session' method.")
 


### PR DESCRIPTION
Renames the "session" parameter of #delete_session to "target_session" to help differentiate session parameters that indicate the active session of the user from parameters used to specify a specific non-active session.