### PR TITLE
23934: Improves handling of time-only Timestamp features in IFA

### DIFF
--- a/howso/client/tests/test_infer_feature_attributes.py
+++ b/howso/client/tests/test_infer_feature_attributes.py
@@ -70,12 +70,12 @@ class TestInferFeatureAttributes:
     def test_datetime_warns_custom_format(self):
         """Test that infer_feature_attributes infers dates correctly."""
         df = pd.DataFrame(data=np.asarray([
-            ['10.10.2020', '12.12.2020', '11.11.1920']
+            ['10.10.2020 4:30', '12.12.2020 1:00', '11.11.1920 3:15']
         ]).transpose(), columns=['datetime'])
         # convert column to contain datetime objects instead of strings
         df['datetime'] = pd.to_datetime(df['datetime'])
 
-        custom_format = {'datetime': ('%m.%d.%Y', 'en_US')}
+        custom_format = {'datetime': ('%m.%d.%Y %h:%m', 'en_US')}
 
         expected_warning = (
             'Providing a datetime feature format for the feature "datetime" '

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -188,8 +188,8 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                     return FeatureType.DATE, {}
                 first_non_null = self._get_first_non_null(feature_name)
                 if isinstance(first_non_null, pd.Timestamp):
-                    # Date-only Timestamp objects in Pandas will have a default time of midnight 
-                    if first_non_null.time() == datetime.time(0, 0, 0):
+                    # Date-only Timestamp objects in Pandas will have a default time of midnight
+                    if first_non_null.time() == datetime.time(0, 0, 0) and (not hasattr(dtype, 'tz') or not dtype.tz):
                         return FeatureType.DATE, {}
                 # Datetime feature (with timezone info)
                 if isinstance(dtype, pd.DatetimeTZDtype):

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -183,13 +183,21 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
 
             elif is_datetime64_any_dtype(dtype):
                 typing_info = {}
+                # Check for date-only features
                 if dtype in ['datetime64[Y]', 'datetime64[M]', 'datetime64[D]']:
                     return FeatureType.DATE, {}
-                elif isinstance(dtype, pd.DatetimeTZDtype):
+                first_non_null = self._get_first_non_null(feature_name)
+                if isinstance(first_non_null, pd.Timestamp):
+                    # Date-only Timestamp objects in Pandas will have a default time of midnight 
+                    if first_non_null.time() == datetime.time(0, 0, 0):
+                        return FeatureType.DATE, {}
+                # Datetime feature (with timezone info)
+                if isinstance(dtype, pd.DatetimeTZDtype):
                     if isinstance(dtype.tz, pytz.BaseTzInfo) and dtype.tz.zone:
                         # If using a named time zone capture it, otherwise
                         # rely on the offset in the iso8601 format
                         typing_info['timezone'] = dtype.tz.zone
+                # Datetime feature with no timezone info
                 return FeatureType.DATETIME, typing_info
 
             elif is_timedelta64_dtype(dtype):

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
@@ -426,15 +426,15 @@ def test_dependent_features(should_include, base_features, dependent_features):
         ['a'],
         [datetime.datetime(1905, 1, 1), datetime.datetime(1904, 5, 3),
          datetime.datetime(2020, 1, 15), datetime.datetime(2022, 3, 26)],
-        {'min': '1904-05-03T00:00:00', 'max': '2022-03-26T00:00:00',
-         'observed_min': '1904-05-03T00:00:00', 'observed_max': '2022-03-26T00:00:00'}
+        {'min': '1904-05-03', 'max': '2022-03-26',
+         'observed_min': '1904-05-03', 'observed_max': '2022-03-26'}
     ),
     (
         None,
         [datetime.datetime(1905, 1, 1), datetime.datetime(1904, 5, 3),
          datetime.datetime(2020, 1, 15), datetime.datetime(2022, 3, 26)],
-        {'min': '1827-11-08T09:55:14', 'max': '2098-09-17T14:04:45',
-         'observed_min': '1904-05-03T00:00:00', 'observed_max': '2022-03-26T00:00:00'}
+        {'min': '1827-11-08', 'max': '2098-09-17',
+         'observed_min': '1904-05-03', 'observed_max': '2022-03-26'}
     ),
     (
         None,
@@ -442,8 +442,8 @@ def test_dependent_features(should_include, base_features, dependent_features):
          datetime.datetime(1904, 5, 3), datetime.datetime(1904, 5, 3),
          datetime.datetime(1904, 5, 3), datetime.datetime(1904, 5, 3),
          datetime.datetime(2020, 1, 15), datetime.datetime(2022, 3, 26)],
-        {'min': '1904-05-03T00:00:00', 'max': '2098-09-17T14:04:45',
-         'observed_min': '1904-05-03T00:00:00', 'observed_max': '2022-03-26T00:00:00'}
+        {'min': '1904-05-03', 'max': '2098-09-17',
+         'observed_min': '1904-05-03', 'observed_max': '2022-03-26'}
     ),
     (
         None,

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
@@ -196,8 +196,6 @@ def test_integer_nominality(feature, nominality):
     # Datetime
     (pd.DataFrame([["2020-01-01T10:00:00"]], dtype='datetime64[ns]', columns=['a']),
      {'data_type': str(FeatureType.DATETIME)}),
-    (pd.DataFrame([["2020-01-01"]], dtype='datetime64[ns]', columns=['a']),
-     {'data_type': str(FeatureType.DATETIME)}),
     (pd.DataFrame([[datetime.datetime.now()]], columns=['a']),
      {'data_type': str(FeatureType.DATETIME)}),
     (pd.DataFrame([[datetime.datetime.now(pytz.timezone('US/Eastern'))]], columns=['a']),
@@ -206,6 +204,10 @@ def test_integer_nominality(feature, nominality):
      {'data_type': str(FeatureType.DATETIME)}),
     # Date
     (pd.DataFrame([[datetime.date(2020, 1, 1)]], columns=['a']),
+     {'data_type': str(FeatureType.DATE)}),
+    (pd.DataFrame([[pd.Timestamp(datetime.date(2020, 1, 1))]], columns=['a']),
+     {'data_type': str(FeatureType.DATE)}),
+    (pd.DataFrame([["2020-01-01"]], dtype='datetime64[ns]', columns=['a']),
      {'data_type': str(FeatureType.DATE)}),
     # Timedelta
     (pd.DataFrame([[datetime.timedelta(days=1)]], columns=['a']),

--- a/howso/utilities/tests/test_features.py
+++ b/howso/utilities/tests/test_features.py
@@ -30,7 +30,7 @@ from . import has_locales
     ([datetime.datetime(2020, 10, 10, 10, 5, tzinfo=pytz.FixedOffset(-300))],
      {'data_type': str(FeatureType.DATETIME)}, True),
     ([datetime.datetime.fromisoformat("2022-01-01")],
-     {'data_type': str(FeatureType.DATETIME)}, False),
+     {'data_type': str(FeatureType.DATE)}, False),
     ([datetime.datetime.fromisoformat("2022-01-01T10:00:00-05:00")],
      {'data_type': str(FeatureType.DATETIME)}, False),
     ([datetime.datetime(2022, 1, 1, 10, 0, 0, tzinfo=pytz.timezone("GMT"))],


### PR DESCRIPTION
Adds additional logic to `infer_feature_attributes` that checks whether a feature that is an instance of a Pandas `Timestamp` object has a time of 0:00:00, which indicates it is a date-only feature. In this case, our inferred datetime feature format should not include time information.