### PR TITLE
23636: Sets minimum batch size to number of cores on HowsoDirectClient

### DIFF
--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -159,6 +159,12 @@ class HowsoDirectClient(AbstractHowsoClient):
         # Show deprecation warnings to the user.
         warnings.filterwarnings("default", category=DeprecationWarning)
 
+        # Set minimum batch size to match available CPUs. NOTE: If necessary
+        # the value returned by os.cpu_count() can be overridden with
+        # `-X cpu_count` when starting Python or with the environment
+        # variable PYTHON_CPU_COUNT as per the Python documentation.
+        self.batch_scaler_class.size_limits = (os.cpu_count() or 1, None)
+
         # Load configuration
         config_path = get_configuration_path(config_path, verbose)
         self.configuration = HowsoConfiguration(config_path, verbose=verbose)


### PR DESCRIPTION
Sets the minimum batch size to at least the number of available CPU cores on the host machine for the HowsoDirectClient.