### PR TITLE
22560: Adds FrozenTimer dataclass MINOR

### DIFF
--- a/howso/utilities/__init__.py
+++ b/howso/utilities/__init__.py
@@ -12,6 +12,7 @@ from .features import (  # noqa: F401
     serialize_cases,
 )
 from .monitors import (
+    FrozenTimer,
     ProgressTimer,
     Timer,
 )
@@ -65,6 +66,7 @@ __all__ = [
     "FeatureAttributesBase",
     "FeatureType",
     "format_dataframe",
+    "FrozenTimer",
     "get_kwargs",
     "get_matrix_diff",
     "infer_feature_attributes",

--- a/howso/utilities/monitors.py
+++ b/howso/utilities/monitors.py
@@ -1,18 +1,36 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 import typing as t
 
 
 __all__ = [
+    "FrozenTimer",
     "ProgressTimer",
     "Timer",
 ]
 
 
+@dataclass(frozen=True)
+class FrozenTimer():
+    """A typed dictionary of a Timer instance's state."""
+
+    message: str | None = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+    duration: timedelta | None = None
+
+
 class Timer:
     """
     Simple context manager to capture run duration of the inner context.
+
+    Parameters
+    ----------
+    message : str, default None
+        Optional. A string message. If provided, the Timer, when used as a
+        context manager, upon exit, will display this message and the duration.
 
     Usage::
 
@@ -90,6 +108,15 @@ class Timer:
     def __exit__(self, *args):
         """Context exit."""
         self.end()
+
+    def to_frozen_timer(self) -> FrozenTimer:
+        """Return the timer as a FrozenTimer instance."""
+        return FrozenTimer(
+            start_time=self.start_time,
+            end_time=self.end_time,
+            duration=self.duration,
+            message=self.message
+        )
 
 
 class ProgressTimer(Timer):

--- a/howso/utilities/tests/test_monitors.py
+++ b/howso/utilities/tests/test_monitors.py
@@ -1,0 +1,30 @@
+from datetime import timedelta
+from time import sleep
+
+from howso.utilities import FrozenTimer, Timer
+
+
+def test_timer():
+    """Simple test to ensure that the timer works."""
+    with Timer() as simple_timer:
+        sleep(0.1)
+    assert (simple_timer.duration or timedelta(0)) >= timedelta(seconds=0.1)
+
+
+def test_message_timer(capsys):
+    """Simple test that the timer with a message works as intended."""
+    with Timer(message="Timing test"):
+        sleep(0.1)
+    assert "Timing test : 0:00:00.1" in capsys.readouterr().out
+
+
+def test_frozen_timer():
+    """Test that Timer.to_frozen_timer() works as expected."""
+    with Timer(message="Build snowman") as msg_timer:
+        sleep(0.1)
+    frozen_timer = msg_timer.to_frozen_timer()
+    assert isinstance(frozen_timer, FrozenTimer)
+    assert (frozen_timer.duration or timedelta(0)) >= timedelta(seconds=0.1)
+    assert frozen_timer.message == "Build snowman"
+    assert frozen_timer.start_time == msg_timer.start_time
+    assert frozen_timer.end_time == msg_timer.end_time


### PR DESCRIPTION
The state of a Timer can now be preserved as a frozen (Data) Class instance using the method `to_frozen_timer()`.

Also, adds some basic unit tests for Timer in general.