### PR TITLE
25828: Updates and consolidates ADC protocols with missing functions/attributes

### DIFF
--- a/howso/utilities/fanout_features.py
+++ b/howso/utilities/fanout_features.py
@@ -718,7 +718,7 @@ def infer_fanout_feature_config(
 
     Parameters
     ----------
-    data : DataFrame or AbstractDataProtocol
+    data : DataFrame or IFACompatibleADCProtocol
         Howso data connector exposing ``yield_chunk()`` -- iterates DataFrames.
     features : Mapping[str, Any]
         Feature mapping in Howso's ``infer_feature_attributes`` format.

--- a/howso/utilities/feature_attributes/protocols.py
+++ b/howso/utilities/feature_attributes/protocols.py
@@ -55,12 +55,13 @@ class IFACompatibleADCProtocol(t.Protocol):
     """
     Protocol for an abstract data class object compatible with `infer_feature_attributes`.
 
-    An ADC is always the combination of the base abstract data class and the
-    IFA support mixin, so this protocol declares both sets of members as one
-    interface rather than splitting them the way the implementations do.
+    Since IFA requires functions declared both in the base `AbstractData` class
+    and the extended IFA support mixin, this protocol declares both sets of
+    members as one interface rather than splitting them like in the way the
+    are written.
 
-    Because this protocol is runtime-checkable, every member declared here is
-    required of any object that will be recognized as an ADC, so adding a
+    Also, because this protocol is runtime-checkable, every member declared here
+    is required of any object that will be recognized as an ADC, so adding a
     member raises the floor on which implementations still qualify. Only
     declare members that all IFA-compatible ADCs implement; members provided
     by a subset of backends (e.g. ``get_inspector``) belong on a narrower

--- a/howso/utilities/feature_attributes/protocols.py
+++ b/howso/utilities/feature_attributes/protocols.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Collection, Generator, Hashable, Iterable
+from collections.abc import (
+    Collection,
+    Generator,
+    Hashable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 import typing as t
 
 import pandas as pd
@@ -23,27 +31,8 @@ class SQLTableProtocol(t.Protocol):
     schema: str
 
 
-class SessionProtocol(t.Protocol):
-    """Protocol for a sqlalchemy Session object."""
-
-    @abstractmethod
-    def commit(self):
-        """Flush pending changes and commit the current transaction."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def close(self):
-        """Close out the transactional resources and ORM objects used by this Session."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def rollback(self):
-        """Rollback the current transaction in progress."""
-        raise NotImplementedError
-
-
 class AbstractDataProtocol(t.Protocol):
-    """Protocol for an abstract data file object."""
+    """Protocol for an abstract data class object."""
 
     @property
     def foreign_keys(self) -> str | Iterable[str] | None:
@@ -61,12 +50,21 @@ class AbstractDataProtocol(t.Protocol):
         raise NotImplementedError
 
     @property
-    def primary_keys(self) -> str | Iterable[str] | None:
+    def primary_keys(self) -> str | list[str] | None:
         """Return the primary key(s) of the table."""
         raise NotImplementedError
 
+    @property
+    def supports_non_nullable_columns(self) -> bool:
+        """Return whether this data source supports columns with nullable constraints."""
+        raise NotImplementedError
+
+    def finalize(self) -> None:
+        """Perform any final clean-up."""
+        raise NotImplementedError
+
     @abstractmethod
-    def get_row_count(self):
+    def get_row_count(self) -> int | None:
         """Get the number of rows in a file."""
         raise NotImplementedError
 
@@ -76,47 +74,93 @@ class AbstractDataProtocol(t.Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def get_group_map(self, column_name: Hashable) -> dict[t.Any, int]:
-        """Get the group map."""
+    def get_group_map(self, column_name: Hashable | Sequence[Hashable], *,
+                      seed: int | None = None
+                      ) -> dict[Hashable, int]:
+        """
+        Get a map of each unique value of `column_name` to its group number.
+
+        If a sequence of column names is provided, groups by the combination of
+        all specified columns.
+        """
         raise NotImplementedError
 
     @abstractmethod
-    def get_n_random_rows(self, samples: int, seed: t.Optional[int]) -> pd.DataFrame:
+    def get_n_random_rows(self, samples: int = 5000, seed: int | None = None) -> pd.DataFrame:
         """Get a specified number of random rows."""
         raise NotImplementedError
 
     @abstractmethod
     def write_chunk(self, chunk: pd.DataFrame, *,
-                    if_exists: str = "append"
+                    if_exists: t.Literal["fail", "replace", "append"] = "append"
                     ) -> None:
         """Write a chunk."""
         raise NotImplementedError
 
     @abstractmethod
+    def yield_variable_length_chunks(self, initial_chunk_size: int = 100, *,
+                                     maintain_natural_order: bool = False,
+                                     max_rows: int | None = None,
+                                     skip_rows: int = 0,
+                                     seed: int | None = None,
+                                     ) -> Generator[pd.DataFrame, int, None]:
+        """
+        Provide a bidirectional generator of variable-length chunks.
+
+        Call ``next(gen)`` or ``gen.send(None)`` for the first chunk; for each
+        subsequent chunk, ``gen.send(n)`` returns a chunk of length ``n``.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def yield_chunk(self, chunk_size: int = 5000, *,
-                    max_chunks: t.Optional[int] = None,
-                    skip_chunks: t.Optional[int] = None,
+                    max_chunks: int | None = None,
+                    skip_chunks: int | None = None,
                     maintain_natural_order: bool = False,
                     seed: int | None = None,
-                    ) -> Generator[pd.DataFrame, None, None]:
+                    ) -> Iterator[pd.DataFrame]:
         """Provide a chunk generator."""
         raise NotImplementedError
 
     @abstractmethod
