### PR TITLE
25701: Upgrades Pytest version, removes relative imports in test files

### DIFF
--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -178,12 +178,12 @@ SOFTWARE.
 
 
 click
-8.4.1
+8.4.2
 BSD-3-Clause
 UNKNOWN
 https://github.com/pallets/click/
 Composable command line interface toolkit
-/home/runner/.pyenv/versions/3.14.6/lib/python3.14/site-packages/click-8.4.1.dist-info/licenses/LICENSE.txt
+/home/runner/.pyenv/versions/3.14.6/lib/python3.14/site-packages/click-8.4.2.dist-info/licenses/LICENSE.txt
 Copyright 2014 Pallets
 
 Redistribution and use in source and binary forms, with or without
@@ -2845,12 +2845,12 @@ DEALINGS IN THE SOFTWARE.
 
 
 regex
-2026.5.9
+2026.6.28
 Apache-2.0 AND CNRI-Python
 Matthew Barnett <regex@mrabarnett.plus.com>
 https://github.com/mrabarnett/mrab-regex
 Alternative regular expression module, to replace re.
-/home/runner/.pyenv/versions/3.14.6/lib/python3.14/site-packages/regex-2026.5.9.dist-info/licenses/LICENSE.txt
+/home/runner/.pyenv/versions/3.14.6/lib/python3.14/site-packages/regex-2026.6.28.dist-info/licenses/LICENSE.txt
 This work was derived from the 're' module of CPython 2.6 and CPython 3.1,
 copyright (c) 1998-2001 by Secret Labs AB and licensed under CNRI's Python 1.6
 license.

