### PR TITLE
24515: Reformats references to custom code, MAJOR

### DIFF
--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -4261,13 +4261,14 @@ class AbstractHowsoClient(ABC):
         features_to_code_map : Mapping of str to str
             A dictionary with feature name keys and custom Amalgam code string values.
 
-            The custom code can use "#feature_name 0" to reference the value
-            of that feature for each case.
+            The custom code can use "(call value {feature \"feature name\"})"
+            to reference the value of that feature for each case.
         aggregation_code : str, optional
             A string of custom Amalgam code that can access the list of values
             derived form the custom code in features_to_code_map.
-            The custom code can use "#feature_name 0" to reference the list of
-            values derived from using the custom code in features_to_code_map.
+            The custom code can use "(call value {feature \"feature name\"})"
+            to reference the list of values derived from using the custom code
+            in features_to_code_map.
 
         Returns
         -------

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -4211,14 +4211,15 @@ class Trainee(BaseTrainee):
             A dictionary with feature name keys and custom Amalgam code string
             values.
 
-            The custom code can use \"#feature_name 0\" to reference the value
-            of that feature for each case.
+            The custom code can use "(call value {feature \"feature name\"})"
+            to reference the value of that feature for each case.
         aggregation_code : str, optional
             A string of custom Amalgam code that can access the list of values
             derived form the custom code in features_to_code_map.
 
-            The custom code can use \"#feature_name 0\" to reference the list of
-            values derived from using the custom code in features_to_code_map.
+            The custom code can use "(call value {feature \"feature name\"})"
+            to reference the list of values derived from using the custom code
+            in features_to_code_map.
 
         Returns
         -------

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "howso-engine": "105.0.1"
+    "howso-engine": "106.0.0"
   }
 }


### PR DESCRIPTION
Marking as major because even though no breaking api changes were made to this project directly, the overall changes are breaking since the values are passed down and the version dependency bump makes this a breaking change for higher up the stack.