### PR TITLE
23545: Skips UTs with connectors repo if it is not installed

### DIFF
--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes_adc.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes_adc.py
@@ -11,8 +11,8 @@ import pytest
 
 try:
     from howso.connectors.abstract_data import MongoDBData
-except ModuleNotFoundError:
-    pytest.skip("howso-engine-connectors not installed")
+except (ModuleNotFoundError, ImportError):
+    pytest.skip("howso-engine-connectors not installed", allow_module_level=True)
 from howso.utilities.feature_attributes import infer_feature_attributes
 from howso.utilities.feature_attributes.abstract_data import InferFeatureAttributesAbstractData
 from howso.utilities.features import FeatureType

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes_adc.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes_adc.py
@@ -9,7 +9,10 @@ import mongomock
 import pandas as pd
 import pytest
 
-from howso.connectors.abstract_data import MongoDBData
+try:
+    from howso.connectors.abstract_data import MongoDBData
+except ModuleNotFoundError:
+    pytest.skip("howso-engine-connectors not installed")
 from howso.utilities.feature_attributes import infer_feature_attributes
 from howso.utilities.feature_attributes.abstract_data import InferFeatureAttributesAbstractData
 from howso.utilities.features import FeatureType


### PR DESCRIPTION
This will allow non-enterprise users to run the entire test suite without error.