--- a/howso/client/__init__.py
+++ b/howso/client/__init__.py
@@ -16,10 +16,10 @@ from the documentation.
 Examples implementations are included in the howso/examples directory.
 """
 
-from . import typing  # noqa: F401
-from .api import get_api  # noqa: F401
-from .base import AbstractHowsoClient  # noqa: F401
-from .client import (  # noqa: F401
+from howso.client import typing  # noqa: F401
+from howso.client.api import get_api  # noqa: F401
+from howso.client.base import AbstractHowsoClient  # noqa: F401
+from howso.client.client import (  # noqa: F401
     CONFIG_FILE_ENV_VAR,
     DEFAULT_CONFIG_FILE,
     DEFAULT_CONFIG_FILE_ALT,
@@ -27,7 +27,7 @@ from .client import (  # noqa: F401
     get_howso_client,
     HowsoClient,
 )
-from .pandas.client import HowsoPandasClient  # noqa: F401
+from howso.client.pandas.client import HowsoPandasClient  # noqa: F401
 
 __all__ = [
     "AbstractHowsoClient",

--- a/howso/client/api.py
+++ b/howso/client/api.py
@@ -7,10 +7,10 @@ from pathlib import Path
 import typing as t
 from uuid import uuid4
 
+from amalgam.api import Amalgam
 from typing_extensions import NotRequired, TypeAlias, TypedDict
 
-from amalgam.api import Amalgam
-from .exceptions import HowsoError
+from howso.client.exceptions import HowsoError
 
 DEFAULT_ENGINE_PATH = Path(__file__).parent.parent.joinpath("howso-engine")
 

--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -23,31 +23,21 @@ import warnings
 import numpy as np
 from pandas import DataFrame
 
-from howso.utilities import internals
-from howso.utilities import utilities as util
-from howso.utilities.feature_attributes.base import (
-    FeatureAttributesBase,
-    MultiTableFeatureAttributes,
-    SingleTableFeatureAttributes,
-)
-from howso.utilities.features import serialize_cases
-from howso.utilities.monitors import ProgressTimer
-
-from .exceptions import (
+from howso.client.exceptions import (
     HowsoError,
     UnsupportedArgumentWarning,
 )
-from .schemas import (
+from howso.client.schemas import (
+    GroupReaction,
     HowsoVersion,
     Project,
-    GroupReaction,
     Reaction,
     Session,
     Trainee,
     TraineeRuntime,
     TraineeRuntimeOptions,
 )
-from .typing import (
+from howso.client.typing import (
     AblationThresholdMap,
     CaseIndices,
     Cases,
@@ -67,6 +57,14 @@ from .typing import (
     TargetedModel,
     TrainStatus,
 )
+from howso.utilities import internals, utilities as util
+from howso.utilities.feature_attributes.base import (
+    FeatureAttributesBase,
+    MultiTableFeatureAttributes,
+    SingleTableFeatureAttributes,
+)
+from howso.utilities.features import serialize_cases
+from howso.utilities.monitors import ProgressTimer
 
 if t.TYPE_CHECKING:
     from .cache import TraineeCache

--- a/howso/client/configuration.py
+++ b/howso/client/configuration.py
@@ -9,7 +9,7 @@ from typing_extensions import TypeVar
 import yaml
 
 from howso.client.exceptions import HowsoConfigurationError
-from .feature_flags import FeatureFlags
+from howso.client.feature_flags import FeatureFlags
 
 CO = TypeVar("CO", bound="ClientOptions")
 

--- a/howso/client/pandas/__init__.py
+++ b/howso/client/pandas/__init__.py
@@ -1,4 +1,4 @@
-from .client import (  # noqa: F401
+from howso.client.pandas.client import (  # noqa: F401
     HowsoPandasClient,
     HowsoPandasClientMixin,
 )

--- a/howso/client/schemas/__init__.py
+++ b/howso/client/schemas/__init__.py
@@ -1,14 +1,20 @@
-from .aggregate_reaction import AggregateReaction
-from .base import BaseSchema
-from .group_reaction import GroupReaction
-from .project import Project, ProjectDict
-from .reaction import ReactDetails, Reaction
-from .session import Session, SessionDict
-from .trainee import (
-    ResourceLimit, Trainee, TraineeDict, TraineeRuntime, TraineeRuntimeOptions, TraineeScaling,
-    TraineeScalingResources, TraineeVersion
+from howso.client.schemas.aggregate_reaction import AggregateReaction
+from howso.client.schemas.base import BaseSchema
+from howso.client.schemas.group_reaction import GroupReaction
+from howso.client.schemas.project import Project, ProjectDict
+from howso.client.schemas.reaction import ReactDetails, Reaction
+from howso.client.schemas.session import Session, SessionDict
+from howso.client.schemas.trainee import (
+    ResourceLimit,
+    Trainee,
+    TraineeDict,
+    TraineeRuntime,
+    TraineeRuntimeOptions,
+    TraineeScaling,
+    TraineeScalingResources,
+    TraineeVersion,
 )
-from .version import HowsoVersion
+from howso.client.schemas.version import HowsoVersion
 
 __all__ = [
     'AggregateReaction',

--- a/howso/client/schemas/aggregate_reaction.py
+++ b/howso/client/schemas/aggregate_reaction.py
@@ -1,11 +1,11 @@
-from collections.abc import Mapping, Iterator
+from collections.abc import Iterator, Mapping
 from copy import deepcopy
 from pprint import pformat
 from typing import Any, Literal, overload, TypeAlias, TypeVar
 
 import pandas as pd
 
-from ..typing import ConfusionMatrix
+from howso.client.typing import ConfusionMatrix
 
 __all__ = [
     "AggregateReaction"

--- a/howso/client/schemas/project.py
+++ b/howso/client/schemas/project.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from dateutil.parser import parse as dt_parse
 
-from .base import BaseSchema
+from howso.client.schemas.base import BaseSchema
 
 __all__ = [
     "Project",

--- a/howso/client/schemas/session.py
+++ b/howso/client/schemas/session.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from dateutil.parser import parse as dt_parse
 
-from .base import BaseSchema
+from howso.client.schemas.base import BaseSchema
 
 __all__ = [
     "Session",

--- a/howso/client/schemas/trainee.py
+++ b/howso/client/schemas/trainee.py
@@ -6,8 +6,8 @@ from uuid import UUID
 
 from typing_extensions import NotRequired, ReadOnly, TypedDict
 
-from .base import BaseSchema
-from ..typing import LibraryType, Persistence
+from howso.client.schemas.base import BaseSchema
+from howso.client.typing import LibraryType, Persistence
 
 __all__ = [
     "Trainee",

--- a/howso/client/tests/test_exceptions.py
+++ b/howso/client/tests/test_exceptions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..exceptions import HowsoApiError, HowsoApiValidationError, HowsoValidationError
+from howso.client.exceptions import HowsoApiError, HowsoApiValidationError, HowsoValidationError
 
 
 @pytest.mark.parametrize("collection, size", [

--- a/howso/client/tests/test_feature_flags.py
+++ b/howso/client/tests/test_feature_flags.py
@@ -1,7 +1,8 @@
-import pytest
 import warnings
 
-from ..feature_flags import FeatureFlags
+import pytest
+
+from howso.client.feature_flags import FeatureFlags
 
 
 @pytest.mark.parametrize("flags, target, expected", [

--- a/howso/client/tests/test_infer_feature_attributes.py
+++ b/howso/client/tests/test_infer_feature_attributes.py
@@ -6,8 +6,8 @@ import pandas as pd
 import pytest
 
 from howso.client.exceptions import DatetimeFormatWarning
+from howso.client.tests import NOMINAL_SUBSTITUTION_AVAILABLE
 from howso.utilities import infer_feature_attributes
-from . import NOMINAL_SUBSTITUTION_AVAILABLE
 
 
 class TestInferFeatureAttributes:

--- a/howso/direct/__init__.py
+++ b/howso/direct/__init__.py
@@ -1,6 +1,6 @@
 """The Python API for the Howso Direct Client."""
 
-from .client import HowsoDirectClient
+from howso.direct.client import HowsoDirectClient
 
 __all__ = [
     "HowsoDirectClient"

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -18,12 +18,12 @@ import typing as t
 import uuid
 import warnings
 
+from amalgam.api import Amalgam
 import certifi
 from packaging.version import parse as parse_version
 import urllib3
 from urllib3.util import Retry, Timeout
 
-from amalgam.api import Amalgam
 from howso import utilities as util
 from howso.client import get_configuration_path
 from howso.client.api import DEFAULT_ENGINE_PATH
@@ -43,7 +43,7 @@ from howso.client.schemas import (
 from howso.client.typing import LibraryType, Persistence
 from howso.direct.schemas import CombineTraineesResult, DirectTrainee
 from howso.utilities import HowsoTokenizer, internals, TokenizerProtocol
-from ..utilities.random import get_random_seed
+from howso.utilities.random import get_random_seed
 
 # Client version
 CLIENT_VERSION = importlib.metadata.version('howso-engine')

--- a/howso/direct/schemas/__init__.py
+++ b/howso/direct/schemas/__init__.py
@@ -1,4 +1,4 @@
-from .trainee import CombineTraineesResult, DirectTrainee, DirectTraineeDict
+from howso.direct.schemas.trainee import CombineTraineesResult, DirectTrainee, DirectTraineeDict
 
 __all__ = [
     "CombineTraineesResult",

--- a/howso/direct/schemas/trainee.py
+++ b/howso/direct/schemas/trainee.py
@@ -4,8 +4,8 @@ from collections.abc import Mapping
 import typing as t
 from uuid import UUID
 
-from ...client.schemas.trainee import Trainee, TraineeDict
-from ...client.typing import Persistence
+from howso.client.schemas.trainee import Trainee, TraineeDict
+from howso.client.typing import Persistence
 
 
 class DirectTraineeDict(TraineeDict):

--- a/howso/engine/__init__.py
+++ b/howso/engine/__init__.py
@@ -1,8 +1,8 @@
 """The Python API for the Howso Engine Client."""
 
 from howso.client import typing
-from .client import get_client, use_client
-from .project import (
+from howso.engine.client import get_client, use_client
+from howso.engine.project import (
     delete_project,
     get_project,
     list_projects,
@@ -10,14 +10,14 @@ from .project import (
     query_projects,
     switch_project,
 )
-from .session import (
+from howso.engine.session import (
     get_active_session,
     get_session,
     list_sessions,
     query_sessions,
     Session,
 )
-from .trainee import (
+from howso.engine.trainee import (
     delete_trainee,
     get_trainee,
     list_trainees,

--- a/howso/scikit/__init__.py
+++ b/howso/scikit/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
         "scikit-learn must be installed to use the howso.scikit module. Please run `pip install howso-engine[scikit]`"
     )
 
-from .scikit import (  # noqa: F401
+from howso.scikit.scikit import (  # noqa: F401
     ACTION,
     CLASSIFICATION,
     DEFAULT_TTL,

--- a/howso/utilities/__init__.py
+++ b/howso/utilities/__init__.py
@@ -1,29 +1,29 @@
 """This module contains various utilities for the Howso clients."""
-from .decorators import ConsoleFeedback
-from .fanout_features import infer_fanout_feature_config
-from .feature_attributes import infer_feature_attributes  # noqa: F401
-from .feature_attributes.base import (
+from howso.utilities.decorators import ConsoleFeedback
+from howso.utilities.fanout_features import infer_fanout_feature_config
+from howso.utilities.feature_attributes import infer_feature_attributes  # noqa: F401
+from howso.utilities.feature_attributes.base import (
     FeatureAttributesBase,
     MultiTableFeatureAttributes,
     SingleTableFeatureAttributes,
 )
-from .features import (  # noqa: F401
+from howso.utilities.features import (  # noqa: F401
     deserialize_cases,
     FeatureType,
     format_column,
     format_dataframe,
     serialize_cases,
 )
-from .monitors import (
+from howso.utilities.monitors import (
     FrozenTimer,
     ProgressTimer,
     Timer,
 )
-from .tokenizing import (
+from howso.utilities.tokenizing import (
     HowsoTokenizer,
     TokenizerProtocol,
 )
-from .utilities import (  # noqa: F401
+from howso.utilities.utilities import (  # noqa: F401
     align_data,
     build_react_series_df,
     check_feature_names,

--- a/howso/utilities/feature_attributes/__init__.py
+++ b/howso/utilities/feature_attributes/__init__.py
@@ -1,5 +1,5 @@
 """This module contains tools to infer feature attributes from a variety of data types."""
-from . import (
+from howso.utilities.feature_attributes import (
     abstract_data,
     base,
     pandas,
@@ -7,7 +7,7 @@ from . import (
     relational,
     time_series,
 )
-from .infer_feature_attributes import infer_feature_attributes
+from howso.utilities.feature_attributes.infer_feature_attributes import infer_feature_attributes
 
 __all__ = [
     "abstract_data",

--- a/howso/utilities/feature_attributes/abstract_data.py
+++ b/howso/utilities/feature_attributes/abstract_data.py
@@ -22,12 +22,12 @@ from pandas.core.dtypes.common import (
     is_unsigned_integer_dtype,
 )
 
-from .base import InferFeatureAttributesBase, SingleTableFeatureAttributes
-from .protocols import IFACompatibleADCProtocol
-from .suggestions import IFASuggestionCollector
-from .warnings import IFAWarningCollector, IFAWarningEmitterType
-from ..features import FeatureType
-from ..utilities import (
+from howso.utilities.feature_attributes.base import InferFeatureAttributesBase, SingleTableFeatureAttributes
+from howso.utilities.feature_attributes.protocols import IFACompatibleADCProtocol
+from howso.utilities.feature_attributes.suggestions import IFASuggestionCollector
+from howso.utilities.feature_attributes.warnings import IFAWarningCollector, IFAWarningEmitterType
+from howso.utilities.features import FeatureType
+from howso.utilities.utilities import (
     date_to_epoch,
     determine_iso_format,
     epoch_to_date,
@@ -39,7 +39,6 @@ from ..utilities import (
     TIME_PATTERN,
     time_to_seconds,
 )
-
 
 logger = logging.getLogger(__name__)
 

--- a/howso/utilities/feature_attributes/infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/infer_feature_attributes.py
@@ -5,12 +5,16 @@ import typing as t
 
 import pandas as pd
 
-from .abstract_data import InferFeatureAttributesAbstractData
-from .base import FeatureAttributesBase
-from .pandas import InferFeatureAttributesDataFrame
-from .protocols import IFACompatibleADCProtocol, SQLRelationalDatastoreProtocol, TableNameProtocol
-from .relational import InferFeatureAttributesSQLDatastore
-from .time_series import IFATimeSeriesADC, IFATimeSeriesPandas
+from howso.utilities.feature_attributes.abstract_data import InferFeatureAttributesAbstractData
+from howso.utilities.feature_attributes.base import FeatureAttributesBase
+from howso.utilities.feature_attributes.pandas import InferFeatureAttributesDataFrame
+from howso.utilities.feature_attributes.protocols import (
+    IFACompatibleADCProtocol,
+    SQLRelationalDatastoreProtocol,
+    TableNameProtocol,
+)
+from howso.utilities.feature_attributes.relational import InferFeatureAttributesSQLDatastore
+from howso.utilities.feature_attributes.time_series import IFATimeSeriesADC, IFATimeSeriesPandas
 
 
 def infer_feature_attributes(data: pd.DataFrame | IFACompatibleADCProtocol | SQLRelationalDatastoreProtocol, *,

--- a/howso/utilities/feature_attributes/pandas.py
+++ b/howso/utilities/feature_attributes/pandas.py
@@ -23,16 +23,13 @@ from pandas.core.dtypes.common import (
     is_unsigned_integer_dtype,
 )
 
+from howso.utilities.feature_attributes.base import InferFeatureAttributesBase, SingleTableFeatureAttributes
 from howso.utilities.feature_attributes.suggestions import (
     IFASuggestionCollector,
 )
-from .base import (
-    InferFeatureAttributesBase,
-    SingleTableFeatureAttributes
-)
-from .warnings import IFAWarningCollector, IFAWarningEmitterType
-from ..features import FeatureType
-from ..utilities import (
+from howso.utilities.feature_attributes.warnings import IFAWarningCollector, IFAWarningEmitterType
+from howso.utilities.features import FeatureType
+from howso.utilities.utilities import (
     date_to_epoch,
     determine_iso_format,
     epoch_to_date,

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -9,22 +9,26 @@ import logging
 from math import ceil, isnan, log
 import re
 import typing as t
-from typing_extensions import override
 import warnings
 
 import numpy as np
 import pandas as pd
 from pandas.core.dtypes.common import is_float_dtype
+from typing_extensions import override
 
-from .base import InferFeatureAttributesBase, MultiTableFeatureAttributes, SingleTableFeatureAttributes
-from .protocols import (
+from howso.utilities.feature_attributes.base import (
+    InferFeatureAttributesBase,
+    MultiTableFeatureAttributes,
+    SingleTableFeatureAttributes,
+)
+from howso.utilities.feature_attributes.protocols import (
     SessionProtocol,
     SQLRelationalDatastoreProtocol,
     SQLTableProtocol,
     TableNameProtocol,
 )
-from ..features import FeatureType
-from ..utilities import (
+from howso.utilities.features import FeatureType
+from howso.utilities.utilities import (
     date_to_epoch,
     determine_iso_format,
     epoch_to_date,

--- a/howso/utilities/feature_attributes/time_series.py
+++ b/howso/utilities/feature_attributes/time_series.py
@@ -15,13 +15,13 @@ import pandas as pd
 from pandas.core.dtypes.common import is_string_dtype
 import psutil
 
-from .abstract_data import InferFeatureAttributesAbstractData
-from .base import InferFeatureAttributesBase, SingleTableFeatureAttributes
-from .pandas import InferFeatureAttributesDataFrame
-from .protocols import IFACompatibleADCProtocol
-from .suggestions import IFASuggestionCollector
-from .warnings import IFAWarningCollector
-from ..utilities import (
+from howso.utilities.feature_attributes.abstract_data import InferFeatureAttributesAbstractData
+from howso.utilities.feature_attributes.base import InferFeatureAttributesBase, SingleTableFeatureAttributes
+from howso.utilities.feature_attributes.pandas import InferFeatureAttributesDataFrame
+from howso.utilities.feature_attributes.protocols import IFACompatibleADCProtocol
+from howso.utilities.feature_attributes.suggestions import IFASuggestionCollector
+from howso.utilities.feature_attributes.warnings import IFAWarningCollector
+from howso.utilities.utilities import (
     date_to_epoch,
     is_valid_datetime_format,
     lazy_map,

--- a/howso/utilities/features.py
+++ b/howso/utilities/features.py
@@ -17,12 +17,12 @@ from pandas.core.dtypes.common import (
     is_timedelta64_dtype,
 )
 
-from .internals import deserialize_to_dataframe, IgnoreWarnings, to_pandas_datetime_format
-from .tokenizing import (
+from howso.utilities.internals import deserialize_to_dataframe, IgnoreWarnings, to_pandas_datetime_format
+from howso.utilities.tokenizing import (
     HowsoTokenizer,
     TokenizerProtocol,
 )
-from .utilities import (
+from howso.utilities.utilities import (
     DATETIME_TIMEZONE_PATTERN,
     destringify_json,
     LocaleOverride,

--- a/howso/utilities/internals.py
+++ b/howso/utilities/internals.py
@@ -6,7 +6,7 @@ Notice: These are internal utilities and are not intended to be
 """
 from __future__ import annotations
 
