### PR TITLE
25544: Fixes issue where some unit tests won't respect `TEST_OPTIONS` setting

### DIFF
--- a/howso/direct/tests/test_hierarchy.py
+++ b/howso/direct/tests/test_hierarchy.py
@@ -40,14 +40,11 @@ def simple_trainee(
 @pytest.fixture
 def client(tmp_path: Path):
     """Direct client instance using latest binaries."""
-    # Get the Amalgam library type set by the user config if it exists
-    amalgam_postfix = "-" + hse.Trainee().get_runtime()["library_type"]
     return get_configurationless_test_client(
         client_class=HowsoDirectClient,
         verbose=True,
         trace=True,
         default_persist_path=tmp_path,
-        amalgam={"library_postfix": amalgam_postfix}
     )
 
 

--- a/howso/direct/tests/test_standalone.py
+++ b/howso/direct/tests/test_standalone.py
@@ -14,10 +14,8 @@ from howso.utilities.testing import get_configurationless_test_client
 def client(tmp_path: Path):
     """Direct client instance using latest binaries."""
     # Get the Amalgam library type set by the user config if it exists
-    amalgam_postfix = "-" + Trainee().get_runtime()["library_type"]
     return get_configurationless_test_client(client_class=HowsoDirectClient,
-                                             verbose=True, trace=True, default_persist_path=tmp_path,
-                                            amalgam={"library_postfix": amalgam_postfix})
+                                             verbose=True, trace=True, default_persist_path=tmp_path)
 
 
 def test_direct_client(client: HowsoDirectClient):

--- a/howso/utilities/testing.py
+++ b/howso/utilities/testing.py
@@ -6,6 +6,7 @@ import os
 from unittest.mock import patch
 
 from howso.client.base import AbstractHowsoClient
+from howso.client.client import get_howso_client_class
 from howso.direct import HowsoDirectClient
 
 
@@ -57,7 +58,9 @@ def get_configurationless_test_client(
         An instance of a subclass of AbstractHowsoClient.
     """
     if "USE_HOWSO_CONFIG" in get_test_options():
-        return client_class(**kwargs)
+        _, client_params = get_howso_client_class(**kwargs)
+        client_params.update(kwargs)
+        return client_class(**client_params)
     else:
         # Ignore any locally defined config (howso.yml) files.
         names_to_remove = ('XDG_CONFIG_HOME', 'HOWSO_CONFIG')


### PR DESCRIPTION
The `get_configurationless_test_client` helper function is supposed to evaluate whether the user sets the `TEST_OPTIONS` environment variable to include `USE_HOWSO_CONFIG`; however, even when this is set, no parameters from the user's config are actually set. This PR fixes that issue and removes temporary patches for Amalgam ST compatibility.