-    def yield_grouped_chunk(self, column_name: Hashable,
-                            groups: Iterable[Iterable[t.Any]]
-                            ) -> Generator[pd.DataFrame, None, None]:
+    def yield_grouped_chunk(self, column_name: Hashable | Sequence[Hashable] | None,
+                            groups: Iterable[Iterable[t.Any]], *,
+                            feature_attributes: Mapping[Hashable, t.Any] | None,
+                            max_chunks: int | None = None,
+                            skip_chunks: int = 0,
+                            time_feature: str = "",
+                            ) -> Iterator[pd.DataFrame]:
         """Provide a grouped chunk generator."""
         raise NotImplementedError
 
-    @abstractmethod
-    def map_keys(self, chunk: pd.DataFrame) -> pd.DataFrame:
-        """Map keys to a chunk."""
+    def yield_grouped_chunk_with_lag_context(self, group_feature: Hashable | Sequence[Hashable],
+                                             groups: Iterable[Iterable[t.Any]], *,
+                                             id_feature_name: Hashable | Sequence[Hashable],
+                                             time_feature: str,
+                                             num_lags: int,
+                                             feature_attributes: Mapping[Hashable, t.Any] | None = None,
+                                             ) -> Iterator[pd.DataFrame]:
+        """
+        Provide a grouped chunk generator augmented with per-series lag context.
+
+        Not all data sources support this; those that do not raise
+        ``NotImplementedError``.
+        """
         raise NotImplementedError
 
     @abstractmethod
-    def get_unique_count(self, column_name: Hashable) -> int:
-        """Get the number of unique values in the provided column."""
+    def map_keys(self, chunk: pd.DataFrame) -> tuple[pd.DataFrame, dict[t.Any, dict[t.Any, list[t.Any]]]]:
+        """Map keys to a chunk, returning the updated chunk and the primary key map."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_unique_values(self, column_name: Hashable | Sequence[Hashable]) -> Collection[t.Any]:
+        """Return the set of unique values in the provided column(s)."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_unique_count(self, column_name: Hashable | Sequence[Hashable]) -> int:
+        """Get the number of unique values in the provided column(s)."""
 
     @abstractmethod
     def is_unique(self, column_name: Hashable) -> bool:
@@ -126,6 +170,16 @@ class AbstractDataProtocol(t.Protocol):
     def contains_nulls(self, column_name: Hashable) -> bool:
         """Return whether the given column contains any null values."""
 
+    def is_nullable_column(self, column_name: Hashable) -> bool:
+        """
+        Return whether the given column allows nulls per the source schema.
+
+        Unlike :meth:`contains_nulls`, which inspects the data itself, this
+        reports the column's declared nullability. Data sources that do not
+        constrain nullability report all columns nullable.
+        """
+        raise NotImplementedError
+
 
 @t.runtime_checkable
 class IFACompatibleADCProtocol(t.Protocol):
@@ -133,7 +187,27 @@ class IFACompatibleADCProtocol(t.Protocol):
     Protocol for an abstract data file object with extended functionality.
 
     Includes functions that make it compatible with `infer_feature_attributes`.
+    Because this protocol is runtime-checkable, every member declared here is
+    required of any object that will be recognized as an ADC. Only declare
+    members that all IFA-compatible ADCs implement; members provided by a
+    subset of backends (e.g. ``get_inspector``) belong on a narrower protocol
+    such as :class:`IFACompatibleSQLADCProtocol`.
     """
+
+    @property
+    @abstractmethod
+    def headers(self) -> list[str]:
+        """Return a list of the column names of the data."""
+
+    @property
+    def primary_keys(self) -> str | list[str] | None:
+        """Return the primary key(s) of the data."""
+        raise NotImplementedError
+
+    @property
+    def foreign_keys(self) -> str | Iterable[str] | None:
+        """Return the foreign key(s) of the data."""
+        raise NotImplementedError
 
     @abstractmethod
     def get_row_count(self) -> int | None:
@@ -148,14 +222,19 @@ class IFACompatibleADCProtocol(t.Protocol):
         """Get the number of decimal places for values in the given column, if applicable."""
 
     @abstractmethod
-    def get_random_value(self, column_name: Hashable, no_nulls: bool = False) -> t.Any:
+    def get_random_value(self, column_name: Hashable, no_nulls: bool = False,
+                         count: int = 1) -> t.Any | list[t.Any]:
         """
-        Return a random sample from the given DataFrame column.
+        Return one or more random samples from the given column.
 
         The return type is determined by the column type.
 