-from collections import OrderedDict, deque
+from collections import deque, OrderedDict
 from collections.abc import Callable, Collection, Generator, Iterable, Mapping
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from copy import deepcopy
@@ -28,7 +28,7 @@ import numpy as np
 import pandas as pd
 from semantic_version import Version
 
-from .monitors import ProgressTimer
+from howso.utilities.monitors import ProgressTimer
 
 logger = logging.getLogger(__name__)
 

--- a/howso/utilities/tests/test_features.py
+++ b/howso/utilities/tests/test_features.py
@@ -19,9 +19,8 @@ from howso.engine import Trainee
 from howso.utilities import infer_feature_attributes
 from howso.utilities.features import FeatureSerializer, FeatureType
 from howso.utilities.internals import sanitize_for_json
+from howso.utilities.tests import has_locales
 from howso.utilities.utilities import LocaleOverride
-
-from . import has_locales
 
 cwd = Path(__file__).parent.parent.parent
 monk_path = Path(cwd, 'utilities', 'tests', 'data', 'monk1.csv')

--- a/howso/utilities/tests/test_utilities.py
+++ b/howso/utilities/tests/test_utilities.py
@@ -10,6 +10,7 @@ import pandas as pd
 from pandas.testing import assert_frame_equal
 import pytest
 
