### PR TITLE
22615: Make monitor tests more resilient to CI/CD delays.

### DIFF
--- a/howso/utilities/tests/test_monitors.py
+++ b/howso/utilities/tests/test_monitors.py
@@ -14,17 +14,17 @@ def test_timer():
 def test_message_timer(capsys):
     """Simple test that the timer with a message works as intended."""
     with Timer(message="Timing test"):
-        sleep(0.1)
-    assert "Timing test : 0:00:00.1" in capsys.readouterr().out
+        sleep(1)
+    assert "Timing test : 0:00:01" in capsys.readouterr().out
 
 
 def test_frozen_timer():
     """Test that Timer.to_frozen_timer() works as expected."""
     with Timer(message="Build snowman") as msg_timer:
-        sleep(0.1)
+        sleep(1)
     frozen_timer = msg_timer.to_frozen_timer()
     assert isinstance(frozen_timer, FrozenTimer)
-    assert (frozen_timer.duration or timedelta(0)) >= timedelta(seconds=0.1)
+    assert (frozen_timer.duration or timedelta(0)) >= timedelta(seconds=1)
     assert frozen_timer.message == "Build snowman"
     assert frozen_timer.start_time == msg_timer.start_time
     assert frozen_timer.end_time == msg_timer.end_time


### PR DESCRIPTION
Use 1 second rather than 0.1 second in the monitor as 0.1 seconds were being delayed by CI/CD, possibly due to concurrent tests running.