-        if `no_nulls` is set, select a random value from the set of non-null
-        values, if any. If there are no such non-nulls, this will return None.
+        If `no_nulls` is set, select random values from the set of non-null
+        values, if any. If there are no such non-nulls, this returns None when
+        `count` is 1, or an empty list when `count` is greater than 1.
+
+        When `count` is 1 (the default) a single value is returned; when it is
+        greater than 1, a list of up to `count` values is returned.
         """
 
     @abstractmethod
@@ -188,12 +267,76 @@ class IFACompatibleADCProtocol(t.Protocol):
         """Get the number of nulls in the given column."""
 
     @abstractmethod
-    def get_unique_values(self, column_name: Hashable) -> Collection[t.Any]:
+    def get_unique_values(self, column_name: Hashable | Sequence[Hashable]) -> Collection[t.Any]:
         """Return the unique values in `column_name`."""
 
     @abstractmethod
+    def get_unique_count(self, column_name: Hashable | Sequence[Hashable]) -> int:
+        """Get the number of unique values in the provided column(s)."""
+
+    @abstractmethod
+    def get_value_count(self, column_name: Hashable, value: t.Any, *, max_rows_to_eval: int | None = None,
+                        chunk_size: int = 5000) -> int:
+        """
+        Get the number of occurrences of `value` in `column_name`.
+
+        If `max_rows_to_eval` is given, at most that many rows are evaluated
+        and the result reflects only the rows inspected, not the full dataset.
+        """
+
+    @abstractmethod
+    def get_group_map(self, column_name: Hashable | Sequence[Hashable], *,
+                      seed: int | None = None) -> dict[Hashable, int]:
+        """
+        Get a map of each unique value of `column_name` to its group number.
+
+        If a sequence of column names is provided, groups by the combination of
+        all specified columns.
+        """
+
+    @abstractmethod
+    def contains_nulls(self, column_name: Hashable) -> bool:
+        """Return whether the given column contains any null values."""
+
+    @abstractmethod
     def is_nullable_column(self, column_name: Hashable) -> bool:
-        """Return whether the provided column allows nulls."""
+        """
+        Return whether the provided column allows nulls.
+
+        Unlike :meth:`contains_nulls`, which inspects the data itself, this
+        reports the column's declared nullability per the source schema. Data
+        sources that do not constrain nullability report all columns nullable.
+        """
+
+    @abstractmethod
+    def yield_chunk(self, chunk_size: int = 5000, *,
+                    max_chunks: int | None = None,
+                    skip_chunks: int | None = None,
+                    maintain_natural_order: bool = False,
+                    seed: int | None = None,
+                    ) -> Iterator[pd.DataFrame]:
+        """Yield `chunk_size` data frames from the data."""
+
+    @abstractmethod
+    def yield_grouped_chunk(self, column_name: Hashable | Sequence[Hashable] | None,
+                            groups: Iterable[Iterable[t.Any]], *,
+                            feature_attributes: Mapping[Hashable, t.Any] | None,
+                            max_chunks: int | None = None,
+                            skip_chunks: int = 0,
+                            time_feature: str = "",
+                            ) -> Iterator[pd.DataFrame]:
+        """Yield a data frame per group from the given groups."""
+
+
+@t.runtime_checkable
+class IFACompatibleSQLADCProtocol(IFACompatibleADCProtocol, t.Protocol):
+    """Protocol for a SQL-backed ADC compatible with `infer_feature_attributes`."""
+
+    table_name: TableNameProtocol
+
+    @abstractmethod
+    def get_inspector(self) -> t.Any | None:
+        """Get a ``sqlalchemy.Inspector`` for this table, if applicable."""
 
 
 class RelationshipProtocol(t.Protocol):
@@ -289,13 +432,6 @@ class DatastoreProtocol(t.Protocol):
     ) -> list[t.Any] | None:
         """Replace the column values in a specified table."""
         raise NotImplementedError
-
-
-@t.runtime_checkable
-class RelationalDatastoreProtocol(DatastoreProtocol, t.Protocol):
-    """Protocol for a relational datastore object."""
-
-    graph: t.Any
 
 
 @t.runtime_checkable

--- a/howso/utilities/feature_attributes/protocols.py
+++ b/howso/utilities/feature_attributes/protocols.py
@@ -10,19 +10,19 @@ from collections.abc import (
     Mapping,
     Sequence,
 )
-import typing as t
+from typing import Any, Literal, runtime_checkable, Protocol
 
 import pandas as pd
 
 
-class TableNameProtocol(t.Protocol):
+class TableNameProtocol(Protocol):
     """Protocol for a database table name object."""
 
     schema: str
     table: str
 
 
-class SQLTableProtocol(t.Protocol):
+class SQLTableProtocol(Protocol):
     """Protocol for a SQL table object."""
 
     c: dict
@@ -31,7 +31,7 @@ class SQLTableProtocol(t.Protocol):
     schema: str
 
 
-class SessionProtocol(t.Protocol):
+class SessionProtocol(Protocol):
     """Protocol for a sqlalchemy Session object."""
 
     @abstractmethod
@@ -50,8 +50,8 @@ class SessionProtocol(t.Protocol):
         raise NotImplementedError
 
 
-@t.runtime_checkable
-class IFACompatibleADCProtocol(t.Protocol):
+@runtime_checkable
+class IFACompatibleADCProtocol(Protocol):
     """
     Protocol for an abstract data class object compatible with `infer_feature_attributes`.
 
@@ -70,6 +70,11 @@ class IFACompatibleADCProtocol(t.Protocol):
 
     @property
     @abstractmethod
+    def foreign_keys(self) -> str | Iterable[str] | None:
+        """Return the foreign key(s) of the data."""
+
+    @property
+    @abstractmethod
     def headers(self) -> list[str]:
         """Return a list of the column names of the data."""
 
@@ -85,37 +90,71 @@ class IFACompatibleADCProtocol(t.Protocol):
 
     @property
     @abstractmethod
-    def foreign_keys(self) -> str | Iterable[str] | None:
-        """Return the foreign key(s) of the data."""
-
-    @property
-    @abstractmethod
     def supports_non_nullable_columns(self) -> bool:
         """Return whether this data source supports columns with nullable constraints."""
