### PR TITLE
23683: Adds `similarity_conviction` to `react_group`, MINOR

### DIFF
--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -4022,6 +4022,7 @@ class AbstractHowsoClient(ABC):
         new_cases: t.Optional[TabularData3D] = None,
         p_value_of_addition: bool = False,
         p_value_of_removal: bool = False,
+        similarity_conviction: bool = False,
         weight_feature: t.Optional[str] = None,
         use_case_weights: t.Optional[bool] = None,
     ) -> dict:
@@ -4091,6 +4092,9 @@ class AbstractHowsoClient(ABC):
             If true will output p value of addition.
         p_value_of_removal : bool, default False
             If true will output p value of removal.
+        similarity_conviction : bool, default False
+            If true will output the mean similarity conviction of the group's
+            cases.
         weight_feature : str, optional
             Name of feature whose values to use as case weights.
             When left unspecified uses the internally managed case weight.
@@ -4137,6 +4141,7 @@ class AbstractHowsoClient(ABC):
             "kl_divergence_removal": kl_divergence_removal,
             "p_value_of_addition": p_value_of_addition,
             "p_value_of_removal": p_value_of_removal,
+            "similarity_conviction": similarity_conviction,
             "weight_feature": weight_feature,
             "use_case_weights": use_case_weights,
         })

--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -3581,7 +3581,7 @@ class AbstractHowsoClient(ABC):
         details: t.Optional[dict] = None,
         features_to_derive: t.Optional[Collection[str]] = None,
         feature_influences_action_feature: t.Optional[str] = None,
-        forecast_window_length: t.Optional[int] = None,
+        forecast_window_length: t.Optional[float] = None,
         goal_dependent_features: t.Optional[Collection[str]] = None,
         goal_features_map: t.Optional[Mapping] = None,
         hyperparameter_param_path: t.Optional[Collection[str]] = None,

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -2898,6 +2898,7 @@ class Trainee(BaseTrainee):
         new_cases: t.Optional[TabularData3D] = None,
         p_value_of_addition: bool = False,
         p_value_of_removal: bool = False,
+        similarity_conviction: bool = False,
         use_case_weights: t.Optional[bool] = None,
         features: t.Optional[Collection[str]] = None,
         weight_feature: t.Optional[str] = None,
@@ -2970,6 +2971,9 @@ class Trainee(BaseTrainee):
             If true will output :math:`p` value of addition.
         p_value_of_removal : bool, default False
             If true will output :math:`p` value of removal.
+        similarity_conviction : bool, default False
+            If true will output the mean similarity conviction of the group's
+            cases.
         use_case_weights : bool, optional
             When True, will scale influence weights by each case's
             ``weight_feature`` weight. If unspecified, case weights will
@@ -2996,6 +3000,7 @@ class Trainee(BaseTrainee):
                 kl_divergence_removal=kl_divergence_removal,
                 p_value_of_addition=p_value_of_addition,
                 p_value_of_removal=p_value_of_removal,
+                similarity_conviction=similarity_conviction,
                 distance_contributions=distance_contributions,
                 use_case_weights=use_case_weights,
                 weight_feature=weight_feature,

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -3212,7 +3212,7 @@ class Trainee(BaseTrainee):
         details: t.Optional[dict] = None,
         features_to_derive: t.Optional[Collection[str]] = None,
         feature_influences_action_feature: t.Optional[str] = None,
-        forecast_window_length: t.Optional[int] = None,
+        forecast_window_length: t.Optional[float] = None,
         goal_dependent_features: t.Optional[Collection[str]] = None,
         goal_features_map: t.Optional[Mapping] = None,
         hyperparameter_param_path: t.Optional[Collection[str]] = None,

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "howso-engine": "99.3.0"
+    "howso-engine": "99.5.0"
   }
 }


### PR DESCRIPTION
Adds a parameter to react group that allows users to compute the mean similarity conviction of the group of cases of interest.