### PR TITLE
22385: Defines to_dataframe in `FeatureAttributesBase`, MINOR

### DIFF
--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -85,6 +85,20 @@ class FeatureAttributesBase(dict):
         """
         return json.dumps(self)
 
+    def to_dataframe(self, *, include_all: bool = False) -> pd.DataFrame:
+        """
+        Return a DataFrame of the feature attributes.
+
+        Among other reasons, this is useful for presenting feature attributes
+        in a Jupyter notebook or other medium.
+
+        Returns
+        -------
+        pandas.DataFrame
+            A DataFrame representation of the inferred feature attributes.
+        """
+        return NotImplementedError('Function not yet implemented for all subclasses of `FeatureAttributesBase`')
+
     def get_names(self, *, types: t.Optional[str | Container] = None,
                   without: t.Optional[Iterable[str]] = None,
                   ) -> list[str]:


### PR DESCRIPTION
While it is only implemented in the `SingleTableFeatureAttributes` subclass, this will allow VSCode to autofill the method signature and display the docstring.