### PR TITLE
22732: Adds observed bounds to feature attributes MINOR

### DIFF
--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -513,8 +513,11 @@ class FeatureAttributesBase(dict):
             orig_type = attributes.get(feature_name, {}).get('type')
             new_type = entries[feature_name].get('type')
             # TODO 22059: Allow ordinals here when we can attempt to infer values
-            if new_type == 'ordinal':
-                raise ValueError('Inferral of ordinal values is not yet supported. Please '
+            if new_type == 'ordinal' and not (
+                attributes.get(feature_name, {}).get('bounds', {}).get('allowed') or
+                entries.get(feature_name, {}).get('bounds', {}).get('allowed')
+            ):
+                raise ValueError('Inference of ordinal values is not yet supported. Please '
                                  'preset ordinal features with their ordered values using '
                                  '`ordinal_feature_values`.')
             # Sanity check: booleans must be nominal
@@ -1436,3 +1439,7 @@ class InferFeatureAttributesBase(ABC):
     @abstractmethod
     def _get_feature_names(self) -> list[str]:
         """Get the names of the features/columns of the data."""
+
+    @abstractmethod
+    def _get_unique_values(self, feature_name: str) -> set[t.Any]:
+        """Get a set of the unique values for the given feature_name."""

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -303,7 +303,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                                          '`cycle_length` must be specified in attributes')
                     return {
                         'min': 0, 'max': feature_attributes[feature_name]['cycle_length'],
-                        'actual_min': 0, 'actual_max': feature_attributes[feature_name]['cycle_length'],
+                        'observed_min': 0, 'observed_max': feature_attributes[feature_name]['cycle_length'],
                         'allow_null': allow_null
                     }
                 # Tight bounds
@@ -319,7 +319,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
 
                     return {
                         'min': min_time, 'max': max_time,
-                        'actual_min': min_time, 'actual_max': max_time,
+                        'observed_min': min_time, 'observed_max': max_time,
                         'allow_null': allow_null,
                     }
 
@@ -435,7 +435,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                     actual_max = epoch_to_date(actual_max_f, format_dt, max_date_tz)
                     return {
                         'min': min_date, 'max': max_date,
-                        'actual_min': actual_min, 'actual_max': actual_max
+                        'observed_min': actual_min, 'observed_max': actual_max
                     }
                 except Exception:  # noqa: Intentionally broad
                     w_str = (f'Feature {feature_name} does not match the '
@@ -486,7 +486,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
 
                 output = {
                     'min': min_f, 'max': max_f,
-                    'actual_min': actual_min_f, 'actual_max': actual_max_f,
+                    'observed_min': actual_min_f, 'observed_max': actual_max_f,
                     'allow_null': allow_null,
                 }
             else:
@@ -497,7 +497,7 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                 if min_value is not None and max_value is not None:
                     output = {
                         'min': min_value, 'max': max_value,
-                        'actual_min': min_f, 'actual_max': max_f,
+                        'observed_min': min_f, 'observed_max': max_f,
                         'allow_null': allow_null,
                     }
                 else:

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -501,7 +501,6 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                 if min_value is not None and max_value is not None:
                     output = {
                         'min': min_value, 'max': max_value,
-                        'observed_min': min_f, 'observed_max': max_f,
                         'allow_null': allow_null,
                     }
                 else:

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -488,9 +488,9 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                     'min': min_f, 'max': max_f,
                     'allow_null': allow_null,
                 }
-                if observed_min_f and not isnan(observed_min_f):
+                if not isnan(observed_min_f):
                     output.update(observed_min=observed_min_f)
-                if observed_max_f and not isnan(observed_max_f):
+                if not isnan(observed_max_f):
                     output.update(observed_max=observed_max_f)
 
             else:

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -958,6 +958,10 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
                         'min': min_v, 'max': max_v,
                         'observed_min': observed_min_value, 'observed_max': observed_max_value,
                     }
+                    if observed_min_value:
+                        output.update(observed_min=observed_min_value)
+                    if observed_max_value:
+                        output.update(observed_max=observed_max_value)
 
         else:  # Non-continuous
             output: dict = {'allow_null': allow_null}

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -945,23 +945,19 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
                     max_v = epoch_to_date(max_v, format_dt, max_date_tz)
                 output = {
                     'min': min_v, 'max': max_v,
-                    'observed_min': observed_min_value, 'observed_max': observed_max_value,
                     'allow_null': allow_null
                 }
