### PR TITLE
24289: Ensures string features don't change type in a deserialized DataFrame if IFA detects they are datetimes

### DIFF
--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -927,7 +927,12 @@ class InferFeatureAttributesBase(ABC):
                 self.attributes[feature_name]['unique'] = True
 
             # Add original type to feature
-            if feature_type is not None:
+            if original_type := typing_info.pop('original_type', None):
+                self.attributes[feature_name]['original_type'] = {
+                    'data_type': str(original_type),
+                    **typing_info
+                }
+            elif feature_type is not None:
                 self.attributes[feature_name]['original_type'] = {
                     'data_type': str(feature_type),
                     **typing_info

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -259,9 +259,10 @@ class InferFeatureAttributesDataFrame(InferFeatureAttributesBase):
                             return FeatureType.STRING, {}
                         if converted_val.time() == pd.Timestamp(0).time() and converted_val.tz is None:
                             converted_dtype = np.datetime64(converted_val, 'D').dtype
-                        typing_info = {}
+                        # Specify an original_type here to ensure the DataFrame is unchanged during deserialization
+                        typing_info = {'original_type': FeatureType.STRING}
                         if converted_dtype in ['datetime64[Y]', 'datetime64[M]', 'datetime64[D]']:
-                            return FeatureType.DATE, {}
+                            return FeatureType.DATE, typing_info
                         elif isinstance(converted_dtype, pd.DatetimeTZDtype) or getattr(converted_dtype.tz):
                             if isinstance(converted_dtype.tz, pytz.BaseTzInfo) and converted_dtype.tz.zone:
                                 # If using a named time zone capture it, otherwise


### PR DESCRIPTION
We have recently improved the ability of `infer_feature_attributes` to detect if a feature in a DataFrame with an `object` `dtype` is actually a date or datetime. However, internally, we must preserve the fact that the feature was originally a string in the data, so that when we deserialize the data from a `Trainee` and convert it back to a `DataFrame`, that original type is not lost.