### PR TITLE
25776: Adds missing parameters around `preserve_rare_values` to time series IFA, MINOR

### DIFF
--- a/howso/client/typing.py
+++ b/howso/client/typing.py
@@ -265,7 +265,7 @@ class FeatureRareValueConfig(TypedDict):
     """The case-weight multiplier applied to all non-protected values of the feature."""
 
 
-class DeferredRareValueConfig(TypedDict):
+class DeferredFeatureValueConfig(TypedDict):
     """
     Rare values marked for protection whose case-weight multipliers are not yet computed.
 
@@ -507,7 +507,7 @@ class FeatureAttributes(TypedDict):
     post_process: NotRequired[str]
     """Custom Amalgam code that is called on resulting values of this feature during react operations."""
 
-    preserve_rare_values: NotRequired[FeatureRareValueConfig | DeferredRareValueConfig]
+    preserve_rare_values: NotRequired[FeatureRareValueConfig | DeferredFeatureValueConfig]
     """
     Configuration for preserving rare values during data distillation.
 

--- a/howso/client/typing.py
+++ b/howso/client/typing.py
@@ -262,12 +262,7 @@ class FeatureRareValueConfig(TypedDict):
     """The protected values and their individual case-weight multipliers."""
 
     unprotected_multiplier: NotRequired[float]
-    """
-    The case-weight multiplier applied to all non-protected values of the feature.
-
-    Optional on input: if omitted from a user-provided configuration, it is computed
-    automatically from the protected multipliers.
-    """
+    """The case-weight multiplier applied to all non-protected values of the feature."""
 
 
 class DeferredRareValueConfig(TypedDict):

--- a/howso/client/typing.py
+++ b/howso/client/typing.py
@@ -245,6 +245,31 @@ class FeatureTimeSeries(TypedDict, total=False):
     the default.
     """
 
+class ProtectedValueMultiplier(TypedDict):
+    """A single protected value paired with its case-weight multiplier."""
+
+    value: Any
+    """The feature value to protect during data distillation."""
+
+    multiplier: float
+    """The case-weight multiplier applied to cases holding this value."""
+
+
+class FeatureRareValueConfig(TypedDict):
+    """A rare-value preservation configuration for a single feature."""
+
+    protected_values_multipliers: list[ProtectedValueMultiplier]
+    """The protected values and their individual case-weight multipliers."""
+
+    unprotected_multiplier: NotRequired[float]
+    """
+    The case-weight multiplier applied to all non-protected values of the feature.
+
+    Optional on input: if omitted from a user-provided configuration, it is computed
+    automatically from the protected multipliers.
+    """
+
+
 class FeatureAttributes(TypedDict):
     """
     Attributes for a single feature.
@@ -553,6 +578,15 @@ PathLike: TypeAlias = Union[str, os.PathLike]
 
 Persistence: TypeAlias = Literal["allow", "always", "never"]
 """Valid values for ``persistence`` parameters."""
+
+PreserveRareValuesMap: TypeAlias = dict[str, list[Any]]
+"""Map of feature name to a list of values to protect during data distillation."""
+
+PreserveRareValuesConfig: TypeAlias = dict[str, list[ProtectedValueMultiplier]]
+"""Map of feature name to a list of protected values with case-weight multipliers."""
+
+FullPreserveRareValuesConfig: TypeAlias = dict[str, FeatureRareValueConfig]
+"""Map of feature name to a complete rare-value configuration (protected and unprotected multipliers)."""
 
 Precision: TypeAlias = Literal["exact", "similar"]
 """Valid values for ``precision`` parameters."""

--- a/howso/client/typing.py
+++ b/howso/client/typing.py
@@ -270,6 +270,19 @@ class FeatureRareValueConfig(TypedDict):
     """
 
 
+class DeferredRareValueConfig(TypedDict):
+    """
+    Rare values marked for protection whose case-weight multipliers are not yet computed.
+
+    Written to a feature's ``preserve_rare_values`` attribute when protected values are
+    supplied without a ``max_distilled_cases`` value; the multipliers are resolved later
+    in the stack.
+    """
+
+    protected_values: list[Any]
+    """The feature values to protect during data distillation."""
+
+
 class FeatureAttributes(TypedDict):
     """
     Attributes for a single feature.
