### PR TITLE
22328: Fixes a bug when doing generative series forecasts using Dataframes for `continue_series_values`

### DIFF
--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -2930,7 +2930,7 @@ class AbstractHowsoClient(ABC):
                 "context_values": contexts,
                 "continue_series": continue_series,
                 "continue_series_features": continue_series_features,
-                "continue_series_values": continue_series_values,
+                "continue_series_values": serialized_continue_series_values,
                 "initial_features": initial_features,
                 "initial_values": initial_values,
                 "final_time_steps": final_time_steps,


### PR DESCRIPTION
When doing a generative series forecast using `react_series` and Dataframes as values for `continue_series_values`, incorrect values were being passed to the howso-engine. Column names were being passed instead of the serialized case values for each series. This fixes the issue.