### PR TITLE
24265: Adds `get_value_masses` to Trainee and base client, MINOR

### DIFF
--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -772,9 +772,9 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -883,9 +883,9 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -1019,9 +1019,9 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -1407,9 +1407,9 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -1461,10 +1461,10 @@ class AbstractHowsoClient(ABC):
         features: Collection[str],
         *,
         condition: t.Optional[Mapping] = None,
-        minimum_mass_threshold: int = 0,
+        minimum_mass_threshold: float = 0.0,
         precision: t.Optional[Precision] = "exact",
         weight_feature: t.Optional[str] = None
-    ):
+    ) -> dict[str, dict[str, list[list] | float]]:
         """
         Get the unique values and their respective masses for each specified feature.
 
@@ -1483,15 +1483,15 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
-        minimum_mass_threshold : int, default 0
+        minimum_mass_threshold : float, default 0.0
             The minimum mass a feature value must possess to be returned in the
-            collection of value masses. If the given value is greater than one,
+            collection of value masses. If the given value is greater than zero,
             the sum of the omitted feature value masses is returned under a
             "remaining" key for each feature.
         precision : str, default "exact"
@@ -1642,9 +1642,9 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -2827,9 +2827,9 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -3358,9 +3358,9 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -4214,9 +4214,9 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -5043,9 +5043,9 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -5301,9 +5301,9 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -5389,9 +5389,9 @@ class AbstractHowsoClient(ABC):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.

--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -1455,6 +1455,88 @@ class AbstractHowsoClient(ABC):
             return dict()
         return stats
 
+    def get_value_masses(
+        self,
+        trainee_id: str,
+        features: Collection[str],
+        *,
+        condition: t.Optional[Mapping] = None,
+        minimum_mass_threshold: int = 0,
+        precision: t.Optional[Precision] = "exact",
+        weight_feature: t.Optional[str] = None
+    ):
+        """
+        Get the unique values and their respective masses for each specified feature.
+
+        Parameters
+        ----------
+        trainee_id : str
+            The ID of the Trainee to retrieve value masses for.
+        features : Collection[str]
+            The feature names for which to compute unique value masses.
+        condition : Mapping or None, optional
+            A condition map to select which cases to compute value masses
+            for.
+
+            .. NOTE::
+                The dictionary keys are feature names and values are one of:
+
+                    - None
+                    - A value, must match exactly.
+                    - An array of two numeric values, specifying an inclusive
+                      range. Only applicable to continuous and numeric ordinal
+                      features.
+                    - An array of string values, must match any of these values
+                      exactly. Only applicable to nominal and string ordinal
+                      features.
+        minimum_mass_threshold : int, default 0
+            The minimum mass a feature value must possess to be returned in the
+            collection of value masses. If the given value is greater than one,
+            the sum of the omitted feature value masses is returned under a
+            "remaining" key for each feature.
+        precision : str, default "exact"
+            The precision to use when selecting cases with ``condition``.
+            Options are 'exact' or 'similar'. Only used if `condition` is not
+            None.
+        weight_feature : str, optional
+            When specified, will return masses based on weights stored
+            in this weight_feature.
+
+        Returns
+        -------
+        dict[str, dict[str, list[list] | float]]
+            A map of each feature name to a dict containing "values" and "remaining"
+            keys. "values" maps to a list of lists where each sublist contains
+            the feature value and its mass. When ``minimum_mass_threshold`` is
+            greater than one, "remaining" maps to a single value that is the sum
+            of all omitted feature value masses.
+        """
+        trainee_id = self._resolve_trainee(trainee_id).id
+
+        if precision is not None and precision not in self.SUPPORTED_PRECISION_VALUES:
+            warnings.warn(self.WARNING_MESSAGES['invalid_precision'].format("precision"))
+
+        # Convert session instance to id
+        if (
+            isinstance(condition, MutableMapping) and
+            isinstance(condition.get('.session'), Session)
+        ):
+            condition['.session'] = condition['.session'].id
+
+        if self.configuration.verbose:
+            print(f'Getting value masses for trainee with id: {trainee_id}')
+
+        value_masses = self.execute(trainee_id, "get_value_masses", {
+            "features": features,
+            "condition": condition,
+            "minimum_mass_threshold": minimum_mass_threshold,
+            "precision": precision,
+            "weight_feature": weight_feature,
+        })
+        if value_masses is None:
+            return dict()
+        return value_masses.get("masses", {})
+
     def react(  # noqa: C901
         self,
         trainee_id: str,

--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -1464,7 +1464,7 @@ class AbstractHowsoClient(ABC):
         minimum_mass_threshold: float = 0.0,
         precision: t.Optional[Precision] = "exact",
         weight_feature: t.Optional[str] = None
-    ) -> dict[str, dict[str, list[list] | float]]:
+    ) -> dict[str, dict[str, list[list[t.Any]] | float]]:
         """
         Get the unique values and their respective masses for each specified feature.
 
