### PR TITLE
24269: Fixes bug in IFA where `decimal_places` is not set for large floats, leading to incorrect validation warnings

### DIFF
--- a/howso/utilities/feature_attributes/abstract_data.py
+++ b/howso/utilities/feature_attributes/abstract_data.py
@@ -527,14 +527,8 @@ class InferFeatureAttributesAbstractData(InferFeatureAttributesBase):
             decimals = self.data.get_decimal_places(feature_name)
             if decimals is None:
                 warnings.warn(f'Cannot compute decimal places for feature "{feature_name}')
-            elif decimals <= 8:
-                attributes['decimal_places'] = decimals
             else:
-                warnings.warn(
-                    f'Feature "{feature_name}" contains floating point '
-                    'values that exceed the maximum supported precision '
-                    'of 64 bits.'
-                )
+                attributes['decimal_places'] = decimals
 
         return attributes
 


### PR DESCRIPTION
The existing check on precision is not correct and also redundant to the one in `get_feature_type`.