+                if not isnan(observed_min_value):
+                    output.update(observed_min=observed_min_value)
+                if not isnan(observed_max_value):
+                    output.update(observed_max=observed_max_value)
             else:
                 # If no min/max were found from the data, use min/max size of
                 # the data type.
                 min_v, max_v = self._get_min_max_number_size_bounds(
                     feature_attributes, feature_name)
                 if min_v is not None and max_v is not None:
-                    output = {
-                        'min': min_v, 'max': max_v,
-                        'observed_min': observed_min_value, 'observed_max': observed_max_value,
-                    }
-                    if observed_min_value:
-                        output.update(observed_min=observed_min_value)
-                    if observed_max_value:
-                        output.update(observed_max=observed_max_value)
+                    output = {'min': min_v, 'max': max_v}
 
         else:  # Non-continuous
             output: dict = {'allow_null': allow_null}

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -822,7 +822,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
                                          '`cycle_length` must be specified in attributes')
                     return {
                         'min': 0, 'max': feature_attributes[feature_name]['cycle_length'],
-                        'actual_min': 0, 'actual_max': feature_attributes[feature_name]['cycle_length'],
+                        'observed_min': 0, 'observed_max': feature_attributes[feature_name]['cycle_length'],
                         'allow_null': allow_null
                     }
                 elif column_type in self.column_types.all_date_time_types:
@@ -831,7 +831,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
                         self._get_min_max_values(feature_name))
                     return {
                         'min': time_to_seconds(min_time), 'max': time_to_seconds(max_time),
-                        'actual_min': time_to_seconds(min_time), 'actual_max': time_to_seconds(max_time),
+                        'observed_min': time_to_seconds(min_time), 'observed_max': time_to_seconds(max_time),
                         'allow_null': allow_null
                     }
                 else:
@@ -945,7 +945,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
                     max_value = epoch_to_date(max_value, format_dt, max_date_tz)
                 output = {
                     'min': min_value, 'max': max_value,
-                    'actual_min': actual_min_value, 'actual_max': actual_max_value,
+                    'observed_min': actual_min_value, 'observed_max': actual_max_value,
                     'allow_null': allow_null
                 }
             else:
@@ -956,7 +956,7 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
                 if min_value is not None and max_value is not None:
                     output = {
                         'min': min_value, 'max': max_value,
-                        'actual_min': actual_min_value, 'actual_max': actual_max_value,
+                        'observed_min': actual_min_value, 'observed_max': actual_max_value,
                     }
 
         else:

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
@@ -269,27 +269,27 @@ def test_infer_time_features(data, is_time, expected_format):
 @pytest.mark.parametrize('data, tight_bounds, provided_format, expected_bounds, cycle_length', [
     (
         pd.DataFrame(["00:00:00", "23:59:59"], columns=['a']), ['a'], None,
-        {'min': 0, 'max': 86399, 'actual_min': 0, 'actual_max': 86399, 'allow_null': True}, 86400
+        {'min': 0, 'max': 86399, 'observed_min': 0, 'observed_max': 86399, 'allow_null': True}, 86400
     ),
     (
         pd.DataFrame(["03:00:00.0", "12:00:01.5"], columns=['a']), ['a'], None,
-        {'min': 10800, 'max': 43201.5, 'actual_min': 10800, 'actual_max': 43201.5, 'allow_null': True}, 86400
+        {'min': 10800, 'max': 43201.5, 'observed_min': 10800, 'observed_max': 43201.5, 'allow_null': True}, 86400
     ),
     (
         pd.DataFrame(["03:00:00.0", "12:00:01.5"], columns=['a']), None, None,
-        {'min': 0, 'max': 86400, 'actual_min': 0, 'actual_max': 86400, 'allow_null': True}, 86400
+        {'min': 0, 'max': 86400, 'observed_min': 0, 'observed_max': 86400, 'allow_null': True}, 86400
     ),
     (
         pd.DataFrame(["25:0", "30:0"], columns=['a']), ['a'], '%M:%S',
-        {'min': 1500, 'max': 1800, 'actual_min': 1500, 'actual_max': 1800, 'allow_null': True}, 3600
+        {'min': 1500, 'max': 1800, 'observed_min': 1500, 'observed_max': 1800, 'allow_null': True}, 3600
     ),
     (
         pd.DataFrame(["25.0", "30.5"], columns=['a']), None, '%S.%f',
-        {'min': 0, 'max': 60, 'actual_min': 0, 'actual_max': 60, 'allow_null': True}, 60
+        {'min': 0, 'max': 60, 'observed_min': 0, 'observed_max': 60, 'allow_null': True}, 60
     ),
     (
         pd.DataFrame(["5", "7"], columns=['a']), None, '%f',
-        {'min': 0, 'max': 1, 'actual_min': 0, 'actual_max': 1, 'allow_null': True}, 1
+        {'min': 0, 'max': 1, 'observed_min': 0, 'observed_max': 1, 'allow_null': True}, 1
     ),
 ])
 def test_infer_time_feature_bounds(data, tight_bounds, provided_format, expected_bounds, cycle_length):