+import howso.utilities as utils
 from howso.utilities import (
     format_confusion_matrix,
     get_hash,
@@ -18,9 +19,7 @@ from howso.utilities import (
     LocaleOverride,
     matrix_processing,
 )
-import howso.utilities as utils
-
-from . import has_locales
+from howso.utilities.tests import has_locales
 
 
 @pytest.mark.skipif(

--- a/howso/utilities/utilities.py
+++ b/howso/utilities/utilities.py
@@ -39,8 +39,8 @@ import mmh3
 import numpy as np
 import pandas as pd
 
-from .internals import serialize_models
-from .tokenizing import TokenizerProtocol
+from howso.utilities.internals import serialize_models
+from howso.utilities.tokenizing import TokenizerProtocol
 
 if TYPE_CHECKING:
     from howso.client.typing import NormalizeMethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,11 @@ dev = [
     "pipdeptree",
     "pycodestyle",
     "pylint",
-    "pytest<8.0",
+    "pytest<10.0",
     "pytest-cov",
     "pytest-xdist",
     "pytest-mock~=1.0,<1.14.0",
+    "ruff~=0.11.0",
 ]
 no-telemetry = [
         "howso-engine-no-telemetry",

--- a/requirements-3.11-dev.txt
+++ b/requirements-3.11-dev.txt
@@ -16,11 +16,11 @@ certifi==2026.6.17
     #   requests
 charset-normalizer==3.4.7
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   pip-tools
     #   sacremoses
-coverage[toml]==7.14.2
+coverage[toml]==7.14.3
     # via pytest-cov
 dill==0.4.1
     # via
@@ -102,14 +102,16 @@ pydocstyle==6.3.0
 pyflakes==2.3.1
     # via flake8
 pygments==2.20.0
-    # via rich
+    # via
+    #   pytest
+    #   rich
 pylint==4.0.6
     # via howso-engine (pyproject.toml)
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==7.4.4
+pytest==9.1.1
     # via
     #   howso-engine (pyproject.toml)
     #   pytest-cov
@@ -131,11 +133,13 @@ pytz==2026.2
     #   pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
-regex==2026.5.9
+regex==2026.6.28
     # via sacremoses
 requests==2.34.2
     # via howso-engine (pyproject.toml)
 rich==15.0.0
+    # via howso-engine (pyproject.toml)
+ruff==0.11.13
     # via howso-engine (pyproject.toml)
 sacremoses==0.1.1
     # via howso-engine (pyproject.toml)

--- a/requirements-3.11.txt
+++ b/requirements-3.11.txt
@@ -12,7 +12,7 @@ certifi==2026.6.17
     #   requests
 charset-normalizer==3.4.7
     # via requests
-click==8.4.1
+click==8.4.2
     # via sacremoses
 faker==40.23.0
     # via howso-engine (pyproject.toml)
@@ -48,7 +48,7 @@ pytz==2026.2
     # via pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
-regex==2026.5.9
+regex==2026.6.28
     # via sacremoses
 requests==2.34.2
     # via howso-engine (pyproject.toml)

--- a/requirements-3.12-dev.txt
+++ b/requirements-3.12-dev.txt
@@ -16,11 +16,11 @@ certifi==2026.6.17
     #   requests
 charset-normalizer==3.4.7
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   pip-tools
     #   sacremoses
-coverage[toml]==7.14.2
+coverage[toml]==7.14.3
     # via pytest-cov
 dill==0.4.1
     # via
@@ -102,14 +102,16 @@ pydocstyle==6.3.0
 pyflakes==2.3.1
     # via flake8
 pygments==2.20.0
-    # via rich
+    # via
+    #   pytest
+    #   rich
 pylint==4.0.6
     # via howso-engine (pyproject.toml)
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==7.4.4
+pytest==9.1.1
     # via
     #   howso-engine (pyproject.toml)
     #   pytest-cov
@@ -131,11 +133,13 @@ pytz==2026.2
     #   pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
-regex==2026.5.9
+regex==2026.6.28
     # via sacremoses
 requests==2.34.2
     # via howso-engine (pyproject.toml)
 rich==15.0.0
+    # via howso-engine (pyproject.toml)
+ruff==0.11.13
     # via howso-engine (pyproject.toml)
 sacremoses==0.1.1
     # via howso-engine (pyproject.toml)

--- a/requirements-3.12.txt
+++ b/requirements-3.12.txt
@@ -12,7 +12,7 @@ certifi==2026.6.17
     #   requests
 charset-normalizer==3.4.7
     # via requests
-click==8.4.1
+click==8.4.2
     # via sacremoses
 faker==40.23.0
     # via howso-engine (pyproject.toml)
@@ -48,7 +48,7 @@ pytz==2026.2
     # via pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
-regex==2026.5.9
+regex==2026.6.28
     # via sacremoses
 requests==2.34.2
     # via howso-engine (pyproject.toml)

--- a/requirements-3.13-dev.txt
+++ b/requirements-3.13-dev.txt
@@ -16,11 +16,11 @@ certifi==2026.6.17
     #   requests
 charset-normalizer==3.4.7
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   pip-tools
     #   sacremoses
-coverage[toml]==7.14.2
+coverage[toml]==7.14.3
     # via pytest-cov
 dill==0.4.1
     # via
@@ -102,14 +102,16 @@ pydocstyle==6.3.0
 pyflakes==2.3.1
     # via flake8
 pygments==2.20.0
-    # via rich
+    # via
+    #   pytest
+    #   rich
 pylint==4.0.6
     # via howso-engine (pyproject.toml)
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==7.4.4
+pytest==9.1.1
     # via
     #   howso-engine (pyproject.toml)
     #   pytest-cov
@@ -131,11 +133,13 @@ pytz==2026.2
     #   pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
-regex==2026.5.9
+regex==2026.6.28
     # via sacremoses
 requests==2.34.2
     # via howso-engine (pyproject.toml)
 rich==15.0.0
+    # via howso-engine (pyproject.toml)
+ruff==0.11.13
     # via howso-engine (pyproject.toml)
 sacremoses==0.1.1
     # via howso-engine (pyproject.toml)

--- a/requirements-3.13.txt
+++ b/requirements-3.13.txt
@@ -12,7 +12,7 @@ certifi==2026.6.17
     #   requests
 charset-normalizer==3.4.7
     # via requests
-click==8.4.1
+click==8.4.2
     # via sacremoses
 faker==40.23.0
     # via howso-engine (pyproject.toml)
@@ -48,7 +48,7 @@ pytz==2026.2
     # via pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
-regex==2026.5.9
+regex==2026.6.28
     # via sacremoses
 requests==2.34.2
     # via howso-engine (pyproject.toml)

--- a/requirements-3.14-dev.txt
+++ b/requirements-3.14-dev.txt
@@ -16,11 +16,11 @@ certifi==2026.6.17
     #   requests
 charset-normalizer==3.4.7
     # via requests
-click==8.4.1
+click==8.4.2
     # via
     #   pip-tools
     #   sacremoses
-coverage[toml]==7.14.2
+coverage[toml]==7.14.3
     # via pytest-cov
 dill==0.4.1
     # via
@@ -102,14 +102,16 @@ pydocstyle==6.3.0
 pyflakes==2.3.1
     # via flake8
 pygments==2.20.0
-    # via rich
+    # via
+    #   pytest
+    #   rich
 pylint==4.0.6
     # via howso-engine (pyproject.toml)
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==7.4.4
+pytest==9.1.1
     # via
     #   howso-engine (pyproject.toml)
     #   pytest-cov
@@ -131,11 +133,13 @@ pytz==2026.2
     #   pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
-regex==2026.5.9
+regex==2026.6.28
     # via sacremoses
 requests==2.34.2
     # via howso-engine (pyproject.toml)
 rich==15.0.0
+    # via howso-engine (pyproject.toml)
+ruff==0.11.13
     # via howso-engine (pyproject.toml)
 sacremoses==0.1.1
     # via howso-engine (pyproject.toml)

--- a/requirements-3.14.txt
+++ b/requirements-3.14.txt
@@ -12,7 +12,7 @@ certifi==2026.6.17
     #   requests
 charset-normalizer==3.4.7
     # via requests
-click==8.4.1
+click==8.4.2
     # via sacremoses
 faker==40.23.0
     # via howso-engine (pyproject.toml)
@@ -48,7 +48,7 @@ pytz==2026.2
     # via pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
-regex==2026.5.9
+regex==2026.6.28
     # via sacremoses
 requests==2.34.2
     # via howso-engine (pyproject.toml)


### PR DESCRIPTION
Relative imports are not compatible with `pytest>8.0`, and violate our `ruff` config.