### PR TITLE
22631: Updates get_cases documentation

### DIFF
--- a/howso/client/tests/test_client.py
+++ b/howso/client/tests/test_client.py
@@ -1086,20 +1086,6 @@ class TestBaseClient:
                     "`contexts` does not match the number of features in "
                     "`context_features`.") in str(exc.value)
 
-    def test_get_cases_warning(self, trainee, capsys):
-        """
-        Test that get_cases issues warning when expected.
-
-        Test for expected warning when get_cases is called without passing in
-        a session id.
-        """
-        expected_message = ('Calling get_cases without a session id does '
-                            'not guarantee case order.')
-        with pytest.warns(Warning, match=expected_message):
-            self.client.get_cases(trainee.id)
-            out, _ = capsys.readouterr()
-            assert 'Retrieving cases for Trainee' in out
-
     def test_react_group(self, trainee, capsys):
         """
         Test that react_group works as expected.

--- a/howso/engine/tests/test_engine.py
+++ b/howso/engine/tests/test_engine.py
@@ -103,8 +103,8 @@ class TestEngine:
         Test that get_cases works as expected.
 
         Test that get_cases works with and without a session ID to
-        get the cases in the order they were trained. This functionality
-        only works in a single-user environment and assumes a single session.
+        get the cases. This functionality only works in a single-user environment
+        and assumes a single session.
         """
         c1 = trainee.get_cases()
 
@@ -367,7 +367,6 @@ class TestEngine:
 
         assert_frame_equal(matrix, saved_matrix)
 
-    @pytest.mark.filterwarnings("ignore:Calling get_cases*")
     def test_reduce_data(self, trainee):
         """Test `reduce_data`."""
         pre_reduction_cases = trainee.get_cases()

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -2369,6 +2369,13 @@ class Trainee(BaseTrainee):
         """
         Get the trainee's cases.
 
+        .. NOTE::
+            The order of the cases returned by this method is not guaranteed to
+            be the same as the order they were trained. However, the ".session"
+            and ".session_training_index" features may be requested, which will
+            provide the session id and the numeric index (or order) within that
+            session the cases were trained (respectively).
+
         Parameters
         ----------
         case_indices : Sequence of (str, int), optional
@@ -2399,11 +2406,6 @@ class Trainee(BaseTrainee):
         session : str or Session, optional
             The id or instance of the session to retrieve training indices for
             from the model.
-
-            .. NOTE::
-                If a session is not provided, the order of the cases is not
-                guaranteed to be the same as the order they were trained into
-                the model.
 
         condition : dict, optional
             The condition map to select the cases to retrieve that meet all the
@@ -2459,6 +2461,15 @@ class Trainee(BaseTrainee):
         -------
         DataFrame
             The trainee's cases.
+
+        Examples
+        --------
+        >>> # Get sorted cases by session
+        >>> cases = trainee.get_cases(
+        >>>     features=[".session", ".session_training_index", "a", "b"]
+        >>> )
+        >>> cases = cases.sort_values(by=[".session", ".session_training_index"])
+        >>> cases = cases.reset_index(drop=True)
         """
         if isinstance(session, BaseSession):
             session_id = session.id

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "howso-engine": "94.0.0"
+    "howso-engine": "95.0.0"
   }
 }


### PR DESCRIPTION
Due to ablation, get_cases may not return cases in the original training order. Added documentation on how to sort cases if needed.