### PR TITLE
22790: Updates Linux/ARM runner to use GitHub instead of emulator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,7 +262,7 @@ jobs:
   install-verification-linux-arm64:
     if: inputs.build-type != 'PR'
     needs: ['metadata', 'build']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
 
     - name: Download Artifact
@@ -282,35 +282,31 @@ jobs:
         cd tmp && if [ ! -f *.whl ]; then mv */*.whl ./; fi
 
     - name: Verify Howso install
-      uses: pguyot/arm-runner-action@v2
-      with:
-        base_image: raspios_lite_arm64:latest
-        cpu: cortex-a8
-        image_additional_mb: 1000
-        commands: |
-          set -e
+      run: |
+        set -e
 
-          # Install python:
-          sudo apt-get install --no-install-recommends -y python3 python3-pip python-is-python3
-          python --version
+        # Install python:
+        sudo apt-get install --no-install-recommends -y python3 python3-pip python-is-python3
+        python --version
 
-          # Overwrite pip.conf so pypi is used, not piwheels
-          sudo echo "" > /etc/pip.conf
+        # Overwrite pip.conf so pypi is used, not piwheels
+        sudo echo "" > /etc/pip.conf
 
-          echo "Installing Howso Engine..."
-          # This environment is considered "externally managed," so use --break-system-packages to bypass
-          # (safe in this use case)
-          pip install howso_engine-*-py3-none-any.whl --break-system-packages
-          if [ -d "tmp" ]; then
-            echo "Found custom amalgam-lang version; installing..."
-            pip uninstall amalgam-lang -y --break-system-packages
-            pip install tmp/*.whl --break-system-packages
-          fi
+        echo "Installing Howso Engine..."
+        # This environment is considered "externally managed," so use --break-system-packages to bypass
+        # (safe in this use case)
+        pip install howso_engine-*-py3-none-any.whl --break-system-packages
+        if [ -d "tmp" ]; then
+          echo "Found custom amalgam-lang version; installing..."
+          pip uninstall amalgam-lang -y --break-system-packages
+          pip install tmp/*.whl --break-system-packages
+        fi
 
-          # amalgam binaries need this under QEMU
-          PATH=$PATH:/usr/aarch64-linux-gnu
+        # amalgam binaries need this under QEMU
+        PATH=$PATH:/usr/aarch64-linux-gnu
 
-          echo "Running Howso verification..."
+        echo "Running Howso verification..."
+        verify_howso_install
 
     - name: Display stacktrace files
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,9 +299,6 @@ jobs:
           pip install tmp/*.whl --break-system-packages
         fi
 
-        # amalgam binaries need this under QEMU
-        PATH=$PATH:/usr/aarch64-linux-gnu
-
         echo "Running Howso verification..."
         verify_howso_install
 
@@ -313,7 +310,7 @@ jobs:
   install-verification-linux-arm64_8a:
     if: inputs.build-type != 'PR'
     needs: ['metadata', 'build']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
 
     - name: Download Artifact
@@ -333,47 +330,36 @@ jobs:
         cd tmp && if [ ! -f *.whl ]; then mv */*.whl ./; fi
 
     - name: Verify Howso install
-      uses: pguyot/arm-runner-action@v2
-      with:
-        base_image: raspios_lite_arm64:latest
-        cpu: cortex-a7
-        image_additional_mb: 1000
-        commands: |
-          set -e
+      run: |
+        set -e
 
-          # Install python:
-          sudo apt-get install --no-install-recommends -y python3 python3-pip python-is-python3
-          python --version
+        # Install python:
+        sudo apt-get install --no-install-recommends -y python3 python3-pip python-is-python3
+        python --version
 
-          # Overwrite pip.conf so pypi is used, not piwheels
-          sudo echo "" > /etc/pip.conf
+        echo "Installing Howso Engine..."
+        # This environment is considered "externally managed," so use --break-system-packages to bypass
+        # (safe in this use case)
+        pip install howso_engine-*-py3-none-any.whl --break-system-packages
+        if [ -d "tmp" ]; then
+          echo "Found custom amalgam-lang version; installing..."
+          pip uninstall amalgam-lang -y --break-system-packages
+          pip install tmp/*.whl --break-system-packages
+        fi
 
-          echo "Installing Howso Engine..."
-          # This environment is considered "externally managed," so use --break-system-packages to bypass
-          # (safe in this use case)
-          pip install howso_engine-*-py3-none-any.whl --break-system-packages
-          if [ -d "tmp" ]; then
-            echo "Found custom amalgam-lang version; installing..."
-            pip uninstall amalgam-lang -y --break-system-packages
-            pip install tmp/*.whl --break-system-packages
-          fi
+        # Set local config to use single threaded because arm64_8a doesn't support multi-threading and set
+        # arm64_8a arch since that is not auto selected by the package currently:
+        echo "
+        howso:
+          client: howso.direct.HowsoDirectClient
+          client_extra_params:
+            amalgam:
+              arch: arm64_8a
+              library_postfix: -st
+        " > howso.yml
 
-          # Set local config to use single threaded because arm64_8a doesn't support multi-threading and set
-          # arm64_8a arch since that is not auto selected by the package currently:
-          echo "
-          howso:
-            client: howso.direct.HowsoDirectClient
-            client_extra_params:
-              amalgam:
-                arch: arm64_8a
-                library_postfix: -st
-          " > howso.yml
-
-          # amalgam binaries need this under QEMU
-          PATH=$PATH:/usr/aarch64-linux-gnu
-
-          echo "Running Howso verification..."
-          verify_howso_install
+        echo "Running Howso verification..."
+        verify_howso_install
 
     - name: Display stacktrace files
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,9 +289,6 @@ jobs:
         sudo apt-get install --no-install-recommends -y python3 python3-pip python-is-python3
         python --version
 
-        # Overwrite pip.conf so pypi is used, not piwheels
-        sudo echo "" > /etc/pip.conf
-
         echo "Installing Howso Engine..."
         # This environment is considered "externally managed," so use --break-system-packages to bypass
         # (safe in this use case)


### PR DESCRIPTION
This will improve the reliability of the workflow.