### PR TITLE
25834: Updates dependencies and adds support for "contributions_context_features" to details dict on `react`, MAJOR

### DIFF
--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -1,10 +1,10 @@
 Faker
-40.35.0
+40.36.0
 MIT License
 joke2k
 https://github.com/joke2k/faker
 Faker is a Python package that generates fake data for you.
-/home/runner/.pyenv/versions/3.14.6/lib/python3.14/site-packages/faker-40.35.0.dist-info/licenses/LICENSE.txt
+/home/runner/.pyenv/versions/3.14.6/lib/python3.14/site-packages/faker-40.36.0.dist-info/licenses/LICENSE.txt
 Copyright (c) 2012 Daniele Faraglia
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -2817,12 +2817,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The above BSD License Applies to all code, even that also covered by Apache 2.0.
 
 pytz
-2026.2
+2026.3.post1
 MIT License
 Stuart Bishop
 http://pythonhosted.org/pytz
 World timezone definitions, modern and historical
-/home/runner/.pyenv/versions/3.14.6/lib/python3.14/site-packages/pytz-2026.2.dist-info/LICENSE.txt
+/home/runner/.pyenv/versions/3.14.6/lib/python3.14/site-packages/pytz-2026.3.post1.dist-info/LICENSE.txt
 Copyright (c) 2003-2019 Stuart Bishop <stuart@stuartbishop.net>
 
 Permission is hereby granted, free of charge, to any person obtaining a
@@ -3362,12 +3362,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 tqdm
-4.69.1
+4.70.0
 MPL-2.0 AND MIT
 UNKNOWN
 https://tqdm.github.io
 Fast, Extensible Progress Meter
-/home/runner/.pyenv/versions/3.14.6/lib/python3.14/site-packages/tqdm-4.69.1.dist-info/licenses/LICENCE
+/home/runner/.pyenv/versions/3.14.6/lib/python3.14/site-packages/tqdm-4.70.0.dist-info/licenses/LICENCE
 `tqdm` is a product of collaborative work.
 Unless otherwise stated, all authors (see commit logs) retain copyright
 for their respective work, and release the work under the MIT licence

--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -1881,6 +1881,10 @@ class AbstractHowsoClient(ABC):
             - categorical_action_probabilities : bool, optional
                 If True, outputs probabilities for each class for the action.
                 Applicable only to categorical action features.
+            - contributions_context_features : list of str, optional
+                A list of feature names that specifies which features are to be used as contexts when computing
+                contribution related details (distance_contribution, similarity_conviction, and residual_contribution).
+                When unspecified, both action and context features are used.
             - derivation_parameters : bool, optional
                 If True, outputs a dictionary of the parameters used in the
                 react call. These include k, p, distance_transform,

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -1471,6 +1471,10 @@ class Trainee(BaseTrainee):
             - categorical_action_probabilities : bool, optional
                 If True, outputs probabilities for each class for the action.
                 Applicable only to categorical action features.
+            - contributions_context_features : list of str, optional
+                A list of feature names that specifies which features are to be used as contexts when computing
+                contribution related details (distance_contribution, similarity_conviction, and residual_contribution).
+                When unspecified, both action and context features are used.
             - derivation_parameters : bool, optional
                 If True, outputs a dictionary of the parameters used in the
                 react call. These include k, p, distance_transform,

--- a/howso/scikit/scikit.py
+++ b/howso/scikit/scikit.py
@@ -679,6 +679,10 @@ class HowsoEstimator(BaseEstimator):
             - categorical_action_probabilities : bool, optional
                 If True, outputs probabilities for each class for the action.
                 Applicable only to categorical action features.
+            - contributions_context_features : list of str, optional
+                A list of feature names that specifies which features are to be used as contexts when computing
+                contribution related details (distance_contribution, similarity_conviction, and residual_contribution).
+                When unspecified, both action and context features are used.
             - derivation_parameters : bool, optional
                 If True, outputs a dictionary of the parameters used in the
                 react call. These include k, p, distance_transform,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "semantic-version~=2.0",
     "typing-extensions~=4.9",
     "urllib3>=2.6.3",
-    "amalgam-lang==34.2.1", # Use exact since Engine is exact in version.json
+    "amalgam-lang==34.2.2", # Use exact since Engine is exact in version.json
 ]
 
 [project.optional-dependencies]

--- a/requirements-3.11-dev.txt
+++ b/requirements-3.11-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --cert=None --client-cert=None --extra=dev --extra=scikit --index-url=None --no-emit-index-url --output-file=requirements-3.11-dev.txt --pip-args=None
 #
-amalgam-lang==34.2.1
+amalgam-lang==34.2.2
     # via howso-engine (pyproject.toml)
 astroid==4.0.4
     # via pylint
@@ -30,7 +30,7 @@ dill==0.4.1
     #   pylint
 execnet==2.1.2
     # via pytest-xdist
