### PR TITLE
24288: Fixes unexpected `KeyError` raised in time series IFA when multiple workers are used

### DIFF
--- a/howso/utilities/feature_attributes/time_series.py
+++ b/howso/utilities/feature_attributes/time_series.py
@@ -191,10 +191,10 @@ class InferFeatureAttributesTimeSeries:
 
                         with ProcessPoolExecutor(max_workers=max_workers, mp_context=mp_context) as pool:
                             df_chunks_generator = yield_dataframe_as_chunks(df_c, max_workers)
-                            for chunk in df_chunks_generator:
+                            for sub_chunk in df_chunks_generator:
                                 future = pool.submit(
                                     _apply_date_to_epoch,
-                                    df=chunk,
+                                    df=sub_chunk,
                                     feature_name=f_name,
                                     dt_format=dt_format
                                 )


### PR DESCRIPTION
In this case, the `chunk` variable name was clobbering another when it was assigned in the `ProcessPoolExecutor`.