### PR TITLE
23487: Adjusts devcontainers release step to continue on error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -710,3 +710,4 @@ jobs:
       check-cache: false
       workflow-name: build.yml
       payload: '{"howso-engine-version": "${{ needs.metadata.outputs.version }}", "build-type": "release"}'
+      continue-on-error: true


### PR DESCRIPTION
When `howso-engine-py` is released, the last step of the workflow is to initialize a "devcontainers" rebuild in `howso-engine-recipes`. Sometimes, however, this step fails because it tries to access the newly released `howso-engine-py` version before it is fully available on PyPi. We added a delay to mitigate this issue but it still happens occasionally. While this doesn't affect the release of `howso-engine-py` at all, it freaks people out. This PR will prevent the release workflow from appearing red when this happens.