+
+    @abstractmethod
+    def contains_nulls(self, column_name: Hashable) -> bool:
+        """Return whether the given column contains any null values."""
 
     @abstractmethod
     def finalize(self) -> None:
         """Perform any final clean-up."""
 
     @abstractmethod
-    def get_row_count(self) -> int | None:
-        """Get the number of rows in the data source."""
+    def get_column_dtype(self, column_name: Hashable) -> str:
+        """Get the dtype of the given column."""
 
     @abstractmethod
     def get_dataframe(self) -> pd.DataFrame:
         """Get the data as a DataFrame."""
 
     @abstractmethod
-    def get_n_random_rows(self, samples: int = 5000, seed: int | None = None) -> pd.DataFrame:
-        """Get random samples from the given data frame as a data frame."""
-
-    @abstractmethod
     def get_decimal_places(self, column_name: Hashable) -> int:
         """Get the number of decimal places for values in the given column, if applicable."""
 
     @abstractmethod
+    def get_first_non_null(self, column_name: Hashable) -> Any | None:
+        """Get the first non-null value in the given column."""
+
+    @abstractmethod
+    def get_group_map(self, column_name: Hashable | Sequence[Hashable], *,
+                      seed: int | None = None) -> dict[Hashable, int]:
+        """
+        Get a map of each unique value of `column_name` to its group number.
+
+        If a sequence of column names is provided, groups by the combination of
+        all specified columns.
+        """
+
+    @abstractmethod
+    def get_mode(self, column_name: Hashable) -> list[tuple[Any, int]]:
+        """
+        Get the most common value in the given feature/column.
+
+        If multiple values have the same mode all of them will be returned, as
+        long as the count is a value greater than 1.
+        """
+
+    @abstractmethod
+    def get_min_max_values(self, column_name: Hashable, *, datetime_format: str | None = None) -> tuple[Any, Any]:
+        """Get the smallest and largest values in the given column."""
+
+    @abstractmethod
+    def get_n_random_rows(self, samples: int = 5000, seed: int | None = None) -> pd.DataFrame:
+        """Get random samples from the given data frame as a data frame."""
+
+    @abstractmethod
+    def get_null_count(self, column_name: Hashable) -> int:
+        """Get the number of nulls in the given column."""
+
+    @abstractmethod
+    def get_num_cases(self, column_name: Hashable) -> int:
+        """Return the number of non-null cases in the given column."""
+
+    @abstractmethod
     def get_random_value(self, column_name: Hashable, no_nulls: bool = False,
-                         count: int = 1) -> t.Any | list[t.Any]:
+                         count: int = 1) -> Any | list[Any]:
         """
         Return one or more random samples from the given column.
 
@@ -130,36 +169,11 @@ class IFACompatibleADCProtocol(t.Protocol):
         """
 
     @abstractmethod
-    def get_min_max_values(self, column_name: Hashable, *, datetime_format: str | None = None) -> tuple[t.Any, t.Any]:
-        """Get the smallest and largest values in the given column."""
+    def get_row_count(self) -> int | None:
+        """Get the number of rows in the data source."""
 
     @abstractmethod
-    def get_num_cases(self, column_name: Hashable) -> int:
-        """Return the number of non-null cases in the given column."""
-
-    @abstractmethod
-    def get_mode(self, column_name: Hashable) -> list[tuple[t.Any, int]]:
-        """
-        Get the most common value in the given feature/column.
-
-        If multiple values have the same mode all of them will be returned, as
-        long as the count is a value greater than 1.
-        """
-
-    @abstractmethod
-    def get_column_dtype(self, column_name: Hashable) -> str:
-        """Get the dtype of the given column."""
-
-    @abstractmethod
-    def get_first_non_null(self, column_name: Hashable) -> t.Any | None:
-        """Get the first non-null value in the given column."""
-
-    @abstractmethod
-    def get_null_count(self, column_name: Hashable) -> int:
-        """Get the number of nulls in the given column."""
-
-    @abstractmethod
-    def get_unique_values(self, column_name: Hashable | Sequence[Hashable]) -> Collection[t.Any]:
+    def get_unique_values(self, column_name: Hashable | Sequence[Hashable]) -> Collection[Any]:
         """Return the unique values in `column_name`."""
 
     @abstractmethod
@@ -167,7 +181,7 @@ class IFACompatibleADCProtocol(t.Protocol):
         """Get the number of unique values in the provided column(s)."""
 
     @abstractmethod