@@ -372,37 +372,37 @@ def test_dependent_features(should_include, base_features, dependent_features):
 
 
 @pytest.mark.parametrize('tight_bounds, data, expected_bounds', [
-    (None, [2, 3, 4, 5, 6, 7], {'min': 1, 'max': 7, 'actual_min': 2, 'actual_max': 7, 'allow_null': False}),
-    (None, [2, 3, 4, 4, 5, 6, 6, 6, 6], {'min': 1, 'max': 6, 'actual_min': 2, 'actual_max': 6, 'allow_null': False}),
-    (None, [2, 3, 4, 4, 4, 4, 6, 6, 6, 6], {'min': 1, 'max': 6, 'actual_min': 2, 'actual_max': 6, 'allow_null': False}),  # noqa: E501
-    (None, [2, 2, 2, 2, 4, 5, 6, 6, 6, 6], {'min': 2, 'max': 6, 'actual_min': 2, 'actual_max': 6, 'allow_null': False}),  # noqa: E501
-    (None, [2, 2, 2, 2, 4, 5, 6, 6, 6, 6, 6], {'min': 1, 'max': 6, 'actual_min': 2, 'actual_max': 6, 'allow_null': False}),  # noqa: E501
-    (None, [2, 2, 2, 2, 4, 5, 6, 7], {'min': 2, 'max': 7, 'actual_min': 2, 'actual_max': 7, 'allow_null': False}),
+    (None, [2, 3, 4, 5, 6, 7], {'min': 1, 'max': 7, 'observed_min': 2, 'observed_max': 7, 'allow_null': False}),
+    (None, [2, 3, 4, 4, 5, 6, 6, 6, 6], {'min': 1, 'max': 6, 'observed_min': 2, 'observed_max': 6, 'allow_null': False}),
+    (None, [2, 3, 4, 4, 4, 4, 6, 6, 6, 6], {'min': 1, 'max': 6, 'observed_min': 2, 'observed_max': 6, 'allow_null': False}),  # noqa: E501
+    (None, [2, 2, 2, 2, 4, 5, 6, 6, 6, 6], {'min': 2, 'max': 6, 'observed_min': 2, 'observed_max': 6, 'allow_null': False}),  # noqa: E501
+    (None, [2, 2, 2, 2, 4, 5, 6, 6, 6, 6, 6], {'min': 1, 'max': 6, 'observed_min': 2, 'observed_max': 6, 'allow_null': False}),  # noqa: E501
+    (None, [2, 2, 2, 2, 4, 5, 6, 7], {'min': 2, 'max': 7, 'observed_min': 2, 'observed_max': 7, 'allow_null': False}),
     (None, [float('nan'), float('nan')], {'allow_null': True}),
-    (['a'], [2, 3, 4, 5, 6, 7], {'min': 2, 'max': 7, 'actual_min': 2, 'actual_max': 7, 'allow_null': False}),
-    (['a'], [2, 3, 4, None, 6, 7], {'min': 2, 'max': 7, 'actual_min': 2, 'actual_max': 7, 'allow_null': True}),
+    (['a'], [2, 3, 4, 5, 6, 7], {'min': 2, 'max': 7, 'observed_min': 2, 'observed_max': 7, 'allow_null': False}),
+    (['a'], [2, 3, 4, None, 6, 7], {'min': 2, 'max': 7, 'observed_min': 2, 'observed_max': 7, 'allow_null': True}),
     (
         ['a'],
         ['1905-01-01', '1904-05-03', '2020-01-15', '2000-04-26', '2000-04-24'],
-        {'min': '1904-05-03', 'max': '2020-01-15', 'actual_min': '1904-05-03', 'actual_max': '2020-01-15'}
+        {'min': '1904-05-03', 'max': '2020-01-15', 'observed_min': '1904-05-03', 'observed_max': '2020-01-15'}
     ),
     (
         None,
         ['1905-01-01', '1904-05-03', '2020-01-15', '2000-04-26', '2000-04-24'],
-        {'min': '1856-05-25', 'max': '2083-08-08', 'actual_min': '1904-05-03', 'actual_max': '2020-01-15'}
+        {'min': '1856-05-25', 'max': '2083-08-08', 'observed_min': '1904-05-03', 'observed_max': '2020-01-15'}
     ),
     (
         None,
         ['1905-01-01', '1904-05-03', '2020-01-15', '2020-01-15', '2020-01-15',
          '2020-01-15', '2000-04-26', '2000-04-24'],
-        {'min': '1856-05-25', 'max': '2020-01-15', 'actual_min': '1904-05-03', 'actual_max': '2020-01-15'}
+        {'min': '1856-05-25', 'max': '2020-01-15', 'observed_min': '1904-05-03', 'observed_max': '2020-01-15'}
     ),
     (
         None,
         ['1905-01-01', '1904-05-03', '1904-05-03', '1904-05-03', '1904-05-03',
          '2020-01-15', '2020-01-15', '2020-01-15', '2020-01-15', '2000-04-26',
          '2000-04-24'],
-        {'min': '1904-05-03', 'max': '2020-01-15', 'actual_min': '1904-05-03', 'actual_max': '2020-01-15'}
+        {'min': '1904-05-03', 'max': '2020-01-15', 'observed_min': '1904-05-03', 'observed_max': '2020-01-15'}
     ),
     (
         None,
@@ -411,21 +411,21 @@ def test_dependent_features(should_include, base_features, dependent_features):
          "1904-05-03T00:00:00+0500", "1904-05-03T00:00:00-0200",
          "1904-05-03T00:00:00+0500", "2022-01-15T00:00:00+0500"],
         {'min': '1904-05-03T00:00:00+0500', 'max': '2083-08-08T01:07:26+0500',
-         'actual_min': '1904-05-03T00:00:00+0500', 'actual_max': '2022-03-26T00:00:00+0500'}
+         'observed_min': '1904-05-03T00:00:00+0500', 'observed_max': '2022-03-26T00:00:00+0500'}
     ),
     (
         ['a'],
         [datetime.datetime(1905, 1, 1), datetime.datetime(1904, 5, 3),
          datetime.datetime(2020, 1, 15), datetime.datetime(2022, 3, 26)],
         {'min': '1904-05-03T00:00:00', 'max': '2022-03-26T00:00:00',
-         'actual_min': '1904-05-03T00:00:00', 'actual_max': '2022-03-26T00:00:00'}
+         'observed_min': '1904-05-03T00:00:00', 'observed_max': '2022-03-26T00:00:00'}
     ),
     (
         None,
         [datetime.datetime(1905, 1, 1), datetime.datetime(1904, 5, 3),
          datetime.datetime(2020, 1, 15), datetime.datetime(2022, 3, 26)],
         {'min': '1856-05-25T22:52:33', 'max': '2083-08-08T01:07:26',
-         'actual_min': '1904-05-03T00:00:00', 'actual_max': '2022-03-26T00:00:00'}
+         'observed_min': '1904-05-03T00:00:00', 'observed_max': '2022-03-26T00:00:00'}
     ),
     (
         None,
@@ -434,7 +434,7 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.datetime(1904, 5, 3), datetime.datetime(1904, 5, 3),
          datetime.datetime(2020, 1, 15), datetime.datetime(2022, 3, 26)],
         {'min': '1904-05-03T00:00:00', 'max': '2083-08-08T01:07:26',
-         'actual_min': '1904-05-03T00:00:00', 'actual_max': '2022-03-26T00:00:00'}
+         'observed_min': '1904-05-03T00:00:00', 'observed_max': '2022-03-26T00:00:00'}
     ),
     (
         None,
@@ -447,7 +447,7 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.datetime(2020, 1, 15, tzinfo=pytz.FixedOffset(300)),
          datetime.datetime(2022, 3, 26, tzinfo=pytz.FixedOffset(300))],
         {'min': '1904-05-03T00:00:00+0500', 'max': '2083-08-08T01:07:26+0500',
-         'actual_min': '1904-05-03T00:00:00+0500', 'actual_max': '2022-03-26T00:00:00+0500'}
+         'observed_min': '1904-05-03T00:00:00+0500', 'observed_max': '2022-03-26T00:00:00+0500'}
     ),
     (
         None,
@@ -460,7 +460,7 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.datetime(2020, 1, 15, tzinfo=pytz.FixedOffset(300)),
          datetime.datetime(2022, 3, 26, tzinfo=pytz.FixedOffset(300))],
         {'min': '1904-05-03T00:00:00+0500', 'max': '2083-08-08T01:07:26+0500',
-         'actual_min': '1904-05-03T00:00:00+0500', 'actual_max': '2022-03-26T00:00:00+0500'}
+         'observed_min': '1904-05-03T00:00:00+0500', 'observed_max': '2022-03-26T00:00:00+0500'}
     ),
     (
         ['a'],
@@ -468,7 +468,7 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.timedelta(seconds=5), datetime.timedelta(days=1, seconds=30),
          datetime.timedelta(minutes=50), datetime.timedelta(days=5)],
         {'min': 5, 'max': 5 * 24 * 60 * 60,
-         'actual_min': 5, 'actual_max': 5 * 24 * 60 * 60,
+         'observed_min': 5, 'observed_max': 5 * 24 * 60 * 60,
          'allow_null': True, 'allow_null': True}
     ),
     (
@@ -479,7 +479,7 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.timedelta(days=5), datetime.timedelta(days=5),
          datetime.timedelta(days=5)],
         {'min': 2.718281828459045, 'max': 5 * 24 * 60 * 60,
-         'actual_min': 5, 'actual_max': 5 * 24 * 60 * 60,
+         'observed_min': 5, 'observed_max': 5 * 24 * 60 * 60,
          'allow_null': True, 'allow_null': True}
     ),
 ])

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
@@ -277,7 +277,7 @@ def test_infer_time_features(data, is_time, expected_format):
     ),
     (
         pd.DataFrame(["03:00:00.0", "12:00:01.5"], columns=['a']), None, None,
-        {'min': 0, 'max': 86400, 'observed_min': 0, 'observed_max': 86400, 'allow_null': True}, 86400
+        {'min': 0, 'max': 86400, 'observed_min': 10800.0, 'observed_max': 43201.5, 'allow_null': True}, 86400
     ),
     (
         pd.DataFrame(["25:0", "30:0"], columns=['a']), ['a'], '%M:%S',
@@ -285,11 +285,11 @@ def test_infer_time_features(data, is_time, expected_format):
     ),
     (
         pd.DataFrame(["25.0", "30.5"], columns=['a']), None, '%S.%f',
-        {'min': 0, 'max': 60, 'observed_min': 0, 'observed_max': 60, 'allow_null': True}, 60
+        {'min': 0, 'max': 60, 'observed_min': 25.0, 'observed_max': 30.5, 'allow_null': True}, 60
     ),
     (
         pd.DataFrame(["5", "7"], columns=['a']), None, '%f',
-        {'min': 0, 'max': 1, 'observed_min': 0, 'observed_max': 1, 'allow_null': True}, 1
+        {'min': 0, 'max': 1, 'observed_min': 0.5, 'observed_max': 0.7, 'allow_null': True}, 1
     ),
 ])
 def test_infer_time_feature_bounds(data, tight_bounds, provided_format, expected_bounds, cycle_length):

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
@@ -267,18 +267,30 @@ def test_infer_time_features(data, is_time, expected_format):
 
 
 @pytest.mark.parametrize('data, tight_bounds, provided_format, expected_bounds, cycle_length', [
-    (pd.DataFrame(["00:00:00", "23:59:59"], columns=['a']), ['a'], None,
-     {'min': 0, 'max': 86399, 'allow_null': True}, 86400),
-    (pd.DataFrame(["03:00:00.0", "12:00:01.5"], columns=['a']), ['a'], None,
-     {'min': 10800, 'max': 43201.5, 'allow_null': True}, 86400),
-    (pd.DataFrame(["03:00:00.0", "12:00:01.5"], columns=['a']), None, None,
-     {'min': 0, 'max': 86400, 'allow_null': True}, 86400),
-    (pd.DataFrame(["25:0", "30:0"], columns=['a']), ['a'], '%M:%S',
-     {'min': 1500, 'max': 1800, 'allow_null': True}, 3600),
-    (pd.DataFrame(["25.0", "30.5"], columns=['a']), None, '%S.%f',
-     {'min': 0, 'max': 60, 'allow_null': True}, 60),
-    (pd.DataFrame(["5", "7"], columns=['a']), None, '%f',
-     {'min': 0, 'max': 1, 'allow_null': True}, 1),
+    (
+        pd.DataFrame(["00:00:00", "23:59:59"], columns=['a']), ['a'], None,
+        {'min': 0, 'max': 86399, 'actual_min': 0, 'actual_max': 86399, 'allow_null': True}, 86400
+    ),
+    (
+        pd.DataFrame(["03:00:00.0", "12:00:01.5"], columns=['a']), ['a'], None,
+        {'min': 10800, 'max': 43201.5, 'actual_min': 10800, 'actual_max': 43201.5, 'allow_null': True}, 86400
+    ),
+    (
+        pd.DataFrame(["03:00:00.0", "12:00:01.5"], columns=['a']), None, None,
+        {'min': 0, 'max': 86400, 'actual_min': 0, 'actual_max': 86400, 'allow_null': True}, 86400
+    ),
+    (
+        pd.DataFrame(["25:0", "30:0"], columns=['a']), ['a'], '%M:%S',
+        {'min': 1500, 'max': 1800, 'actual_min': 1500, 'actual_max': 1800, 'allow_null': True}, 3600
+    ),
+    (
+        pd.DataFrame(["25.0", "30.5"], columns=['a']), None, '%S.%f',
+        {'min': 0, 'max': 60, 'actual_min': 0, 'actual_max': 60, 'allow_null': True}, 60
+    ),
+    (
+        pd.DataFrame(["5", "7"], columns=['a']), None, '%f',
+        {'min': 0, 'max': 1, 'actual_min': 0, 'actual_max': 1, 'allow_null': True}, 1
+    ),
 ])
 def test_infer_time_feature_bounds(data, tight_bounds, provided_format, expected_bounds, cycle_length):
     """Test that IFA correctly calculates the bounds and cycle length of time-only features."""