@@ -1504,7 +1504,7 @@ class AbstractHowsoClient(ABC):
 
         Returns
         -------
-        dict[str, dict[str, list[list] | float]]
+        dict[str, dict[str, list[list[Any]] | float]]
             A map of each feature name to a dict containing "values" and "remaining"
             keys. "values" maps to a list of lists where each sublist contains
             the feature value and its mass. When ``minimum_mass_threshold`` is

--- a/howso/client/pandas/client.py
+++ b/howso/client/pandas/client.py
@@ -8,9 +8,10 @@ from pandas import DataFrame, Index
 
 from howso.client.client import get_howso_client_class
 from howso.client.schemas.reaction import Reaction
+from howso.client.typing import ValueMasses
 from howso.utilities import deserialize_cases, format_dataframe
-from howso.utilities.internals import deserialize_to_dataframe
 from howso.utilities.features import FeatureSerializer
+from howso.utilities.internals import deserialize_to_dataframe
 
 
 class HowsoPandasClientMixin:
@@ -156,25 +157,26 @@ class HowsoPandasClientMixin:
         response = super().get_marginal_stats(*args, **kwargs)
         return pd.DataFrame(response)
 
-    def get_value_masses(self, trainee_id: str,  *args, **kwargs) -> DataFrame:
+    def get_value_masses(self, trainee_id: str,  *args, **kwargs) -> dict[str, ValueMasses]:
         """
-        Base: :func:`howso.client.AbstractHowsoClient.get_marginal_stats`.
+        Base: :func:`howso.client.AbstractHowsoClient.get_value_masses`.
 
         Returns
         -------
-        DataFrame
-            A DataFrame of feature name columns to statistic value rows.
+        dict[str, ValueMasses]
+            A DataFrame of feature name columns to a dict describing the value masses.
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         feature_attributes = self.resolve_feature_attributes(trainee_id)
         response = super().get_value_masses(trainee_id, *args, **kwargs)
         out_response = {}
         for f_name, results in response.items():
-            masses_df = pd.DataFrame(data=results.get('values', []), columns=["Feature Value", "Mass"])
-            masses_df['Feature Value'] = FeatureSerializer.format_column(
-                masses_df['Feature Value'],
-                feature_attributes[f_name]
-            )
+            masses_df = pd.DataFrame(data=results.get('values', []), columns=["feature_value", "mass"])
+            if f_name in feature_attributes:
+                masses_df['feature_value'] = FeatureSerializer.format_column(
+                    masses_df['feature_value'],
+                    feature_attributes[f_name]
+                )
             results['values'] = masses_df
             out_response[f_name] = results
 

--- a/howso/client/pandas/client.py
+++ b/howso/client/pandas/client.py
@@ -164,7 +164,7 @@ class HowsoPandasClientMixin:
         Returns
         -------
         dict[str, ValueMasses]
-            A DataFrame of feature name columns to a dict describing the value masses.
+            A dict of feature names to dictionaries describing the value masses.
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         feature_attributes = self.resolve_feature_attributes(trainee_id)

--- a/howso/client/typing.py
+++ b/howso/client/typing.py
@@ -56,6 +56,15 @@ class SortByFeature(TypedDict):
     order: Literal["asc", "desc"]
     """The direction of the sort."""
 
+class ValueMasses(TypedDict):
+    """Represents the computed value masses of a single feature."""
+
+    values: DataFrame | list[list]
+    """A dataframe or lists of lists containing each feature value and its corresponding mass."""
+
+    remaining: float
+    """The combined mass of all omitted feature values."""
+
 
 CaseIndices: TypeAlias = Sequence[tuple[str, int]]
 """Sequence of ``case_indices`` tuples."""

--- a/howso/client/typing.py
+++ b/howso/client/typing.py
@@ -60,7 +60,7 @@ class ValueMasses(TypedDict):
     """Represents the computed value masses of a single feature."""
 
     values: DataFrame
-    """A dataframe or lists of lists containing each feature value and its corresponding mass."""
+    """A dataframe containing each feature value and its corresponding mass."""
 
     remaining: float
     """The combined mass of all omitted feature values."""

--- a/howso/client/typing.py
+++ b/howso/client/typing.py
@@ -59,7 +59,7 @@ class SortByFeature(TypedDict):
 class ValueMasses(TypedDict):
     """Represents the computed value masses of a single feature."""
 
-    values: DataFrame | list[list]
+    values: DataFrame
     """A dataframe or lists of lists containing each feature value and its corresponding mass."""
 
     remaining: float

--- a/howso/engine/tests/test_engine.py
+++ b/howso/engine/tests/test_engine.py
@@ -74,7 +74,7 @@ class TestEngine:
     def test_get_value_masses(self, trainee):
         """Test that get_value_masses returns correct values."""
         value_masses = trainee.get_value_masses(features=['target'])
-        value_masses_map = {f_value: mass for f_value, mass in value_masses['target']['values']}
+        value_masses_map = {f_value: mass for f_value, mass in value_masses['target']['values'].values.tolist()}
         assert value_masses_map[0] == 50
         assert value_masses_map[1] == 50
         assert value_masses_map[2] == 50

--- a/howso/engine/tests/test_engine.py
+++ b/howso/engine/tests/test_engine.py
@@ -13,8 +13,6 @@ from howso.engine import (
     load_trainee,
     Trainee,
 )
-from howso.utilities import matrix_processing
-
 
 class TestEngine:
     """Test the Howso Engine module."""
@@ -72,6 +70,14 @@ class TestEngine:
         result = result['distances'].values.tolist()
 
         assert result == expected
+
+    def test_get_value_masses(self, trainee):
+        """Test that get_value_masses returns correct values."""
+        value_masses = trainee.get_value_masses(features=['target'])
+        value_masses_map = {f_value: mass for f_value, mass in value_masses['target']['values']}
+        assert value_masses_map[0] == 50
+        assert value_masses_map[1] == 50
+        assert value_masses_map[2] == 50
 
     @pytest.mark.parametrize(
         "case_indices,unexpected",

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -3201,6 +3201,19 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the 'get_marginal_stats' method.")
 
+    @t.overload
+    def get_value_masses(
+        self,
+        features: str,
+        *,
+        condition: t.Optional[Mapping] = None,
+        minimum_mass_threshold: float = 0.0,
+        precision: t.Optional[Precision] = "exact",
+        weight_feature: t.Optional[str] = None
+    ) -> ValueMasses:
+        ...
+
+
     def get_value_masses(
         self,
         features: Collection[str],
@@ -3258,14 +3271,20 @@ class Trainee(BaseTrainee):
             hasattr(self.client, "get_value_masses") and
             isinstance(self.client.get_value_masses, t.Callable)
         ):
-            return self.client.get_value_masses(
+            value_masses_response =  self.client.get_value_masses(
                 self.id,
-                features=features,
+                features=[features] if isinstance(features, str) else features,
                 condition=condition,
                 minimum_mass_threshold=minimum_mass_threshold,
                 precision=precision,
                 weight_feature=weight_feature
             )
+            if isinstance(features, str):
+                # Single feature flow
+                return value_masses_response[features]
+            else:
+                return value_masses_response
+
         else:
             raise AssertionError("Client must have the `get_value_masses` method.")
 

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -3213,7 +3213,7 @@ class Trainee(BaseTrainee):
     ) -> ValueMasses:
         ...
 
-
+    @t.overload
     def get_value_masses(
         self,
         features: Collection[str],
@@ -3223,12 +3223,23 @@ class Trainee(BaseTrainee):
         precision: t.Optional[Precision] = "exact",
         weight_feature: t.Optional[str] = None
     ) -> dict[str, ValueMasses]:
+        ...
+
+    def get_value_masses(
+        self,
+        features: str | Collection[str],
+        *,
+        condition: t.Optional[Mapping] = None,
+        minimum_mass_threshold: float = 0.0,
+        precision: t.Optional[Precision] = "exact",
+        weight_feature: t.Optional[str] = None
+    ) -> ValueMasses | dict[str, ValueMasses]:
         """
         Get the unique values and their respective masses for each specified feature.
 
         Parameters
         ----------