-    def get_value_count(self, column_name: Hashable, value: t.Any, *, max_rows_to_eval: int | None = None,
+    def get_value_count(self, column_name: Hashable, value: Any, *, max_rows_to_eval: int | None = None,
                         chunk_size: int = 5000) -> int:
         """
         Get the number of occurrences of `value` in `column_name`.
@@ -175,20 +189,6 @@ class IFACompatibleADCProtocol(t.Protocol):
         If `max_rows_to_eval` is given, at most that many rows are evaluated
         and the result reflects only the rows inspected, not the full dataset.
         """
-
-    @abstractmethod
-    def get_group_map(self, column_name: Hashable | Sequence[Hashable], *,
-                      seed: int | None = None) -> dict[Hashable, int]:
-        """
-        Get a map of each unique value of `column_name` to its group number.
-
-        If a sequence of column names is provided, groups by the combination of
-        all specified columns.
-        """
-
-    @abstractmethod
-    def contains_nulls(self, column_name: Hashable) -> bool:
-        """Return whether the given column contains any null values."""
 
     @abstractmethod
     def is_unique(self, column_name: Hashable) -> bool:
@@ -205,6 +205,16 @@ class IFACompatibleADCProtocol(t.Protocol):
         """
 
     @abstractmethod
+    def map_keys(self, chunk: pd.DataFrame) -> tuple[pd.DataFrame, dict[Any, dict[Any, list[Any]]]]:
+        """Map keys to a chunk, returning the updated chunk and the primary key map."""
+
+    @abstractmethod
+    def write_chunk(self, chunk: pd.DataFrame, *,
+                    if_exists: Literal["fail", "replace", "append"] = "append"
+                    ) -> None:
+        """Write a chunk."""
+
+    @abstractmethod
     def yield_chunk(self, chunk_size: int = 5000, *,
                     max_chunks: int | None = None,
                     skip_chunks: int | None = None,
@@ -215,8 +225,8 @@ class IFACompatibleADCProtocol(t.Protocol):
 
     @abstractmethod
     def yield_grouped_chunk(self, column_name: Hashable | Sequence[Hashable] | None,
-                            groups: Iterable[Iterable[t.Any]], *,
-                            feature_attributes: Mapping[Hashable, t.Any] | None,
+                            groups: Iterable[Iterable[Any]], *,
+                            feature_attributes: Mapping[Hashable, Any] | None,
                             max_chunks: int | None = None,
                             skip_chunks: int = 0,
                             time_feature: str = "",
@@ -225,11 +235,11 @@ class IFACompatibleADCProtocol(t.Protocol):
 
     @abstractmethod
     def yield_grouped_chunk_with_lag_context(self, group_feature: Hashable | Sequence[Hashable],
-                                             groups: Iterable[Iterable[t.Any]], *,
+                                             groups: Iterable[Iterable[Any]], *,
                                              id_feature_name: Hashable | Sequence[Hashable],
                                              time_feature: str,
                                              num_lags: int,
-                                             feature_attributes: Mapping[Hashable, t.Any] | None = None,
+                                             feature_attributes: Mapping[Hashable, Any] | None = None,
                                              ) -> Iterator[pd.DataFrame]:
         """
         Provide a grouped chunk generator augmented with per-series lag context.
@@ -252,29 +262,19 @@ class IFACompatibleADCProtocol(t.Protocol):
         subsequent chunk, ``gen.send(n)`` returns a chunk of length ``n``.
         """
 
-    @abstractmethod
-    def write_chunk(self, chunk: pd.DataFrame, *,
-                    if_exists: t.Literal["fail", "replace", "append"] = "append"
-                    ) -> None:
-        """Write a chunk."""
 
-    @abstractmethod
-    def map_keys(self, chunk: pd.DataFrame) -> tuple[pd.DataFrame, dict[t.Any, dict[t.Any, list[t.Any]]]]:
-        """Map keys to a chunk, returning the updated chunk and the primary key map."""
-
-
-@t.runtime_checkable
-class IFACompatibleSQLADCProtocol(IFACompatibleADCProtocol, t.Protocol):
+@runtime_checkable
+class IFACompatibleSQLADCProtocol(IFACompatibleADCProtocol, Protocol):
     """Protocol for a SQL-backed ADC compatible with `infer_feature_attributes`."""
 
     table_name: TableNameProtocol
 
     @abstractmethod
-    def get_inspector(self) -> t.Any | None:
+    def get_inspector(self) -> Any | None:
         """Get a ``sqlalchemy.Inspector`` for this table, if applicable."""
 
 
-class RelationshipProtocol(t.Protocol):
+class RelationshipProtocol(Protocol):
     """Protocol for an object representing a relationship in a database."""
 
     source: TableNameProtocol
@@ -283,15 +283,15 @@ class RelationshipProtocol(t.Protocol):
     destination_columns: tuple[str]
 
 
-class ComponentProtocol(t.Protocol):
+class ComponentProtocol(Protocol):
     """Protocol for an object representing an independent collection of DataFrame."""
 
-    datastore: t.Any
-    graph: t.Any
+    datastore: Any
+    graph: Any
 
 
-@t.runtime_checkable
-class DatastoreProtocol(t.Protocol):
+@runtime_checkable
+class DatastoreProtocol(Protocol):
     """Protocol for a datastore object."""
 
     @abstractmethod
@@ -317,12 +317,12 @@ class DatastoreProtocol(t.Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def pre_synth_check(self, related_datastore: t.Any, **kwargs) -> bool:
+    def pre_synth_check(self, related_datastore: Any, **kwargs) -> bool:
         """Attempt a pre-synth check."""
         raise NotImplementedError
 
     @abstractmethod
-    def reflect(self, source: t.Any, drop_existing: bool = False) -> None:
+    def reflect(self, source: Any, drop_existing: bool = False) -> None:
         """Do a reflection."""
         raise NotImplementedError
 
@@ -350,8 +350,8 @@ class DatastoreProtocol(t.Protocol):
     def get_values(self,
                    table_name: TableNameProtocol,
                    primary_key_columns: list[str] | str,
-                   primary_key_values: list[list[t.Any]] | list[t.Any],
-                   column_name: Hashable) -> list[t.Any]:
+                   primary_key_values: list[list[Any]] | list[Any],
+                   column_name: Hashable) -> list[Any]:
         """Get the column values in a specified table."""
         raise NotImplementedError
 
@@ -360,18 +360,18 @@ class DatastoreProtocol(t.Protocol):
         self,
         table_name: TableNameProtocol,
         primary_key_columns: list[str] | str,
-        primary_key_values: list[t.Any] | t.Any,
+        primary_key_values: list[Any] | Any,
         column_name: Hashable,
-        replace_values: list[t.Any],
+        replace_values: list[Any],
         return_old: bool = False,
-    ) -> list[t.Any] | None:
+    ) -> list[Any] | None:
         """Replace the column values in a specified table."""
         raise NotImplementedError
 
 
-@t.runtime_checkable
-class SQLRelationalDatastoreProtocol(DatastoreProtocol, t.Protocol):
+@runtime_checkable
+class SQLRelationalDatastoreProtocol(DatastoreProtocol, Protocol):
     """Protocol for a SQL relational datastore object."""
 
     engine: int
-    graph: t.Any
+    graph: Any

--- a/howso/utilities/feature_attributes/protocols.py
+++ b/howso/utilities/feature_attributes/protocols.py
@@ -31,18 +31,46 @@ class SQLTableProtocol(t.Protocol):
     schema: str
 
 
-class AbstractDataProtocol(t.Protocol):
-    """Protocol for an abstract data class object."""
+class SessionProtocol(t.Protocol):
+    """Protocol for a sqlalchemy Session object."""
 
-    @property
-    def foreign_keys(self) -> str | Iterable[str] | None:
-        """Return the foreign key(s) of the table."""
+    @abstractmethod
+    def commit(self):
+        """Flush pending changes and commit the current transaction."""
         raise NotImplementedError
+
+    @abstractmethod
+    def close(self):
+        """Close out the transactional resources and ORM objects used by this Session."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def rollback(self):
+        """Rollback the current transaction in progress."""
+        raise NotImplementedError
+
+
+@t.runtime_checkable
+class IFACompatibleADCProtocol(t.Protocol):
+    """
+    Protocol for an abstract data class object compatible with `infer_feature_attributes`.
+
+    An ADC is always the combination of the base abstract data class and the
+    IFA support mixin, so this protocol declares both sets of members as one
+    interface rather than splitting them the way the implementations do.
+
+    Because this protocol is runtime-checkable, every member declared here is
+    required of any object that will be recognized as an ADC, so adding a
+    member raises the floor on which implementations still qualify. Only
+    declare members that all IFA-compatible ADCs implement; members provided
+    by a subset of backends (e.g. ``get_inspector``) belong on a narrower
+    protocol such as :class:`IFACompatibleSQLADCProtocol`.
+    """
 
     @property
     @abstractmethod
     def headers(self) -> list[str]:
-        """Return a list of the column names of the table."""
+        """Return a list of the column names of the data."""
 
     @property
     def name(self) -> str:
@@ -51,7 +79,12 @@ class AbstractDataProtocol(t.Protocol):
 
     @property
     def primary_keys(self) -> str | list[str] | None:
-        """Return the primary key(s) of the table."""
+        """Return the primary key(s) of the data."""
+        raise NotImplementedError
+
+    @property
+    def foreign_keys(self) -> str | Iterable[str] | None:
+        """Return the foreign key(s) of the data."""
         raise NotImplementedError
 
     @property
@@ -65,153 +98,11 @@ class AbstractDataProtocol(t.Protocol):
 
     @abstractmethod
     def get_row_count(self) -> int | None:
-        """Get the number of rows in a file."""
-        raise NotImplementedError
+        """Get the number of rows in the data source."""
 
     @abstractmethod
     def get_dataframe(self) -> pd.DataFrame:
-        """Get the file as a DataFrame."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_group_map(self, column_name: Hashable | Sequence[Hashable], *,
-                      seed: int | None = None
-                      ) -> dict[Hashable, int]:
-        """
-        Get a map of each unique value of `column_name` to its group number.
-
-        If a sequence of column names is provided, groups by the combination of
-        all specified columns.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_n_random_rows(self, samples: int = 5000, seed: int | None = None) -> pd.DataFrame:
-        """Get a specified number of random rows."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def write_chunk(self, chunk: pd.DataFrame, *,
-                    if_exists: t.Literal["fail", "replace", "append"] = "append"
-                    ) -> None:
-        """Write a chunk."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def yield_variable_length_chunks(self, initial_chunk_size: int = 100, *,
-                                     maintain_natural_order: bool = False,
-                                     max_rows: int | None = None,
-                                     skip_rows: int = 0,
-                                     seed: int | None = None,
-                                     ) -> Generator[pd.DataFrame, int, None]:
-        """
-        Provide a bidirectional generator of variable-length chunks.
-
-        Call ``next(gen)`` or ``gen.send(None)`` for the first chunk; for each
-        subsequent chunk, ``gen.send(n)`` returns a chunk of length ``n``.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def yield_chunk(self, chunk_size: int = 5000, *,
-                    max_chunks: int | None = None,
-                    skip_chunks: int | None = None,
-                    maintain_natural_order: bool = False,
-                    seed: int | None = None,
-                    ) -> Iterator[pd.DataFrame]:
-        """Provide a chunk generator."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def yield_grouped_chunk(self, column_name: Hashable | Sequence[Hashable] | None,
-                            groups: Iterable[Iterable[t.Any]], *,
-                            feature_attributes: Mapping[Hashable, t.Any] | None,
-                            max_chunks: int | None = None,
-                            skip_chunks: int = 0,
-                            time_feature: str = "",
-                            ) -> Iterator[pd.DataFrame]:
-        """Provide a grouped chunk generator."""
-        raise NotImplementedError
-
-    def yield_grouped_chunk_with_lag_context(self, group_feature: Hashable | Sequence[Hashable],
-                                             groups: Iterable[Iterable[t.Any]], *,
-                                             id_feature_name: Hashable | Sequence[Hashable],
-                                             time_feature: str,
-                                             num_lags: int,
-                                             feature_attributes: Mapping[Hashable, t.Any] | None = None,
-                                             ) -> Iterator[pd.DataFrame]:
-        """
-        Provide a grouped chunk generator augmented with per-series lag context.
-
-        Not all data sources support this; those that do not raise
-        ``NotImplementedError``.
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def map_keys(self, chunk: pd.DataFrame) -> tuple[pd.DataFrame, dict[t.Any, dict[t.Any, list[t.Any]]]]:
-        """Map keys to a chunk, returning the updated chunk and the primary key map."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_unique_values(self, column_name: Hashable | Sequence[Hashable]) -> Collection[t.Any]:
-        """Return the set of unique values in the provided column(s)."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_unique_count(self, column_name: Hashable | Sequence[Hashable]) -> int:
-        """Get the number of unique values in the provided column(s)."""
-
-    @abstractmethod
-    def is_unique(self, column_name: Hashable) -> bool:
-        """Return whether the given column contains only unique values."""
-
-    @abstractmethod
-    def contains_nulls(self, column_name: Hashable) -> bool:
-        """Return whether the given column contains any null values."""
-
-    def is_nullable_column(self, column_name: Hashable) -> bool:
-        """
-        Return whether the given column allows nulls per the source schema.
-
-        Unlike :meth:`contains_nulls`, which inspects the data itself, this
-        reports the column's declared nullability. Data sources that do not
-        constrain nullability report all columns nullable.
-        """
-        raise NotImplementedError
-
-
-@t.runtime_checkable
-class IFACompatibleADCProtocol(t.Protocol):
-    """
-    Protocol for an abstract data file object with extended functionality.
-
-    Includes functions that make it compatible with `infer_feature_attributes`.
-    Because this protocol is runtime-checkable, every member declared here is
-    required of any object that will be recognized as an ADC. Only declare
-    members that all IFA-compatible ADCs implement; members provided by a
-    subset of backends (e.g. ``get_inspector``) belong on a narrower protocol
-    such as :class:`IFACompatibleSQLADCProtocol`.
-    """
-
-    @property
-    @abstractmethod
-    def headers(self) -> list[str]:
-        """Return a list of the column names of the data."""
-
-    @property
-    def primary_keys(self) -> str | list[str] | None:
-        """Return the primary key(s) of the data."""
-        raise NotImplementedError
-
-    @property
-    def foreign_keys(self) -> str | Iterable[str] | None:
-        """Return the foreign key(s) of the data."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_row_count(self) -> int | None:
-        """Get the number of rows in the data source."""
+        """Get the data as a DataFrame."""
 
     @abstractmethod
     def get_n_random_rows(self, samples: int = 5000, seed: int | None = None) -> pd.DataFrame:
@@ -299,6 +190,10 @@ class IFACompatibleADCProtocol(t.Protocol):
         """Return whether the given column contains any null values."""
 
     @abstractmethod
+    def is_unique(self, column_name: Hashable) -> bool:
+        """Return whether the given column contains only unique values."""
+
+    @abstractmethod
     def is_nullable_column(self, column_name: Hashable) -> bool:
         """
         Return whether the provided column allows nulls.
@@ -326,6 +221,45 @@ class IFACompatibleADCProtocol(t.Protocol):
                             time_feature: str = "",
                             ) -> Iterator[pd.DataFrame]:
         """Yield a data frame per group from the given groups."""
+
+    def yield_grouped_chunk_with_lag_context(self, group_feature: Hashable | Sequence[Hashable],
+                                             groups: Iterable[Iterable[t.Any]], *,
+                                             id_feature_name: Hashable | Sequence[Hashable],
+                                             time_feature: str,
+                                             num_lags: int,
+                                             feature_attributes: Mapping[Hashable, t.Any] | None = None,
+                                             ) -> Iterator[pd.DataFrame]:
+        """
+        Provide a grouped chunk generator augmented with per-series lag context.
+
+        Not all data sources support this; those that do not raise
+        ``NotImplementedError``.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def yield_variable_length_chunks(self, initial_chunk_size: int = 100, *,
+                                     maintain_natural_order: bool = False,
+                                     max_rows: int | None = None,
+                                     skip_rows: int = 0,
+                                     seed: int | None = None,
+                                     ) -> Generator[pd.DataFrame, int, None]:
+        """
+        Provide a bidirectional generator of variable-length chunks.
+
+        Call ``next(gen)`` or ``gen.send(None)`` for the first chunk; for each
+        subsequent chunk, ``gen.send(n)`` returns a chunk of length ``n``.
+        """
+
+    @abstractmethod
+    def write_chunk(self, chunk: pd.DataFrame, *,
+                    if_exists: t.Literal["fail", "replace", "append"] = "append"
+                    ) -> None:
+        """Write a chunk."""
+
+    @abstractmethod
+    def map_keys(self, chunk: pd.DataFrame) -> tuple[pd.DataFrame, dict[t.Any, dict[t.Any, list[t.Any]]]]:
+        """Map keys to a chunk, returning the updated chunk and the primary key map."""
 
 
 @t.runtime_checkable