@@ -499,8 +512,13 @@ class FeatureAttributes(TypedDict):
     post_process: NotRequired[str]
     """Custom Amalgam code that is called on resulting values of this feature during react operations."""
 
-    preserve_rare_values: NotRequired[dict[str, Any]]
-    """Configuration for preserving rare values during data distillation."""
+    preserve_rare_values: NotRequired[FeatureRareValueConfig | DeferredRareValueConfig]
+    """
+    Configuration for preserving rare values during data distillation.
+
+    Either a fully-computed config with case-weight multipliers, or a deferred config
+    listing only the protected values (when multipliers have not yet been computed).
+    """
 
     recursive_matching: NotRequired[bool]
     """

--- a/howso/client/typing.py
+++ b/howso/client/typing.py
@@ -474,6 +474,9 @@ class FeatureAttributes(TypedDict):
     post_process: NotRequired[str]
     """Custom Amalgam code that is called on resulting values of this feature during react operations."""
 
+    preserve_rare_values: NotRequired[dict[str, Any]]
+    """Configuration for preserving rare values during data distillation."""
+
     recursive_matching: NotRequired[bool]
     """
     Whether operations work recursively on feature values.

--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -25,13 +25,8 @@ from howso.utilities.feature_attributes.serializers import feature_attributes_pa
 from howso.utilities.feature_attributes.suggestions import (
     FanoutFeaturesMap,
     FanoutFeaturesSuggestion,
-    FeatureRareValueConfig,
-    FullPreserveRareValuesConfig,
     IFASuggestion,
     IFASuggestionCollector,
-    PreserveRareValuesConfig,
-    PreserveRareValuesMap,
-    ProtectedValueMultiplier,
     PRVSuggestion,
 )
 from howso.utilities.feature_attributes.warnings import IFAWarningCollector, IFAWarningEmitterType
@@ -44,7 +39,14 @@ from howso.utilities.utilities import (
 )
 
 if t.TYPE_CHECKING:
-    from howso.client.typing import FeatureAttributes
+    from howso.client.typing import (
+        FeatureAttributes,
+        FeatureRareValueConfig,
+        FullPreserveRareValuesConfig,
+        PreserveRareValuesConfig,
+        PreserveRareValuesMap,
+        ProtectedValueMultiplier,
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/howso/utilities/feature_attributes/base.py
+++ b/howso/utilities/feature_attributes/base.py
@@ -25,11 +25,13 @@ from howso.utilities.feature_attributes.serializers import feature_attributes_pa
 from howso.utilities.feature_attributes.suggestions import (
     FanoutFeaturesMap,
     FanoutFeaturesSuggestion,
+    FeatureRareValueConfig,
     FullPreserveRareValuesConfig,
     IFASuggestion,
     IFASuggestionCollector,
     PreserveRareValuesConfig,
     PreserveRareValuesMap,
+    ProtectedValueMultiplier,
     PRVSuggestion,
 )
 from howso.utilities.feature_attributes.warnings import IFAWarningCollector, IFAWarningEmitterType
@@ -1175,7 +1177,8 @@ class InferFeatureAttributesBase(ABC):
         # If not provided, infer them and issue a suggestion (unless suggestions are disabled)
         elif enable_suggestions:
             candidate_fanout = infer_fanout_feature_config(self.attributes, self.data, max_rows=self.max_rows_to_eval)
-            self.suggestions_collector.append(FanoutFeaturesSuggestion(candidate_fanout))
+            if candidate_fanout:
+                self.suggestions_collector.append(FanoutFeaturesSuggestion(candidate_fanout))
 
         # Compute or suggest `preserve_rare_values` configuration
         self._process_rare_values(preserve_rare_values_map, preserve_rare_values_config, max_distilled_cases,
@@ -1878,7 +1881,8 @@ class InferFeatureAttributesBase(ABC):
         top_five = sorted(value_counts, key=lambda d: d["count"], reverse=True)[:5]
         return pvm, top_five
 
-    def _compute_unprotected_multiplier(self, feature: str, protected_values_multipliers: Sequence[dict[str, t.Any]],
+    def _compute_unprotected_multiplier(self, feature: str,
+                                        protected_values_multipliers: Sequence[ProtectedValueMultiplier],
                                         *, row_count: int | None = None) -> float:
         """
         Compute the unprotected multiplier for the provided feature given a list of rare values with multipliers.
@@ -1947,9 +1951,9 @@ class InferFeatureAttributesBase(ABC):
             preserve_rare_values_map, _ = self._find_protected_value_candidates(max_distilled_cases,
                                                                                 significance_threshold)
         for feature, values in preserve_rare_values_map.items():
-            prvc[feature] = {"protected_values_multipliers": []}
             total_cases = self._get_row_count()
             data_type = self.attributes[feature]["data_type"] # pyright: ignore[reportTypedDictNotRequiredAccess]
+            protected_values_multipliers: list[ProtectedValueMultiplier] = []
             for value in values:
                 count = self._get_value_count(feature, value)
                 if count == 0:
@@ -1960,19 +1964,27 @@ class InferFeatureAttributesBase(ABC):
                 # If a value has a computed multiplier of < 1, it does not need signal preservation
                 if multiplier < 1:
                     continue
-                prvc[feature]["protected_values_multipliers"].append(
+                protected_values_multipliers.append(
                     {"value": float(value) if data_type == "number" else value,
                     "multiplier": max(float(multiplier), 1)}
                 )
             # Now that all protected value multipliers have been computed, determine the unprotected value multiplier
-            prvc[feature]["unprotected_multiplier"] = self._compute_unprotected_multiplier(
-                feature, prvc[feature]["protected_values_multipliers"], row_count=total_cases
-            )
+            prvc[feature] = {
+                "protected_values_multipliers": protected_values_multipliers,
+                "unprotected_multiplier": self._compute_unprotected_multiplier(
+                    feature, protected_values_multipliers, row_count=total_cases
+                ),
+            }
         return prvc
 
-    def _process_rare_values(self, preserve_rare_values_map: PreserveRareValuesMap | t.Literal["all", "off"] | None,  # noqa: PLR0912, PLR0915
-                             preserve_rare_values_config: PreserveRareValuesConfig | None, max_distilled_cases: int,
-                             significance_threshold: int, enable_suggestions: bool = True) -> None:
+    def _process_rare_values(  # noqa: PLR0912, PLR0915
+        self,
+        preserve_rare_values_map: PreserveRareValuesMap | t.Literal["all", "off"] | None,
+        preserve_rare_values_config: PreserveRareValuesConfig | FullPreserveRareValuesConfig | None,
+        max_distilled_cases: int,
+        significance_threshold: int,
+        enable_suggestions: bool = True,
+    ) -> None:
         """Procesess `preserve_rare_values` configuration or make recommendation."""
         _prvc: FullPreserveRareValuesConfig = {}
         # Did the user specify max_distilled_cases? Save this information for later.
@@ -2012,17 +2024,22 @@ class InferFeatureAttributesBase(ABC):
                                                "will be ignored.")
             # Config provided; check if unprotected multipliers need computation
             for feature, cfg in preserve_rare_values_config.items():
-                feature_full_config = {}
+                feature_full_config: FeatureRareValueConfig
                 if not isinstance(cfg, Mapping):
-                    # Workflow 1A: User provided a "simple" config (Mapping of feature names to list of rare values)
-                    feature_full_config["protected_values_multipliers"] = deepcopy(cfg)
+                    # Workflow 1A: User provided a "simple" config (feature name to list of protected values)
+                    protected_values_multipliers = deepcopy(cfg)
+                    feature_full_config = {
+                        "protected_values_multipliers": protected_values_multipliers,
+                        "unprotected_multiplier": self._compute_unprotected_multiplier(
+                            feature, protected_values_multipliers),
+                    }
                 else:
                     # Workflow 1B: User provided a "full" config with sub-keys (likely through the suggestion loop)
                     feature_full_config = deepcopy(cfg)
-                # In any case, ensure the unprotected multipliers are present
-                if "unprotected_multiplier" not in feature_full_config:
-                    feature_full_config["unprotected_multiplier"] = self._compute_unprotected_multiplier(feature,
-                                                                                                         feature_full_config["protected_values_multipliers"])
+                    # Ensure the unprotected multiplier is present
+                    if "unprotected_multiplier" not in feature_full_config:
+                        feature_full_config["unprotected_multiplier"] = self._compute_unprotected_multiplier(
+                            feature, feature_full_config["protected_values_multipliers"])
                 _prvc[feature] = feature_full_config
         # Workflow 2: User provided a map of rare values to protect, but no multipliers
         elif preserve_rare_values_map is not None:

--- a/howso/utilities/feature_attributes/infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/infer_feature_attributes.py
@@ -252,10 +252,11 @@ def infer_feature_attributes(data: pd.DataFrame | IFACompatibleADCProtocol | SQL
         the format that can be expected if your `preserve_rare_values_config` comes from a
         suggestion after calling `infer_feature_attributes`.
 
-    preserve_rare_values_map : dict or "all", default None
+    preserve_rare_values_map : dict, "all", or "off", default None
         (Optional) A map of feature name to list of values that should be protected during data
         distillation. If set to "all", will infer and attempt to preserve all detected rare
-        values.
+        values. If set to "off", rare value preservation is disabled entirely, including its
+        automatic suggestion.
 
     rate_boundaries : dict, default None
         (Optional) For time series, specify the rate boundaries in the form

--- a/howso/utilities/feature_attributes/infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/infer_feature_attributes.py
@@ -252,7 +252,7 @@ def infer_feature_attributes(data: pd.DataFrame | IFACompatibleADCProtocol | SQL
         the format that can be expected if your `preserve_rare_values_config` comes from a
         suggestion after calling `infer_feature_attributes`.
 
-    preserve_rare_values_map : dict, "all", or "off", default None
+    preserve_rare_values_map : dict or "all" or "off", default None
         (Optional) A map of feature name to list of values that should be protected during data
         distillation. If set to "all", will infer and attempt to preserve all detected rare
         values. If set to "off", rare value preservation is disabled entirely, including its

--- a/howso/utilities/feature_attributes/suggestions.py
+++ b/howso/utilities/feature_attributes/suggestions.py
@@ -1,41 +1,20 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 import textwrap
-from typing import Any, TypedDict
+from typing import Any, Self, TYPE_CHECKING
 import warnings
 
 from rich.console import Console
 from rich.table import Table
-from typing import Self
+
+if TYPE_CHECKING:
+    from howso.client.typing import FullPreserveRareValuesConfig, PreserveRareValuesMap
 
 # Fanout features parameters
 # --------------------------
 FanoutFeaturesMap = dict[tuple[str, ...] | str, list[str]]
-
-# Signal preservation parameters
-# ------------------------------
-
-
-class ProtectedValueMultiplier(TypedDict):
-    """A single protected value paired with its case-weight multiplier."""
-
-    value: Any
-    multiplier: float
-
-
-class FeatureRareValueConfig(TypedDict):
-    """A "complete" rare-value configuration for a single feature: protected *and* unprotected multipliers."""
-
-    protected_values_multipliers: list[ProtectedValueMultiplier]
-    unprotected_multiplier: float
-
-
-# Provided by the user to specify values to protect, multipliers must be computed automatically
-PreserveRareValuesMap = dict[str, list[Any]]
-# Provided by the user to specify values to protect *with* multipliers, must only compute unprotected multipliers
-PreserveRareValuesConfig = dict[str, list[ProtectedValueMultiplier]]
-# Used internally to represent a "complete" configuration with protected *and* unprotected multipliers
-FullPreserveRareValuesConfig = dict[str, FeatureRareValueConfig]
 
 
 def wrap_text(text: str, width: int) -> str:

--- a/howso/utilities/feature_attributes/suggestions.py
+++ b/howso/utilities/feature_attributes/suggestions.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 import textwrap
-from typing import Any, cast
+from typing import Any, TypedDict
 import warnings
 
 from rich.console import Console
@@ -14,12 +14,28 @@ FanoutFeaturesMap = dict[tuple[str, ...] | str, list[str]]
 
 # Signal preservation parameters
 # ------------------------------
+
+
+class ProtectedValueMultiplier(TypedDict):
+    """A single protected value paired with its case-weight multiplier."""
+
+    value: Any
+    multiplier: float
+
+
+class FeatureRareValueConfig(TypedDict):
+    """A "complete" rare-value configuration for a single feature: protected *and* unprotected multipliers."""
+
+    protected_values_multipliers: list[ProtectedValueMultiplier]
+    unprotected_multiplier: float
+
+
 # Provided by the user to specify values to protect, multipliers must be computed automatically
 PreserveRareValuesMap = dict[str, list[Any]]
 # Provided by the user to specify values to protect *with* multipliers, must only compute unprotected multipliers
-PreserveRareValuesConfig = dict[str, list[dict[str, Any]]]
+PreserveRareValuesConfig = dict[str, list[ProtectedValueMultiplier]]
 # Used internally to represent a "complete" configuration with protected *and* unprotected multipliers
-FullPreserveRareValuesConfig = dict[str, dict[str, list[dict[str, Any]] | float]]
+FullPreserveRareValuesConfig = dict[str, FeatureRareValueConfig]
 
 
 def wrap_text(text: str, width: int) -> str:
@@ -227,7 +243,7 @@ class PRVSuggestion(IFASuggestion):
     def __repr__(self) -> str:
         """Print a helpful description of this IFASuggestion."""
         num_candidates = sum(
-            len(cast(list[dict[str, Any]], cfg["protected_values_multipliers"]))
+            len(cfg["protected_values_multipliers"])
             for cfg in self._prvc.values()
         )
         candidates_explanation = ""
@@ -366,7 +382,7 @@ class PRVSuggestion(IFASuggestion):
             )
         values_map = {}
         for feature, config in self._prvc.items():
-            multipliers = cast(list[dict[str, Any]], config["protected_values_multipliers"])
+            multipliers = config["protected_values_multipliers"]
             values_map[feature] = [value_config["value"] for value_config in multipliers]
         return values_map
 

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes.py
@@ -1323,12 +1323,15 @@ def test_infer_fanout_features():
 
 
 def test_infer_fanout_features_ignores_constant_columns():
-    """Globally-constant columns must not produce fan-out levels or trip the strict-tree warning.
+    """Globally-constant columns must not produce fan-out suggestions or trip the strict-tree warning.
 
     A constant column is functionally determined by every key, so prior to the
     fix it attached to every key's fan-out set -- manufacturing sibling levels
     that violate the strict-subset-chain assumption (emitting a misleading
     "strict-tree" warning) and listing the constant itself as a fan-out feature.
+    Once the constant column is correctly excluded, this data has no genuine
+    fan-out structure, so no fan-out suggestion (and thus no suggestion warning)
+    should be produced.
     """
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
@@ -1339,15 +1342,17 @@ def test_infer_fanout_features_ignores_constant_columns():
         f"unexpected strict-tree warning(s): {[str(w.message) for w in strict_tree]}"
     )
 
-    # The constant column must never be configured as a fan-out feature.
-    fof_map = features.suggestions.fanout_features.get_fanout_feature_map()
-    assert "const_col" not in fof_map
-    assert all("const_col" not in cols for cols in fof_map.values())
+    # The constant column is the only fan-out candidate and is correctly excluded, so
+    # no fan-out suggestion should be produced -- and therefore no suggestion warning.
+    assert "fanout_features" not in features.suggestions.suggestions
+    suggestion_warnings = [w for w in record if "one or more suggestions" in str(w.message)]
+    assert not suggestion_warnings, (
+        f"unexpected suggestion warning(s): {[str(w.message) for w in suggestion_warnings]}"
+    )
 
-    features.apply_suggestion("fanout_features")
-    assert "fanout_on" not in features["const_col"]
+    # No feature should be configured as a fan-out feature, least of all the constant column.
     for feat in fanout_constant_df.columns:
-        assert "const_col" not in features[feat].get("fanout_on", [])
+        assert "fanout_on" not in features[feat]
 
 
 def test_enable_suggestions_false():

--- a/howso/utilities/feature_attributes/tests/test_infer_feature_attributes_adc.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_feature_attributes_adc.py
@@ -837,12 +837,15 @@ def test_infer_fanout_features(adc):
     ("DataFrameData", pd.DataFrame()),
 ], indirect=True)
 def test_infer_fanout_features_ignores_constant_columns(adc):