@@ -360,37 +372,37 @@ def test_dependent_features(should_include, base_features, dependent_features):
 
 
 @pytest.mark.parametrize('tight_bounds, data, expected_bounds', [
-    (None, [2, 3, 4, 5, 6, 7], {'min': 1, 'max': 7, 'allow_null': False}),
-    (None, [2, 3, 4, 4, 5, 6, 6, 6, 6], {'min': 1, 'max': 6, 'allow_null': False}),
-    (None, [2, 3, 4, 4, 4, 4, 6, 6, 6, 6], {'min': 1, 'max': 6, 'allow_null': False}),
-    (None, [2, 2, 2, 2, 4, 5, 6, 6, 6, 6], {'min': 2, 'max': 6, 'allow_null': False}),
-    (None, [2, 2, 2, 2, 4, 5, 6, 6, 6, 6, 6], {'min': 1, 'max': 6, 'allow_null': False}),
-    (None, [2, 2, 2, 2, 4, 5, 6, 7], {'min': 2, 'max': 7, 'allow_null': False}),
+    (None, [2, 3, 4, 5, 6, 7], {'min': 1, 'max': 7, 'actual_min': 2, 'actual_max': 7, 'allow_null': False}),
+    (None, [2, 3, 4, 4, 5, 6, 6, 6, 6], {'min': 1, 'max': 6, 'actual_min': 2, 'actual_max': 6, 'allow_null': False}),
+    (None, [2, 3, 4, 4, 4, 4, 6, 6, 6, 6], {'min': 1, 'max': 6, 'actual_min': 2, 'actual_max': 6, 'allow_null': False}),  # noqa: E501
+    (None, [2, 2, 2, 2, 4, 5, 6, 6, 6, 6], {'min': 2, 'max': 6, 'actual_min': 2, 'actual_max': 6, 'allow_null': False}),  # noqa: E501
+    (None, [2, 2, 2, 2, 4, 5, 6, 6, 6, 6, 6], {'min': 1, 'max': 6, 'actual_min': 2, 'actual_max': 6, 'allow_null': False}),  # noqa: E501
+    (None, [2, 2, 2, 2, 4, 5, 6, 7], {'min': 2, 'max': 7, 'actual_min': 2, 'actual_max': 7, 'allow_null': False}),
     (None, [float('nan'), float('nan')], {'allow_null': True}),
-    (['a'], [2, 3, 4, 5, 6, 7], {'min': 2, 'max': 7, 'allow_null': False}),
-    (['a'], [2, 3, 4, None, 6, 7], {'min': 2, 'max': 7, 'allow_null': True}),
+    (['a'], [2, 3, 4, 5, 6, 7], {'min': 2, 'max': 7, 'actual_min': 2, 'actual_max': 7, 'allow_null': False}),
+    (['a'], [2, 3, 4, None, 6, 7], {'min': 2, 'max': 7, 'actual_min': 2, 'actual_max': 7, 'allow_null': True}),
     (
         ['a'],
         ['1905-01-01', '1904-05-03', '2020-01-15', '2000-04-26', '2000-04-24'],
-        {'min': '1904-05-03', 'max': '2020-01-15'}
+        {'min': '1904-05-03', 'max': '2020-01-15', 'actual_min': '1904-05-03', 'actual_max': '2020-01-15'}
     ),
     (
         None,
         ['1905-01-01', '1904-05-03', '2020-01-15', '2000-04-26', '2000-04-24'],
-        {'min': '1856-05-25', 'max': '2083-08-08'}
+        {'min': '1856-05-25', 'max': '2083-08-08', 'actual_min': '1904-05-03', 'actual_max': '2020-01-15'}
     ),
     (
         None,
         ['1905-01-01', '1904-05-03', '2020-01-15', '2020-01-15', '2020-01-15',
          '2020-01-15', '2000-04-26', '2000-04-24'],
-        {'min': '1856-05-25', 'max': '2020-01-15'}
+        {'min': '1856-05-25', 'max': '2020-01-15', 'actual_min': '1904-05-03', 'actual_max': '2020-01-15'}
     ),
     (
         None,
         ['1905-01-01', '1904-05-03', '1904-05-03', '1904-05-03', '1904-05-03',
          '2020-01-15', '2020-01-15', '2020-01-15', '2020-01-15', '2000-04-26',
          '2000-04-24'],
-        {'min': '1904-05-03', 'max': '2020-01-15'}
+        {'min': '1904-05-03', 'max': '2020-01-15', 'actual_min': '1904-05-03', 'actual_max': '2020-01-15'}
     ),
     (
         None,
@@ -398,19 +410,22 @@ def test_dependent_features(should_include, base_features, dependent_features):
          "1904-05-03T00:00:00+0500", "1904-05-03T00:00:00+0500",
          "1904-05-03T00:00:00+0500", "1904-05-03T00:00:00-0200",
          "1904-05-03T00:00:00+0500", "2022-01-15T00:00:00+0500"],
-        {'min': '1904-05-03T00:00:00+0500', 'max': '2083-08-08T01:07:26+0500'}
+        {'min': '1904-05-03T00:00:00+0500', 'max': '2083-08-08T01:07:26+0500',
+         'actual_min': '1904-05-03T00:00:00+0500', 'actual_max': '2022-03-26T00:00:00+0500'}
     ),
     (
         ['a'],
         [datetime.datetime(1905, 1, 1), datetime.datetime(1904, 5, 3),
          datetime.datetime(2020, 1, 15), datetime.datetime(2022, 3, 26)],
-        {'min': '1904-05-03T00:00:00', 'max': '2022-03-26T00:00:00'}
+        {'min': '1904-05-03T00:00:00', 'max': '2022-03-26T00:00:00',
+         'actual_min': '1904-05-03T00:00:00', 'actual_max': '2022-03-26T00:00:00'}
     ),
     (
         None,
         [datetime.datetime(1905, 1, 1), datetime.datetime(1904, 5, 3),
          datetime.datetime(2020, 1, 15), datetime.datetime(2022, 3, 26)],
-        {'min': '1856-05-25T22:52:33', 'max': '2083-08-08T01:07:26'}
+        {'min': '1856-05-25T22:52:33', 'max': '2083-08-08T01:07:26',
+         'actual_min': '1904-05-03T00:00:00', 'actual_max': '2022-03-26T00:00:00'}
     ),
     (
         None,
@@ -418,7 +433,8 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.datetime(1904, 5, 3), datetime.datetime(1904, 5, 3),
          datetime.datetime(1904, 5, 3), datetime.datetime(1904, 5, 3),
          datetime.datetime(2020, 1, 15), datetime.datetime(2022, 3, 26)],
-        {'min': '1904-05-03T00:00:00', 'max': '2083-08-08T01:07:26'}
+        {'min': '1904-05-03T00:00:00', 'max': '2083-08-08T01:07:26',
+         'actual_min': '1904-05-03T00:00:00', 'actual_max': '2022-03-26T00:00:00'}
     ),
     (
         None,
@@ -430,7 +446,8 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.datetime(1904, 5, 3, tzinfo=pytz.FixedOffset(300)),
          datetime.datetime(2020, 1, 15, tzinfo=pytz.FixedOffset(300)),
          datetime.datetime(2022, 3, 26, tzinfo=pytz.FixedOffset(300))],