@@ -360,7 +294,7 @@ class DatastoreProtocol(t.Protocol):
     """Protocol for a datastore object."""
 
     @abstractmethod
-    def items(self) -> Generator[tuple[TableNameProtocol, AbstractDataProtocol], None, None]:
+    def items(self) -> Generator[tuple[TableNameProtocol, IFACompatibleADCProtocol], None, None]:
         """Get items in the datastore."""
         raise NotImplementedError
 
@@ -402,12 +336,12 @@ class DatastoreProtocol(t.Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def get_data(self, table_name: TableNameProtocol) -> AbstractDataProtocol:
+    def get_data(self, table_name: TableNameProtocol) -> IFACompatibleADCProtocol:
         """Get the data in a specified table."""
         raise NotImplementedError
 
     @abstractmethod
-    def set_data(self, table_name: TableNameProtocol, data: AbstractDataProtocol):
+    def set_data(self, table_name: TableNameProtocol, data: IFACompatibleADCProtocol):
         """Set the data in a specified table."""
         raise NotImplementedError
 

--- a/howso/utilities/feature_attributes/protocols.py
+++ b/howso/utilities/feature_attributes/protocols.py
@@ -74,28 +74,28 @@ class IFACompatibleADCProtocol(t.Protocol):
         """Return a list of the column names of the data."""
 
     @property
+    @abstractmethod
     def name(self) -> str:
         """Return a meaningful name for this data."""
-        raise NotImplementedError
 
     @property
+    @abstractmethod
     def primary_keys(self) -> str | list[str] | None:
         """Return the primary key(s) of the data."""
-        raise NotImplementedError
 
     @property
+    @abstractmethod
     def foreign_keys(self) -> str | Iterable[str] | None:
         """Return the foreign key(s) of the data."""
-        raise NotImplementedError
 
     @property
+    @abstractmethod
     def supports_non_nullable_columns(self) -> bool:
         """Return whether this data source supports columns with nullable constraints."""
-        raise NotImplementedError
 
+    @abstractmethod
     def finalize(self) -> None:
         """Perform any final clean-up."""
-        raise NotImplementedError
 
     @abstractmethod
     def get_row_count(self) -> int | None:
@@ -223,6 +223,7 @@ class IFACompatibleADCProtocol(t.Protocol):
                             ) -> Iterator[pd.DataFrame]:
         """Yield a data frame per group from the given groups."""
 
