### PR TITLE
23666: Removes pre-save error on Trainee create, replaced with warning

### DIFF
--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -853,7 +853,7 @@ class HowsoDirectClient(AbstractHowsoClient):
                 success, reason = self.check_name_valid_for_save(
                     proposed_path, clobber=overwrite_trainee)
             if not success:
-                raise HowsoError(
+                warnings.warn(
                     f'Trainee file name "{proposed_path}" is not valid for '
                     f'saving (reason: {reason}).')
 


### PR DESCRIPTION
Fixes #409

While we want to leave the check in place to determine whether the Trainee can be saved at the default persist path or CWD, some use cases may dictate the Trainee need not be saved to the file system. Thus, upon creating the Trainee, we should only raise a warning and save the error until the Trainee is intentionally saved.