-    """Globally-constant columns must not produce fan-out levels or trip the strict-tree warning.
+    """Globally-constant columns must not produce fan-out suggestions or trip the strict-tree warning.
 
     A constant column is functionally determined by every key, so prior to the
     fix it attached to every key's fan-out set -- manufacturing sibling levels
     that violate the strict-subset-chain assumption (emitting a misleading
     "strict-tree" warning) and listing the constant itself as a fan-out feature.
+    Once the constant column is correctly excluded, this data has no genuine
+    fan-out structure, so no fan-out suggestion (and thus no suggestion warning)
+    should be produced.
     """
     convert_data(DataFrameData(fanout_constant_df), adc)
     with warnings.catch_warnings(record=True) as record:
@@ -854,15 +857,17 @@ def test_infer_fanout_features_ignores_constant_columns(adc):
         f"unexpected strict-tree warning(s): {[str(w.message) for w in strict_tree]}"
     )
 
-    # The constant column must never be configured as a fan-out feature.
-    fof_map = features.suggestions.fanout_features.get_fanout_feature_map()
-    assert "const_col" not in fof_map
-    assert all("const_col" not in cols for cols in fof_map.values())
+    # The constant column is the only fan-out candidate and is correctly excluded, so
+    # no fan-out suggestion should be produced -- and therefore no suggestion warning.
+    assert "fanout_features" not in features.suggestions.suggestions
+    suggestion_warnings = [w for w in record if "one or more suggestions" in str(w.message)]
+    assert not suggestion_warnings, (
+        f"unexpected suggestion warning(s): {[str(w.message) for w in suggestion_warnings]}"
+    )
 
-    features.apply_suggestion("fanout_features")
-    assert "fanout_on" not in features["const_col"]
+    # No feature should be configured as a fan-out feature, least of all the constant column.
     for feat in fanout_constant_df.columns:
-        assert "const_col" not in features[feat].get("fanout_on", [])
+        assert "fanout_on" not in features[feat]
 
 
 @pytest.mark.parametrize("adc", [

--- a/howso/utilities/feature_attributes/tests/test_infer_time_series_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_time_series_attributes.py
@@ -570,6 +570,49 @@ def test_time_series_suggestions_collector_is_attached():
     assert isinstance(features.suggestions, IFASuggestionCollector)
 
 
+def test_preserve_rare_values_time_series():
+    """The rare-value distillation params are accepted and applied on the time series IFA path."""
+    rng = np.random.default_rng(0)
+    n_series, n_steps = 20, 100
+    rows = []
+    for sid in range(n_series):
+        for t in range(n_steps):
+            rows.append({
+                "ID": f"s{sid}",
+                "date": float(t),
+                "value": float(rng.normal(100.0, 10.0)),
+                # "rare" is significant on its own (count >= significance_threshold) but
+                # would drop below it after distillation, making it a rare-value candidate.
+                "cat": rng.choice(["a", "b", "c", "rare"], p=[0.4, 0.3, 0.27, 0.03]),
+            })
+    df = pd.DataFrame(rows)
+
+    # preserve_rare_values_map="all" with max_distilled_cases computes multipliers.
+    # Previously these params raised a TypeError on the time series path.
+    features = infer_feature_attributes(
+        df,
+        time_feature_name="date",
+        id_feature_name="ID",
+        max_distilled_cases=500,
+        preserve_rare_values_map="all",
+        significance_threshold=25,
+        enable_suggestions=False,
+    )
+    assert "preserve_rare_values" in features["cat"]
+    assert "protected_values_multipliers" in features["cat"]["preserve_rare_values"]
+
+    # A pre-computed preserve_rare_values_config is applied as-is.
+    config = {"cat": [{"value": "rare", "multiplier": 5}]}
+    features = infer_feature_attributes(
+        df,
+        time_feature_name="date",
+        id_feature_name="ID",
+        preserve_rare_values_config=config,
+        enable_suggestions=False,
+    )
+    assert "preserve_rare_values" in features["cat"]
+
+
 def test_time_series_fanout_suggestions():
     """Fanout suggestions are accessible and applicable on the time series IFA path."""
     rng = np.random.default_rng(42)

--- a/howso/utilities/feature_attributes/time_series.py
+++ b/howso/utilities/feature_attributes/time_series.py
@@ -16,10 +16,19 @@ from pandas.core.dtypes.common import is_string_dtype
 import psutil
 
 from howso.utilities.feature_attributes.abstract_data import InferFeatureAttributesAbstractData
-from howso.utilities.feature_attributes.base import InferFeatureAttributesBase, SingleTableFeatureAttributes
+from howso.utilities.feature_attributes.base import (
+    InferFeatureAttributesBase,
+    SIGNIFICANT_THRESHOLD_DEFAULT,
+    SingleTableFeatureAttributes,
+)
 from howso.utilities.feature_attributes.pandas import InferFeatureAttributesDataFrame
 from howso.utilities.feature_attributes.protocols import IFACompatibleADCProtocol
-from howso.utilities.feature_attributes.suggestions import IFASuggestionCollector
+from howso.utilities.feature_attributes.suggestions import (
+    FullPreserveRareValuesConfig,
+    IFASuggestionCollector,
+    PreserveRareValuesConfig,
+    PreserveRareValuesMap,
+)
 from howso.utilities.feature_attributes.warnings import IFAWarningCollector
 from howso.utilities.utilities import (
     date_to_epoch,
@@ -359,6 +368,7 @@ class InferFeatureAttributesTimeSeries(ABC):
         include_sample: bool = False,
         infer_bounds: bool = True,
         lags: t.Optional[list | dict] = None,
+        max_distilled_cases: t.Optional[int] = None,
         max_workers: t.Optional[int] = None,
         memory_warning_threshold: t.Optional[int] = 512,
         mode_bound_features: t.Optional[Iterable[str]] = None,
@@ -366,7 +376,10 @@ class InferFeatureAttributesTimeSeries(ABC):
         num_lags: t.Optional[int | dict] = None,
         orders_of_derivatives: t.Optional[dict] = None,
         ordinal_feature_values: t.Optional[dict[str, list[str]]] = None,
+        preserve_rare_values_map: t.Optional[PreserveRareValuesMap | t.Literal["all", "off"]] = None,
+        preserve_rare_values_config: t.Optional[PreserveRareValuesConfig | FullPreserveRareValuesConfig] = None,
         rate_boundaries: t.Optional[dict] = None,
+        significance_threshold: int = SIGNIFICANT_THRESHOLD_DEFAULT,
         time_invariant_features: t.Optional[Iterable[str]] = None,
         tight_bounds: t.Optional[Iterable[str]] = None,
         time_feature_is_universal: t.Optional[bool] = None,
@@ -516,6 +529,13 @@ class InferFeatureAttributesTimeSeries(ABC):
                 case by holding the value of a feature from a previous time step.
                 These lag features allow for cases to hold more temporal information.
 
+        max_distilled_cases : int, default None
+            (Optional) The maximum target size of the data after distillation. If provided, allows for
+            a potentially more accurate suggestion of a `preserve_rare_values_map` configuration.
+
+            .. note ::
+                See also: `preserve_rare_values_map`.
+
         max_workers: int, default None
             If unset or set to None (recommended), let the ProcessPoolExecutor
             choose the best maximum number of process pool workers to process
@@ -574,6 +594,31 @@ class InferFeatureAttributesTimeSeries(ABC):
                     "size" : [ "small", "medium", "large", "huge" ]
                 }
 
+        preserve_rare_values_config : dict, default None
+            (Optional) A map of feature name to a list of dict specifying a protected value and
+            a case weight multiplier. Enables case weight rebalancing for data distillation workflows
+            such that protected values do not lose signal. Compute automatically by providing
+            a `preserve_rare_values_map` for a fine-grained selection of protected values.
+
+            Example::
+
+                {
+                    "feature_a": [
+                        {"value": "x", "multiplier": 3},
+                        {"value": "y", "multiplier": 150}
+                    ]
+                }
+
+            Alternatively, you may provide a "full" `preserve_rare_values_config` that specifies both
+            the "unprotected_multiplier" and "protected_values_multipliers" for each feature. This is
+            the format that can be expected if your `preserve_rare_values_config` comes from a
+            suggestion after calling `infer_feature_attributes`.
+
+        preserve_rare_values_map : dict or "all", default None
+            (Optional) A map of feature name to list of values that should be protected during data
+            distillation. If set to "all", will infer and attempt to preserve all detected rare
+            values.
+
         rate_boundaries : dict, default None
             (Optional) For time series, specify the rate boundaries in the form
             {"feature" : {"min|max" : {order : value}}}. Works with partial values
@@ -591,6 +636,10 @@ class InferFeatureAttributesTimeSeries(ABC):
                         }
                     }
                 }
+
+        significance_threshold : int, default 30
+            (Optional) After data distillation, the number of cases that are expected to result in a
+            signal for preserved rare values.
 
         tight_bounds: Iterable of str, default None
             (Optional) Set tight min and max bounds for the features
@@ -701,12 +750,16 @@ class InferFeatureAttributesTimeSeries(ABC):
             include_extended_nominal_probabilities=include_extended_nominal_probabilities,
             include_sample=include_sample,
             infer_bounds=infer_bounds,
+            max_distilled_cases=max_distilled_cases,
             max_workers=max_workers,
             memory_warning_threshold=memory_warning_threshold,
             mode_bound_features=mode_bound_features,
             nominal_substitution_config=nominal_substitution_config,
             num_series=num_series,
             ordinal_feature_values=ordinal_feature_values,
+            preserve_rare_values_map=preserve_rare_values_map,
+            preserve_rare_values_config=preserve_rare_values_config,
+            significance_threshold=significance_threshold,
             tight_bounds=set(tight_bounds) if tight_bounds else None,
             types=types,
         )

--- a/howso/utilities/feature_attributes/time_series.py
+++ b/howso/utilities/feature_attributes/time_series.py
@@ -614,10 +614,11 @@ class InferFeatureAttributesTimeSeries(ABC):
             the format that can be expected if your `preserve_rare_values_config` comes from a
             suggestion after calling `infer_feature_attributes`.
 
-        preserve_rare_values_map : dict or "all", default None
+        preserve_rare_values_map : dict, "all", or "off", default None
             (Optional) A map of feature name to list of values that should be protected during data
             distillation. If set to "all", will infer and attempt to preserve all detected rare
-            values.
+            values. If set to "off", rare value preservation is disabled entirely, including its
+            automatic suggestion.
 
         rate_boundaries : dict, default None
             (Optional) For time series, specify the rate boundaries in the form

--- a/howso/utilities/feature_attributes/time_series.py
+++ b/howso/utilities/feature_attributes/time_series.py
@@ -23,18 +23,20 @@ from howso.utilities.feature_attributes.base import (
 )
 from howso.utilities.feature_attributes.pandas import InferFeatureAttributesDataFrame
 from howso.utilities.feature_attributes.protocols import IFACompatibleADCProtocol
-from howso.utilities.feature_attributes.suggestions import (
-    FullPreserveRareValuesConfig,
-    IFASuggestionCollector,
-    PreserveRareValuesConfig,
-    PreserveRareValuesMap,
-)
+from howso.utilities.feature_attributes.suggestions import IFASuggestionCollector
 from howso.utilities.feature_attributes.warnings import IFAWarningCollector
 from howso.utilities.utilities import (
     date_to_epoch,
     is_valid_datetime_format,
     lazy_map,
 )
+
+if t.TYPE_CHECKING:
+    from howso.client.typing import (
+        FullPreserveRareValuesConfig,
+        PreserveRareValuesConfig,
+        PreserveRareValuesMap,
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/howso/utilities/feature_attributes/time_series.py
+++ b/howso/utilities/feature_attributes/time_series.py
@@ -614,7 +614,7 @@ class InferFeatureAttributesTimeSeries(ABC):
             the format that can be expected if your `preserve_rare_values_config` comes from a
             suggestion after calling `infer_feature_attributes`.
 
-        preserve_rare_values_map : dict, "all", or "off", default None
+        preserve_rare_values_map : dict or "all" or "off", default None
             (Optional) A map of feature name to list of values that should be protected during data
             distillation. If set to "all", will infer and attempt to preserve all detected rare
             values. If set to "off", rare value preservation is disabled entirely, including its


### PR DESCRIPTION
Also fixes a bug where an empty fanout feature configuration would always be suggested if no "real" candidate was found.