### PR TITLE
25709: Ensures `tokenize_strings` and related utility functions handle unexpected `None` values in feature attributes

### DIFF
--- a/howso/utilities/tests/test_utilities.py
+++ b/howso/utilities/tests/test_utilities.py
@@ -16,6 +16,7 @@ from howso.utilities import (
     get_hash,
     get_kwargs,
     get_optimized_max_chunk_size,
+    HowsoTokenizer,
     LocaleOverride,
     matrix_processing,
 )
@@ -672,16 +673,6 @@ def test_get_optimized_max_chunk_size(
         assert max_chunk_size < 2 * chunk_size <= 2 * max_chunk_size
 
 
-class _UpperTokenizer:
-    """Minimal tokenizer satisfying ``TokenizerProtocol`` for tests."""
-
-    def tokenize(self, text, **kwargs):
-        return text.upper().split()
-
-    def detokenize(self, tokens, **kwargs):
-        return " ".join(tokens)
-
-
 def test_tokenize_strings_null_original_type():
     """A tokenizable feature whose ``original_type`` is None must not raise."""
     cases = [["hello world"]]
@@ -690,7 +681,7 @@ def test_tokenize_strings_null_original_type():
     # chained ``.get`` calls with an AttributeError.
     feature_attributes = {"text": {"original_type": None}}
 
-    tokenize_strings(cases, features, feature_attributes, _UpperTokenizer())
+    tokenize_strings(cases, features, feature_attributes, HowsoTokenizer())
 
     # Without a resolvable ``tokenizable_string`` data_type, the case is left as-is.
     assert cases == [["hello world"]]

--- a/howso/utilities/tests/test_utilities.py
+++ b/howso/utilities/tests/test_utilities.py
@@ -20,6 +20,7 @@ from howso.utilities import (
     matrix_processing,
 )
 from howso.utilities.tests import has_locales
+from howso.utilities.utilities import tokenize_strings
 
 
 @pytest.mark.skipif(
@@ -669,3 +670,27 @@ def test_get_optimized_max_chunk_size(
     if respects_max:
         chunk_size = result[0]
         assert max_chunk_size < 2 * chunk_size <= 2 * max_chunk_size
+
+
+class _UpperTokenizer:
+    """Minimal tokenizer satisfying ``TokenizerProtocol`` for tests."""
+
+    def tokenize(self, text, **kwargs):
+        return text.upper().split()
+
+    def detokenize(self, tokens, **kwargs):
+        return " ".join(tokens)
+
+
+def test_tokenize_strings_null_original_type():
+    """A tokenizable feature whose ``original_type`` is None must not raise."""
+    cases = [["hello world"]]
+    features = ["text"]
+    # ``original_type`` present but set to None previously broke the None-safe
+    # chained ``.get`` calls with an AttributeError.
+    feature_attributes = {"text": {"original_type": None}}
+
+    tokenize_strings(cases, features, feature_attributes, _UpperTokenizer())
+
+    # Without a resolvable ``tokenizable_string`` data_type, the case is left as-is.
+    assert cases == [["hello world"]]

--- a/howso/utilities/utilities.py
+++ b/howso/utilities/utilities.py
@@ -839,7 +839,7 @@ def destringify_json(cases: pd.Series, feature_attributes: Mapping) -> pd.Series
         The feature attributes of the feature to which the provided cases belong.
     """
     destringified_cases = []
-    typing_info = feature_attributes.get("original_type", {})
+    typing_info = feature_attributes.get("original_type", {}) or {}
     for case_to_destringify in cases:
         if is_null_value(case_to_destringify):
             destringified_cases.append(None)
@@ -877,7 +877,8 @@ def tokenize_strings(
     if not isinstance(tokenizer, TokenizerProtocol):
         raise ValueError("The class provided under `token_processor` must satisfy the `TokenizerProtocol` protocol.")
     for idx, feature_name in enumerate(features):
-        if feature_attributes.get(feature_name, {}).get("original_type", {}).get("data_type") != "tokenizable_string":
+        orig_type = feature_attributes.get(feature_name, {}).get("original_type", {}) or {}
+        if orig_type.get("data_type") != "tokenizable_string":
             continue
         for case_group in cases:
             if is_null_value(case_group[idx]):


### PR DESCRIPTION
Fixes a small bug where an unexpected `None` in feature attributes broke nested uses of `.get()`.