-faker==40.35.0
+faker==40.36.0
     # via howso-engine (pyproject.toml)
 flake8==3.9.2
     # via
@@ -140,7 +140,7 @@ python-dateutil==2.9.0.post0
     # via
     #   howso-engine (pyproject.toml)
     #   pandas
-pytz==2026.2
+pytz==2026.3.post1
     # via
     #   mongomock
     #   pandas
@@ -176,7 +176,7 @@ tomli-w==1.2.0
     # via nab-python
 tomlkit==0.15.1
     # via pylint
-tqdm==4.69.1
+tqdm==4.70.0
     # via sacremoses
 truststore==0.10.4
     # via nab-index
@@ -197,7 +197,7 @@ wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.2
+pip==26.2
     # via pip-tools
 setuptools==83.0.0
     # via

--- a/requirements-3.11.txt
+++ b/requirements-3.11.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --cert=None --client-cert=None --index-url=None --no-emit-index-url --output-file=requirements-3.11.txt --pip-args=None
 #
-amalgam-lang==34.2.1
+amalgam-lang==34.2.2
     # via howso-engine (pyproject.toml)
 certifi==2026.7.22
     # via
@@ -14,7 +14,7 @@ charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via sacremoses
-faker==40.35.0
+faker==40.36.0
     # via howso-engine (pyproject.toml)
 humanize==4.16.0
     # via howso-engine (pyproject.toml)
@@ -44,7 +44,7 @@ python-dateutil==2.9.0.post0
     # via
     #   howso-engine (pyproject.toml)
     #   pandas
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
@@ -60,7 +60,7 @@ semantic-version==2.10.0
     # via howso-engine (pyproject.toml)
 six==1.17.0
     # via python-dateutil
-tqdm==4.69.1
+tqdm==4.70.0
     # via sacremoses
 typing-extensions==4.16.0
     # via howso-engine (pyproject.toml)

--- a/requirements-3.12-dev.txt
+++ b/requirements-3.12-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --cert=None --client-cert=None --extra=dev --extra=scikit --index-url=None --no-emit-index-url --output-file=requirements-3.12-dev.txt --pip-args=None
 #
-amalgam-lang==34.2.1
+amalgam-lang==34.2.2
     # via howso-engine (pyproject.toml)
 astroid==4.0.4
     # via pylint
@@ -30,7 +30,7 @@ dill==0.4.1
     #   pylint
 execnet==2.1.2
     # via pytest-xdist
-faker==40.35.0
+faker==40.36.0
     # via howso-engine (pyproject.toml)
 flake8==3.9.2
     # via
@@ -140,7 +140,7 @@ python-dateutil==2.9.0.post0
     # via
     #   howso-engine (pyproject.toml)
     #   pandas
-pytz==2026.2
+pytz==2026.3.post1
     # via
     #   mongomock
     #   pandas
@@ -176,7 +176,7 @@ tomli-w==1.2.0
     # via nab-python
 tomlkit==0.15.1
     # via pylint
-tqdm==4.69.1
+tqdm==4.70.0
     # via sacremoses
 truststore==0.10.4
     # via nab-index
@@ -197,7 +197,7 @@ wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.2
+pip==26.2
     # via pip-tools
 setuptools==83.0.0
     # via

--- a/requirements-3.12.txt
+++ b/requirements-3.12.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --cert=None --client-cert=None --index-url=None --no-emit-index-url --output-file=requirements-3.12.txt --pip-args=None
 #
-amalgam-lang==34.2.1
+amalgam-lang==34.2.2
     # via howso-engine (pyproject.toml)
 certifi==2026.7.22
     # via
@@ -14,7 +14,7 @@ charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via sacremoses
-faker==40.35.0
+faker==40.36.0
     # via howso-engine (pyproject.toml)
 humanize==4.16.0
     # via howso-engine (pyproject.toml)
@@ -44,7 +44,7 @@ python-dateutil==2.9.0.post0
     # via
     #   howso-engine (pyproject.toml)
     #   pandas
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
@@ -60,7 +60,7 @@ semantic-version==2.10.0
     # via howso-engine (pyproject.toml)
 six==1.17.0
     # via python-dateutil
-tqdm==4.69.1
+tqdm==4.70.0
     # via sacremoses
 typing-extensions==4.16.0
     # via howso-engine (pyproject.toml)

--- a/requirements-3.13-dev.txt
+++ b/requirements-3.13-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --cert=None --client-cert=None --extra=dev --extra=scikit --index-url=None --no-emit-index-url --output-file=requirements-3.13-dev.txt --pip-args=None
 #
-amalgam-lang==34.2.1
+amalgam-lang==34.2.2
     # via howso-engine (pyproject.toml)
 astroid==4.0.4
     # via pylint