+    @abstractmethod
     def yield_grouped_chunk_with_lag_context(self, group_feature: Hashable | Sequence[Hashable],
                                              groups: Iterable[Iterable[t.Any]], *,
                                              id_feature_name: Hashable | Sequence[Hashable],
@@ -236,7 +237,6 @@ class IFACompatibleADCProtocol(t.Protocol):
         Not all data sources support this; those that do not raise
         ``NotImplementedError``.
         """
-        raise NotImplementedError
 
     @abstractmethod
     def yield_variable_length_chunks(self, initial_chunk_size: int = 100, *,

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -272,6 +272,9 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
             raise ImportError('Must have SQLAlchemy installed to instantiate '
                               'FeatureAttributesSQLTable. See synthesizer-data-services/'
                               'requirements.in for versioning.')
+        warnings.warn("Direct SQL datastore support for infer_feature_attributes is deprecated. "
+                      "Please contact support@howso.com for information about data connectors.",
+                      DeprecationWarning, stacklevel=2)
         self.data = data
         self.table_name = table_name
         self.column_types = column_types

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -272,7 +272,8 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
             raise ImportError('Must have SQLAlchemy installed to instantiate '
                               'FeatureAttributesSQLTable. See synthesizer-data-services/'
                               'requirements.in for versioning.')
-        warnings.warn("Direct SQL datastore support for infer_feature_attributes is deprecated. "
+        warnings.warn("Direct SQL datastore support for infer_feature_attributes is deprecated "
+                      "and will be removed in a future release. "
                       "Please contact support@howso.com for information about data connectors.",
                       DeprecationWarning, stacklevel=2)
         self.data = data

--- a/howso/utilities/feature_attributes/time_series.py
+++ b/howso/utilities/feature_attributes/time_series.py
@@ -1069,11 +1069,11 @@ class IFATimeSeriesADC(InferFeatureAttributesTimeSeries):
         try:
             from howso.connectors.abstract_data import get_chunk_groups
         except (ModuleNotFoundError, ImportError):
-            chunk_iterator = self.data.yield_chunk(chunk_size=chunk_size)  # type: ignore
+            chunk_iterator = self.data.yield_chunk(chunk_size=chunk_size)
         else:
-            group_map = self.data.get_group_map(column_name=id_feature_name)  # type: ignore
+            group_map = self.data.get_group_map(column_name=id_feature_name)
             groups = get_chunk_groups(group_map=group_map, chunk_size=chunk_size)
-            chunk_iterator = self.data.yield_grouped_chunk(  # type: ignore
+            chunk_iterator = self.data.yield_grouped_chunk(
                 column_name=id_feature_name,
                 groups=groups,
                 feature_attributes=features,


### PR DESCRIPTION
* Ensures parity between ADCs and the protocol representations defined here used for IFA
* Collapses `AbstractDataProtocol` into `IFACompatibleADCProtocol` as methods from both the base `AbstractData` class and IFA mixin extension are required for IFA
* Adds `DeprecationWarning` for unsupported SQL datastore implementation of IFA
* Minor linting