-        {'min': '1904-05-03T00:00:00+0500', 'max': '2083-08-08T01:07:26+0500'}
+        {'min': '1904-05-03T00:00:00+0500', 'max': '2083-08-08T01:07:26+0500',
+         'actual_min': '1904-05-03T00:00:00+0500', 'actual_max': '2022-03-26T00:00:00+0500'}
     ),
     (
         None,
@@ -442,14 +459,17 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.datetime(1904, 5, 3, tzinfo=pytz.FixedOffset(300)),
          datetime.datetime(2020, 1, 15, tzinfo=pytz.FixedOffset(300)),
          datetime.datetime(2022, 3, 26, tzinfo=pytz.FixedOffset(300))],
-        {'min': '1904-05-03T00:00:00+0500', 'max': '2083-08-08T01:07:26+0500'}
+        {'min': '1904-05-03T00:00:00+0500', 'max': '2083-08-08T01:07:26+0500',
+         'actual_min': '1904-05-03T00:00:00+0500', 'actual_max': '2022-03-26T00:00:00+0500'}
     ),
     (
         ['a'],
         [datetime.timedelta(days=1), datetime.timedelta(days=1),
          datetime.timedelta(seconds=5), datetime.timedelta(days=1, seconds=30),
          datetime.timedelta(minutes=50), datetime.timedelta(days=5)],
-        {'min': 5, 'max': 5 * 24 * 60 * 60, 'allow_null': True}
+        {'min': 5, 'max': 5 * 24 * 60 * 60,
+         'actual_min': 5, 'actual_max': 5 * 24 * 60 * 60,
+         'allow_null': True, 'allow_null': True}
     ),
     (
         None,
@@ -458,7 +478,9 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.timedelta(minutes=50), datetime.timedelta(days=5),
          datetime.timedelta(days=5), datetime.timedelta(days=5),
          datetime.timedelta(days=5)],
-        {'min': 2.718281828459045, 'max': 5 * 24 * 60 * 60, 'allow_null': True}
+        {'min': 2.718281828459045, 'max': 5 * 24 * 60 * 60,
+         'actual_min': 5, 'actual_max': 5 * 24 * 60 * 60,
+         'allow_null': True, 'allow_null': True}
     ),
 ])
 def test_infer_feature_bounds(data, tight_bounds, expected_bounds):

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "howso-engine": "94.0.0"
+    "howso-engine": "94.1.0"
   }
 }


### PR DESCRIPTION
- Adds `observed_min` to record the actual smallest value in each continuous feature.
- Adds `observed_max` to record the actual largest value in each continuous feature.
- Adds support for `observed_min/max` for ordinals as wel.
- Updates tests accordingly.

Depends on: https://github.com/howsoai/howso-engine/pull/415 ✅ 