@@ -30,7 +30,7 @@ dill==0.4.1
     #   pylint
 execnet==2.1.2
     # via pytest-xdist
-faker==40.35.0
+faker==40.36.0
     # via howso-engine (pyproject.toml)
 flake8==3.9.2
     # via
@@ -140,7 +140,7 @@ python-dateutil==2.9.0.post0
     # via
     #   howso-engine (pyproject.toml)
     #   pandas
-pytz==2026.2
+pytz==2026.3.post1
     # via
     #   mongomock
     #   pandas
@@ -176,7 +176,7 @@ tomli-w==1.2.0
     # via nab-python
 tomlkit==0.15.1
     # via pylint
-tqdm==4.69.1
+tqdm==4.70.0
     # via sacremoses
 truststore==0.10.4
     # via nab-index
@@ -197,7 +197,7 @@ wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.2
+pip==26.2
     # via pip-tools
 setuptools==83.0.0
     # via

--- a/requirements-3.13.txt
+++ b/requirements-3.13.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --cert=None --client-cert=None --index-url=None --no-emit-index-url --output-file=requirements-3.13.txt --pip-args=None
 #
-amalgam-lang==34.2.1
+amalgam-lang==34.2.2
     # via howso-engine (pyproject.toml)
 certifi==2026.7.22
     # via
@@ -14,7 +14,7 @@ charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via sacremoses
-faker==40.35.0
+faker==40.36.0
     # via howso-engine (pyproject.toml)
 humanize==4.16.0
     # via howso-engine (pyproject.toml)
@@ -44,7 +44,7 @@ python-dateutil==2.9.0.post0
     # via
     #   howso-engine (pyproject.toml)
     #   pandas
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
@@ -60,7 +60,7 @@ semantic-version==2.10.0
     # via howso-engine (pyproject.toml)
 six==1.17.0
     # via python-dateutil
-tqdm==4.69.1
+tqdm==4.70.0
     # via sacremoses
 typing-extensions==4.16.0
     # via howso-engine (pyproject.toml)

--- a/requirements-3.14-dev.txt
+++ b/requirements-3.14-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --cert=None --client-cert=None --extra=dev --extra=scikit --index-url=None --no-emit-index-url --output-file=requirements-3.14-dev.txt --pip-args=None
 #
-amalgam-lang==34.2.1
+amalgam-lang==34.2.2
     # via howso-engine (pyproject.toml)
 astroid==4.0.4
     # via pylint
@@ -30,7 +30,7 @@ dill==0.4.1
     #   pylint
 execnet==2.1.2
     # via pytest-xdist
-faker==40.35.0
+faker==40.36.0
     # via howso-engine (pyproject.toml)
 flake8==3.9.2
     # via
@@ -140,7 +140,7 @@ python-dateutil==2.9.0.post0
     # via
     #   howso-engine (pyproject.toml)
     #   pandas
-pytz==2026.2
+pytz==2026.3.post1
     # via
     #   mongomock
     #   pandas
@@ -176,7 +176,7 @@ tomli-w==1.2.0
     # via nab-python
 tomlkit==0.15.1
     # via pylint
-tqdm==4.69.1
+tqdm==4.70.0
     # via sacremoses
 truststore==0.10.4
     # via nab-index
@@ -197,7 +197,7 @@ wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.2
+pip==26.2
     # via pip-tools
 setuptools==83.0.0
     # via

--- a/requirements-3.14.txt
+++ b/requirements-3.14.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --cert=None --client-cert=None --index-url=None --no-emit-index-url --output-file=requirements-3.14.txt --pip-args=None
 #
-amalgam-lang==34.2.1
+amalgam-lang==34.2.2
     # via howso-engine (pyproject.toml)
 certifi==2026.7.22
     # via
@@ -14,7 +14,7 @@ charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via sacremoses
-faker==40.35.0
+faker==40.36.0
     # via howso-engine (pyproject.toml)
 humanize==4.16.0
     # via howso-engine (pyproject.toml)
@@ -44,7 +44,7 @@ python-dateutil==2.9.0.post0
     # via
     #   howso-engine (pyproject.toml)
     #   pandas
-pytz==2026.2
+pytz==2026.3.post1
     # via pandas
 pyyaml==6.0.3
     # via howso-engine (pyproject.toml)
@@ -60,7 +60,7 @@ semantic-version==2.10.0
     # via howso-engine (pyproject.toml)
 six==1.17.0
     # via python-dateutil
-tqdm==4.69.1
+tqdm==4.70.0
     # via sacremoses
 typing-extensions==4.16.0
     # via howso-engine (pyproject.toml)

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "howso-engine": "116.4.1"
+    "howso-engine": "117.0.1"
   }
 }


### PR DESCRIPTION
This is a MAJOR because the details "non_clustered_distance_contribution" and "non_clustered_similarity_conviction" are no longer automatically returned when a case is clustered in `react`