-        features : Collection[str]
+        features : str | Collection[str]
             The feature names for which to compute unique value masses.
         condition : Mapping or None, optional
             A condition map to select which cases to compute value masses

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -3202,7 +3202,7 @@ class Trainee(BaseTrainee):
             raise AssertionError("Client must have the 'get_marginal_stats' method.")
 
     @t.overload
-    def get_value_masses(
+    def get_value_masses(  # pyright: ignore[reportOverlappingOverload]
         self,
         features: str,
         *,
@@ -3278,10 +3278,7 @@ class Trainee(BaseTrainee):
             greater than one, "remaining" maps to a single value that is the sum
             of all omitted feature value masses.
         """
-        if (
-            hasattr(self.client, "get_value_masses") and
-            isinstance(self.client.get_value_masses, t.Callable)
-        ):
+        if isinstance(self.client, HowsoPandasClientMixin):
             value_masses_response =  self.client.get_value_masses(
                 self.id,
                 features=[features] if isinstance(features, str) else features,

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -3295,7 +3295,7 @@ class Trainee(BaseTrainee):
         ValueMasses | dict[str, ValueMasses]
             If only a single feature is given, then a single dictionary
             describing the value masses is returned, otherwise a dict is
-            returned with value masses for each specified feautre. In the
+            returned with value masses for each specified feature. In the
             per-feature dict, "values" maps to a DataFrame where each row
             contains a unique feature value and its mass. When
             ``minimum_mass_threshold`` is greater than zero, "remaining" maps

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -3271,12 +3271,15 @@ class Trainee(BaseTrainee):
 
         Returns
         -------
-        dict[str, dict[str, list[list] | float]]
-            A map of each feature name to a dict containing "values" and "remaining"
-            keys. "values" maps to a list of lists where each sublist contains
-            the feature value and its mass. When ``minimum_mass_threshold`` is
-            greater than one, "remaining" maps to a single value that is the sum
-            of all omitted feature value masses.
+        ValueMasses | dict[str, ValueMasses]
+            If only a single feature is given, then a single dictionary
+            describing the value masses is returned, otherwise a dict is
+            returned with value masses for each specified feautre. In the
+            per-feature dict, "values" maps to a DataFrame where each row
+            contains a unique feature value and its mass. When
+            ``minimum_mass_threshold`` is greater than zero, "remaining" maps
+            to a single value that is the sum of all omitted feature value
+            masses.
         """
         if isinstance(self.client, HowsoPandasClientMixin):
             value_masses_response =  self.client.get_value_masses(
@@ -3299,7 +3302,7 @@ class Trainee(BaseTrainee):
     def react_into_features(
         self,
         *,
-        analyze: bool = None,
+        analyze: t.Optional[bool] = None,
         distance_contribution: str | bool = False,
         familiarity_conviction_addition: str | bool = False,
         familiarity_conviction_removal: str | bool = False,

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -3200,6 +3200,74 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the 'get_marginal_stats' method.")
 
+    def get_value_masses(
+        self,
+        features: Collection[str],
+        *,
+        condition: t.Optional[Mapping] = None,
+        minimum_mass_threshold: int = 0,
+        precision: t.Optional[Precision] = "exact",
+        weight_feature: t.Optional[str] = None
+    ):
+        """
+        Get the unique values and their respective masses for each specified feature.
+
+        Parameters
+        ----------
+        features : Collection[str]
+            The feature names for which to compute unique value masses.
+        condition : Mapping or None, optional
+            A condition map to select which cases to compute value masses
+            for.
+
+            .. NOTE::
+                The dictionary keys are feature names and values are one of:
+
+                    - None
+                    - A value, must match exactly.
+                    - An array of two numeric values, specifying an inclusive
+                      range. Only applicable to continuous and numeric ordinal
+                      features.
+                    - An array of string values, must match any of these values
+                      exactly. Only applicable to nominal and string ordinal
+                      features.
+        minimum_mass_threshold : int, default 0
+            The minimum mass a feature value must possess to be returned in the
+            collection of value masses. If the given value is greater than one,
+            the sum of the omitted feature value masses is returned under a
+            "remaining" key for each feature.
+        precision : str, default "exact"
+            The precision to use when selecting cases with ``condition``.
+            Options are 'exact' or 'similar'. Only used if `condition` is not
+            None.
+        weight_feature : str, optional
+            When specified, will return masses based on weights stored
+            in this weight_feature.
+
+        Returns
+        -------
+        dict[str, dict[str, list[list] | float]]
+            A map of each feature name to a dict containing "values" and "remaining"
+            keys. "values" maps to a list of lists where each sublist contains
+            the feature value and its mass. When ``minimum_mass_threshold`` is
+            greater than one, "remaining" maps to a single value that is the sum
+            of all omitted feature value masses.
+        """
+        if (
+            hasattr(self.client, "get_value_masses") and
+            isinstance(self.client.get_value_masses, t.Callable)
+        ):
+            return self.client.get_value_masses(
+                self.id,
+                features=features,
+                condition=condition,
+                minimum_mass_threshold=minimum_mass_threshold,
+                precision=precision,
+                weight_feature=weight_feature
+            )
+        else:
+            raise AssertionError("Client must have the `get_value_masses` method.")
+
     def react_into_features(
         self,
         *,

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -52,6 +52,7 @@ from howso.client.typing import (
     TabularData2D,
     TabularData3D,
     TargetedModel,
+    ValueMasses,
 )
 from howso.engine.client import get_client
 from howso.engine.project import Project
@@ -1272,9 +1273,9 @@ class Trainee(BaseTrainee):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -1861,9 +1862,9 @@ class Trainee(BaseTrainee):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -2117,9 +2118,9 @@ class Trainee(BaseTrainee):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -2295,9 +2296,9 @@ class Trainee(BaseTrainee):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -2389,9 +2390,9 @@ class Trainee(BaseTrainee):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -2582,9 +2583,9 @@ class Trainee(BaseTrainee):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -2751,9 +2752,9 @@ class Trainee(BaseTrainee):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -2822,9 +2823,9 @@ class Trainee(BaseTrainee):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -3007,9 +3008,9 @@ class Trainee(BaseTrainee):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -3165,9 +3166,9 @@ class Trainee(BaseTrainee):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
@@ -3205,10 +3206,10 @@ class Trainee(BaseTrainee):
         features: Collection[str],
         *,
         condition: t.Optional[Mapping] = None,
-        minimum_mass_threshold: int = 0,
+        minimum_mass_threshold: float = 0.0,
         precision: t.Optional[Precision] = "exact",
         weight_feature: t.Optional[str] = None
-    ):
+    ) -> dict[str, ValueMasses]:
         """
         Get the unique values and their respective masses for each specified feature.
 
@@ -3225,15 +3226,15 @@ class Trainee(BaseTrainee):
 
                     - None
                     - A value, must match exactly.
-                    - An array of two numeric values, specifying an inclusive
-                      range. Only applicable to continuous and numeric ordinal
-                      features.
+                    - An array of two numeric values (or formatted datetimes),
+                      specifying an inclusive range. Only applicable to
+                      continuous and numeric ordinal features.
                     - An array of string values, must match any of these values
                       exactly. Only applicable to nominal and string ordinal
                       features.
-        minimum_mass_threshold : int, default 0
+        minimum_mass_threshold : float, default 0.0
             The minimum mass a feature value must possess to be returned in the
-            collection of value masses. If the given value is greater than one,
+            collection of value masses. If the given value is greater than zero,
             the sum of the omitted feature value masses is returned under a
             "remaining" key for each feature.
         precision : str, default "exact"


### PR DESCRIPTION
Included a test this time around, mostly as a mechanism to ensure this doesn't merge without an updated Engine.