### PR TITLE
25904: Fixes issue where rate/delta computation causes `IndexError` with all-null chunks in TS IFA (ADC)

### DIFF
--- a/howso/utilities/fanout_features.py
+++ b/howso/utilities/fanout_features.py
@@ -718,7 +718,7 @@ def infer_fanout_feature_config(
 
     Parameters
     ----------
-    data : DataFrame or AbstractDataProtocol
+    data : DataFrame or IFACompatibleADCProtocol
         Howso data connector exposing ``yield_chunk()`` -- iterates DataFrames.
     features : Mapping[str, Any]
         Feature mapping in Howso's ``infer_feature_attributes`` format.

--- a/howso/utilities/feature_attributes/protocols.py
+++ b/howso/utilities/feature_attributes/protocols.py
@@ -1,20 +1,28 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Collection, Generator, Hashable, Iterable
-import typing as t
+from collections.abc import (
+    Collection,
+    Generator,
+    Hashable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
+from typing import Any, Literal, runtime_checkable, Protocol
 
 import pandas as pd
 
 
-class TableNameProtocol(t.Protocol):
+class TableNameProtocol(Protocol):
     """Protocol for a database table name object."""
 
     schema: str
     table: str
 
 
-class SQLTableProtocol(t.Protocol):
+class SQLTableProtocol(Protocol):
     """Protocol for a SQL table object."""
 
     c: dict
@@ -23,7 +31,7 @@ class SQLTableProtocol(t.Protocol):
     schema: str
 
 
-class SessionProtocol(t.Protocol):
+class SessionProtocol(Protocol):
     """Protocol for a sqlalchemy Session object."""
 
     @abstractmethod
@@ -42,132 +50,85 @@ class SessionProtocol(t.Protocol):
         raise NotImplementedError
 
 
-class AbstractDataProtocol(t.Protocol):
-    """Protocol for an abstract data file object."""
+@runtime_checkable
+class IFACompatibleADCProtocol(Protocol):
+    """
+    Protocol for an abstract data class object compatible with `infer_feature_attributes`.
+
+    Since IFA requires functions declared both in the base `AbstractData` class
+    and the extended IFA support mixin, this protocol declares both sets of
+    members as one interface rather than splitting them like in the way the
+    are written.
+
+    Also, because this protocol is runtime-checkable, every member declared here
+    is required of any object that will be recognized as an ADC, so adding a
+    member raises the floor on which implementations still qualify. Only
+    declare members that all IFA-compatible ADCs implement; members provided
+    by a subset of backends (e.g. ``get_inspector``) belong on a narrower
+    protocol such as :class:`IFACompatibleSQLADCProtocol`.
+    """
 
     @property
+    @abstractmethod
     def foreign_keys(self) -> str | Iterable[str] | None:
-        """Return the foreign key(s) of the table."""
-        raise NotImplementedError
+        """Return the foreign key(s) of the data."""
 
     @property
     @abstractmethod
     def headers(self) -> list[str]:
-        """Return a list of the column names of the table."""
+        """Return a list of the column names of the data."""
 
     @property
+    @abstractmethod
     def name(self) -> str:
         """Return a meaningful name for this data."""
-        raise NotImplementedError
 
     @property
-    def primary_keys(self) -> str | Iterable[str] | None:
-        """Return the primary key(s) of the table."""
-        raise NotImplementedError
-
     @abstractmethod
-    def get_row_count(self):
-        """Get the number of rows in a file."""
-        raise NotImplementedError
+    def primary_keys(self) -> str | list[str] | None:
+        """Return the primary key(s) of the data."""
 
+    @property
     @abstractmethod
-    def get_dataframe(self) -> pd.DataFrame:
-        """Get the file as a DataFrame."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_group_map(self, column_name: Hashable) -> dict[t.Any, int]:
-        """Get the group map."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_n_random_rows(self, samples: int, seed: t.Optional[int]) -> pd.DataFrame:
-        """Get a specified number of random rows."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def write_chunk(self, chunk: pd.DataFrame, *,
-                    if_exists: str = "append"
-                    ) -> None:
-        """Write a chunk."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def yield_chunk(self, chunk_size: int = 5000, *,
-                    max_chunks: t.Optional[int] = None,
-                    skip_chunks: t.Optional[int] = None,
-                    maintain_natural_order: bool = False,
-                    seed: int | None = None,
-                    ) -> Generator[pd.DataFrame, None, None]:
-        """Provide a chunk generator."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def yield_grouped_chunk(self, column_name: Hashable,
-                            groups: Iterable[Iterable[t.Any]]
-                            ) -> Generator[pd.DataFrame, None, None]:
-        """Provide a grouped chunk generator."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def map_keys(self, chunk: pd.DataFrame) -> pd.DataFrame:
-        """Map keys to a chunk."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_unique_count(self, column_name: Hashable) -> int:
-        """Get the number of unique values in the provided column."""
-
-    @abstractmethod
-    def is_unique(self, column_name: Hashable) -> bool:
-        """Return whether the given column contains only unique values."""
+    def supports_non_nullable_columns(self) -> bool:
+        """Return whether this data source supports columns with nullable constraints."""
 
     @abstractmethod
     def contains_nulls(self, column_name: Hashable) -> bool:
         """Return whether the given column contains any null values."""
 
-
-@t.runtime_checkable
-class IFACompatibleADCProtocol(t.Protocol):
-    """
-    Protocol for an abstract data file object with extended functionality.
-
-    Includes functions that make it compatible with `infer_feature_attributes`.
-    """
+    @abstractmethod
+    def finalize(self) -> None:
+        """Perform any final clean-up."""
 
     @abstractmethod
-    def get_row_count(self) -> int | None:
-        """Get the number of rows in the data source."""
+    def get_column_dtype(self, column_name: Hashable) -> str:
+        """Get the dtype of the given column."""
 
     @abstractmethod
-    def get_n_random_rows(self, samples: int = 5000, seed: int | None = None) -> pd.DataFrame:
-        """Get random samples from the given data frame as a data frame."""
+    def get_dataframe(self) -> pd.DataFrame:
+        """Get the data as a DataFrame."""
 
     @abstractmethod
     def get_decimal_places(self, column_name: Hashable) -> int:
         """Get the number of decimal places for values in the given column, if applicable."""
 
     @abstractmethod
-    def get_random_value(self, column_name: Hashable, no_nulls: bool = False) -> t.Any:
+    def get_first_non_null(self, column_name: Hashable) -> Any | None:
+        """Get the first non-null value in the given column."""
+
+    @abstractmethod
+    def get_group_map(self, column_name: Hashable | Sequence[Hashable], *,
+                      seed: int | None = None) -> dict[Hashable, int]:
         """
-        Return a random sample from the given DataFrame column.
+        Get a map of each unique value of `column_name` to its group number.
 
-        The return type is determined by the column type.
-
-        if `no_nulls` is set, select a random value from the set of non-null
-        values, if any. If there are no such non-nulls, this will return None.
+        If a sequence of column names is provided, groups by the combination of
+        all specified columns.
         """
 
     @abstractmethod
-    def get_min_max_values(self, column_name: Hashable, *, datetime_format: str | None = None) -> tuple[t.Any, t.Any]:
-        """Get the smallest and largest values in the given column."""
-
-    @abstractmethod
-    def get_num_cases(self, column_name: Hashable) -> int:
-        """Return the number of non-null cases in the given column."""
-
-    @abstractmethod
-    def get_mode(self, column_name: Hashable) -> list[tuple[t.Any, int]]:
+    def get_mode(self, column_name: Hashable) -> list[tuple[Any, int]]:
         """
         Get the most common value in the given feature/column.
 
@@ -176,27 +137,144 @@ class IFACompatibleADCProtocol(t.Protocol):
         """
 
     @abstractmethod
-    def get_column_dtype(self, column_name: Hashable) -> str:
-        """Get the dtype of the given column."""
+    def get_min_max_values(self, column_name: Hashable, *, datetime_format: str | None = None) -> tuple[Any, Any]:
+        """Get the smallest and largest values in the given column."""
 
     @abstractmethod
-    def get_first_non_null(self, column_name: Hashable) -> t.Any | None:
-        """Get the first non-null value in the given column."""
+    def get_n_random_rows(self, samples: int = 5000, seed: int | None = None) -> pd.DataFrame:
+        """Get random samples from the given data frame as a data frame."""
 
     @abstractmethod
     def get_null_count(self, column_name: Hashable) -> int:
         """Get the number of nulls in the given column."""
 
     @abstractmethod
-    def get_unique_values(self, column_name: Hashable) -> Collection[t.Any]:
+    def get_num_cases(self, column_name: Hashable) -> int:
+        """Return the number of non-null cases in the given column."""
+
+    @abstractmethod
+    def get_random_value(self, column_name: Hashable, no_nulls: bool = False,
+                         count: int = 1) -> Any | list[Any]:
+        """
+        Return one or more random samples from the given column.
+
+        The return type is determined by the column type.
+
+        If `no_nulls` is set, select random values from the set of non-null
+        values, if any. If there are no such non-nulls, this returns None when
+        `count` is 1, or an empty list when `count` is greater than 1.
+
+        When `count` is 1 (the default) a single value is returned; when it is
+        greater than 1, a list of up to `count` values is returned.
+        """
+
+    @abstractmethod
+    def get_row_count(self) -> int | None:
+        """Get the number of rows in the data source."""
+
+    @abstractmethod
+    def get_unique_values(self, column_name: Hashable | Sequence[Hashable]) -> Collection[Any]:
         """Return the unique values in `column_name`."""
 
     @abstractmethod
+    def get_unique_count(self, column_name: Hashable | Sequence[Hashable]) -> int:
+        """Get the number of unique values in the provided column(s)."""
+
+    @abstractmethod
+    def get_value_count(self, column_name: Hashable, value: Any, *, max_rows_to_eval: int | None = None,
+                        chunk_size: int = 5000) -> int:
+        """
+        Get the number of occurrences of `value` in `column_name`.
+
+        If `max_rows_to_eval` is given, at most that many rows are evaluated
+        and the result reflects only the rows inspected, not the full dataset.
+        """
+
+    @abstractmethod
+    def is_unique(self, column_name: Hashable) -> bool:
+        """Return whether the given column contains only unique values."""
+
+    @abstractmethod
     def is_nullable_column(self, column_name: Hashable) -> bool:
-        """Return whether the provided column allows nulls."""
+        """
+        Return whether the provided column allows nulls.
+
+        Unlike :meth:`contains_nulls`, which inspects the data itself, this
+        reports the column's declared nullability per the source schema. Data
+        sources that do not constrain nullability report all columns nullable.
+        """
+
+    @abstractmethod
+    def map_keys(self, chunk: pd.DataFrame) -> tuple[pd.DataFrame, dict[Any, dict[Any, list[Any]]]]:
+        """Map keys to a chunk, returning the updated chunk and the primary key map."""
+
+    @abstractmethod
+    def write_chunk(self, chunk: pd.DataFrame, *,
+                    if_exists: Literal["fail", "replace", "append"] = "append"
+                    ) -> None:
+        """Write a chunk."""
+
+    @abstractmethod
+    def yield_chunk(self, chunk_size: int = 5000, *,
+                    max_chunks: int | None = None,
+                    skip_chunks: int | None = None,
+                    maintain_natural_order: bool = False,
+                    seed: int | None = None,
+                    ) -> Iterator[pd.DataFrame]:
+        """Yield `chunk_size` data frames from the data."""
+
+    @abstractmethod
+    def yield_grouped_chunk(self, column_name: Hashable | Sequence[Hashable] | None,
+                            groups: Iterable[Iterable[Any]], *,
+                            feature_attributes: Mapping[Hashable, Any] | None,
+                            max_chunks: int | None = None,
+                            skip_chunks: int = 0,
+                            time_feature: str = "",
+                            ) -> Iterator[pd.DataFrame]:
+        """Yield a data frame per group from the given groups."""
+
+    @abstractmethod
+    def yield_grouped_chunk_with_lag_context(self, group_feature: Hashable | Sequence[Hashable],
+                                             groups: Iterable[Iterable[Any]], *,
+                                             id_feature_name: Hashable | Sequence[Hashable],
+                                             time_feature: str,
+                                             num_lags: int,
+                                             feature_attributes: Mapping[Hashable, Any] | None = None,
+                                             ) -> Iterator[pd.DataFrame]:
+        """
+        Provide a grouped chunk generator augmented with per-series lag context.
+
+        Not all data sources support this; those that do not raise
+        ``NotImplementedError``.
+        """
+
+    @abstractmethod
+    def yield_variable_length_chunks(self, initial_chunk_size: int = 100, *,
+                                     maintain_natural_order: bool = False,
+                                     max_rows: int | None = None,
+                                     skip_rows: int = 0,
+                                     seed: int | None = None,
+                                     ) -> Generator[pd.DataFrame, int, None]:
+        """
+        Provide a bidirectional generator of variable-length chunks.
+
+        Call ``next(gen)`` or ``gen.send(None)`` for the first chunk; for each
+        subsequent chunk, ``gen.send(n)`` returns a chunk of length ``n``.
+        """
 
 
-class RelationshipProtocol(t.Protocol):
+@runtime_checkable
+class IFACompatibleSQLADCProtocol(IFACompatibleADCProtocol, Protocol):
+    """Protocol for a SQL-backed ADC compatible with `infer_feature_attributes`."""
+
+    table_name: TableNameProtocol
+
+    @abstractmethod
+    def get_inspector(self) -> Any | None:
+        """Get a ``sqlalchemy.Inspector`` for this table, if applicable."""
+
+
+class RelationshipProtocol(Protocol):
     """Protocol for an object representing a relationship in a database."""
 
     source: TableNameProtocol
@@ -205,19 +283,19 @@ class RelationshipProtocol(t.Protocol):
     destination_columns: tuple[str]
 
 
-class ComponentProtocol(t.Protocol):
+class ComponentProtocol(Protocol):
     """Protocol for an object representing an independent collection of DataFrame."""
 
-    datastore: t.Any
-    graph: t.Any
+    datastore: Any
+    graph: Any
 
 
-@t.runtime_checkable
-class DatastoreProtocol(t.Protocol):
+@runtime_checkable
+class DatastoreProtocol(Protocol):
     """Protocol for a datastore object."""
 
     @abstractmethod
-    def items(self) -> Generator[tuple[TableNameProtocol, AbstractDataProtocol], None, None]:
+    def items(self) -> Generator[tuple[TableNameProtocol, IFACompatibleADCProtocol], None, None]:
         """Get items in the datastore."""
         raise NotImplementedError
 
@@ -239,12 +317,12 @@ class DatastoreProtocol(t.Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def pre_synth_check(self, related_datastore: t.Any, **kwargs) -> bool:
+    def pre_synth_check(self, related_datastore: Any, **kwargs) -> bool:
         """Attempt a pre-synth check."""
         raise NotImplementedError
 
     @abstractmethod
-    def reflect(self, source: t.Any, drop_existing: bool = False) -> None:
+    def reflect(self, source: Any, drop_existing: bool = False) -> None:
         """Do a reflection."""
         raise NotImplementedError
 
@@ -259,12 +337,12 @@ class DatastoreProtocol(t.Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def get_data(self, table_name: TableNameProtocol) -> AbstractDataProtocol:
+    def get_data(self, table_name: TableNameProtocol) -> IFACompatibleADCProtocol:
         """Get the data in a specified table."""
         raise NotImplementedError
 
     @abstractmethod
-    def set_data(self, table_name: TableNameProtocol, data: AbstractDataProtocol):
+    def set_data(self, table_name: TableNameProtocol, data: IFACompatibleADCProtocol):
         """Set the data in a specified table."""
         raise NotImplementedError
 
@@ -272,8 +350,8 @@ class DatastoreProtocol(t.Protocol):
     def get_values(self,
                    table_name: TableNameProtocol,
                    primary_key_columns: list[str] | str,
-                   primary_key_values: list[list[t.Any]] | list[t.Any],
-                   column_name: Hashable) -> list[t.Any]:
+                   primary_key_values: list[list[Any]] | list[Any],
+                   column_name: Hashable) -> list[Any]:
         """Get the column values in a specified table."""
         raise NotImplementedError
 
@@ -282,25 +360,18 @@ class DatastoreProtocol(t.Protocol):
         self,
         table_name: TableNameProtocol,
         primary_key_columns: list[str] | str,
-        primary_key_values: list[t.Any] | t.Any,
+        primary_key_values: list[Any] | Any,
         column_name: Hashable,
-        replace_values: list[t.Any],
+        replace_values: list[Any],
         return_old: bool = False,
-    ) -> list[t.Any] | None:
+    ) -> list[Any] | None:
         """Replace the column values in a specified table."""
         raise NotImplementedError
 
 
-@t.runtime_checkable
-class RelationalDatastoreProtocol(DatastoreProtocol, t.Protocol):
-    """Protocol for a relational datastore object."""
-
-    graph: t.Any
-
-
-@t.runtime_checkable
-class SQLRelationalDatastoreProtocol(DatastoreProtocol, t.Protocol):
+@runtime_checkable
+class SQLRelationalDatastoreProtocol(DatastoreProtocol, Protocol):
     """Protocol for a SQL relational datastore object."""
 
     engine: int
-    graph: t.Any
+    graph: Any

--- a/howso/utilities/feature_attributes/relational.py
+++ b/howso/utilities/feature_attributes/relational.py
@@ -272,6 +272,10 @@ class InferFeatureAttributesSQLTable(InferFeatureAttributesBase):
             raise ImportError('Must have SQLAlchemy installed to instantiate '
                               'FeatureAttributesSQLTable. See synthesizer-data-services/'
                               'requirements.in for versioning.')
+        warnings.warn("Direct SQL datastore support for infer_feature_attributes is deprecated "
+                      "and will be removed in a future release. "
+                      "Please contact support@howso.com for information about data connectors.",
+                      DeprecationWarning, stacklevel=2)
         self.data = data
         self.table_name = table_name
         self.column_types = column_types

--- a/howso/utilities/feature_attributes/tests/test_infer_time_series_attributes.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_time_series_attributes.py
@@ -288,6 +288,23 @@ def test_lags():
         fa = infer_feature_attributes(df, time_feature_name="date", id_feature_name="ID", lags={"date": "0"})
 
 
+def test_lags_num_lags_confusion():
+    """Validates that passing one of `lags`/`num_lags` the other's type raises a helpful TypeError."""
+    df = pd.read_csv(example_timeseries_path)
+
+    # `lags` takes a list or dict; an int is almost certainly a `num_lags` value.
+    with pytest.raises(TypeError, match=r"`lags` must be a list or dict.*Did you mean `num_lags`\?"):
+        infer_feature_attributes(df, time_feature_name="date", id_feature_name="ID", lags=3)
+
+    # ...and the mirror case.
+    with pytest.raises(TypeError, match=r"`num_lags` must be an int or dict.*Did you mean `lags`\?"):
+        infer_feature_attributes(df, time_feature_name="date", id_feature_name="ID", num_lags=[1, 3, 5])
+
+    # Other unsupported types still raise, just without the cross-reference.
+    with pytest.raises(TypeError, match=r"`lags` must be a list or dict"):
+        infer_feature_attributes(df, time_feature_name="date", id_feature_name="ID", lags="3")
+
+
 def test_nominal_vs_continuous_detection():
     """Test that IFA correctly determines nominal vs. continuous features in time series data."""
     # Time-series data with 4756 cases, 41 series; avg. 116 cases/series; sqrt(116) ~= 10.77

--- a/howso/utilities/feature_attributes/tests/test_infer_time_series_attributes_adc.py
+++ b/howso/utilities/feature_attributes/tests/test_infer_time_series_attributes_adc.py
@@ -786,3 +786,66 @@ def test_infer_time_invariant_features_max_rows(adc):
         ]
         # Should be exactly one call (to _infer_time_invariant_features) with these parameters
         assert len(calls_with_max_chunks) == 1
+
+
+@pytest.mark.parametrize('chunk_groups', [
+    # The populated series land in the first chunk, so the second chunk contributes an empty list.
+    [["a", "b"], ["c", "d"]],
+    # ...and the reverse, where the first chunk is the one that contributes an empty list.
+    [["c", "d"], ["a", "b"]],
+])
+@pytest.mark.parametrize('adc', [
+    ("MongoDBData", pd.DataFrame()),
+    ("SQLTableData", pd.DataFrame()),
+    ("ParquetDataFile", pd.DataFrame()),
+    ("ParquetDataset", pd.DataFrame()),
+    ("TabularFile", pd.DataFrame()),
+    ("DaskDataFrameData", pd.DataFrame()),
+    ("DataFrameData", pd.DataFrame()),
+], indirect=True)
+def test_chunked_delta_min_max_with_sparse_feature(adc, chunk_groups):
+    """Test that chunk aggregation tolerates chunks in which a feature is entirely null.
+
+    A feature that is null for every row of some series yields no rate/delta values for the chunks
+    made up only of those series, so the per-chunk results are ragged. Aggregating them must not
+    depend on which chunk happens to come first.
+    """
+    data = {
+        "ID1": ["a"] * 3 + ["b"] * 3 + ["c"] * 3 + ["d"] * 3,
+        "time": [1, 2, 3] * 4,
+        "value": [11, 12, 15, 18, 23, 31, 18, 25, 27, 28, 25, 54],
+        # Populated only for series "a" and "b", so whichever chunk holds "c" and "d" produces
+        # no rate/delta values at all for these two features.
+        "sparse_rate": [4.0, 4.9, 5.8, 7.6, 6.2, 0.3, None, None, None, None, None, None],
+        "sparse_delta": [1.0, 3.5, 2.5, 9.0, 2.0, 5.0, None, None, None, None, None, None],
+    }
+    df = pd.DataFrame(data)
+    convert_data(DataFrameData(df), adc)
+
+    ifa_kwargs: dict[Any, Any] = dict(
+        time_feature_name="time",
+        id_feature_name="ID1",
+        default_time_zone="UTC",
+        time_series_types_override={"sparse_delta": "delta"},
+        max_workers=1,
+    )
+
+    # `get_chunk_groups` packs series into chunks with an unseeded RNG and refuses to make more
+    # than one chunk for so few series, so pin the split rather than driving it via `chunk_size`.
+    groups_target = "howso.connectors.abstract_data.get_chunk_groups"
+    with patch(groups_target, return_value=chunk_groups):
+        chunked = infer_feature_attributes(adc, **ifa_kwargs)  # pyright: ignore[reportArgumentType]
+    # Every series in a single chunk, which bypasses aggregation entirely.
+    with patch(groups_target, return_value=[["a", "b", "c", "d"]]):
+        single = infer_feature_attributes(adc, **ifa_kwargs)  # pyright: ignore[reportArgumentType]
+
+    checks = [
+        ("sparse_rate", ("rate_min", "rate_max")),
+        ("sparse_delta", ("delta_min", "delta_max")),
+        ("value", ("rate_min", "rate_max")),
+    ]
+    for f_name, keys in checks:
+        for key in keys:
+            expected = single[f_name]["time_series"][key]
+            assert expected, f"{f_name}.{key} was unexpectedly empty in the single-chunk run"
+            assert chunked[f_name]["time_series"][key] == expected

--- a/howso/utilities/feature_attributes/time_series.py
+++ b/howso/utilities/feature_attributes/time_series.py
@@ -701,6 +701,20 @@ class InferFeatureAttributesTimeSeries(ABC):
             A subclass of FeatureAttributesBase that extends `dict`, thus providing
             dict-like access to feature attributes and useful helper methods.
         """
+        # `lags` and `num_lags` are easy to confuse, and each silently do nothing when handed the
+        # other's type, so reject unsupported types up front and point at the other parameter.
+        if lags is not None and not isinstance(lags, (list, dict)):
+            hint = " Did you mean `num_lags`?" if isinstance(lags, int) and not isinstance(lags, bool) else ""
+            raise TypeError(
+                f"`lags` must be a list or dict, but a value of type {type(lags).__name__} was provided.{hint}"
+            )
+        if num_lags is not None and not isinstance(num_lags, (int, dict)):
+            hint = " Did you mean `lags`?" if isinstance(num_lags, list) else ""
+            raise TypeError(
+                f"`num_lags` must be an int or dict, but a value of type "
+                f"{type(num_lags).__name__} was provided.{hint}"
+            )
+
         if isinstance(self.data, IFACompatibleADCProtocol):
             infer = InferFeatureAttributesAbstractData(self.data)
         elif isinstance(self.data, pd.DataFrame):

--- a/howso/utilities/feature_attributes/time_series.py
+++ b/howso/utilities/feature_attributes/time_series.py
@@ -248,7 +248,14 @@ def _infer_delta_min_max_from_chunk(  # noqa: C901
 
         # Process orders
         ts_type = ts.get("type", "rate")
-        rates = deltas.values if ts_type == "rate" else None
+        if ts_type != "rate":
+            rates = None
+        elif deltas.dtype == object:
+            # A feature that is entirely null within this chunk can come back as object dtype
+            # from some data sources, which the vectorized math below cannot operate on.
+            rates = deltas.to_numpy(dtype=float)
+        else:
+            rates = deltas.values
         deltas_arr = deltas if ts_type == "delta" else None
 
         for order in range(1, num_orders + 1):
@@ -1378,13 +1385,21 @@ class IFATimeSeriesADC(InferFeatureAttributesTimeSeries):
                 if not aggregated[key]:
                     continue
 
-                # Values are lists (one per order of derivative)
-                # Need to aggregate element-wise across chunks
-                num_orders = len(aggregated[key][0])
+                # Values are lists (one per order of derivative). A chunk in which the feature
+                # is entirely null contributes an empty list, so the lists are not guaranteed to
+                # be the same length; aggregate element-wise over only those that have a value.
+                non_empty = [chunk_vals for chunk_vals in aggregated[key] if chunk_vals]
+                if not non_empty:
+                    continue
+
+                num_orders = max(len(chunk_vals) for chunk_vals in non_empty)
                 result = []
                 for order_idx in range(num_orders):
-                    values_at_order = [chunk_vals[order_idx] for chunk_vals in aggregated[key]]
-                    result.append(op(values_at_order))
+                    values_at_order = [
+                        chunk_vals[order_idx] for chunk_vals in non_empty if order_idx < len(chunk_vals)
+                    ]
+                    if values_at_order:
+                        result.append(op(values_at_order))
 
                 features[f_name]["time_series"][key] = result
 

--- a/howso/utilities/feature_attributes/time_series.py
+++ b/howso/utilities/feature_attributes/time_series.py
@@ -1069,11 +1069,11 @@ class IFATimeSeriesADC(InferFeatureAttributesTimeSeries):
         try:
             from howso.connectors.abstract_data import get_chunk_groups
         except (ModuleNotFoundError, ImportError):
-            chunk_iterator = self.data.yield_chunk(chunk_size=chunk_size)  # type: ignore
+            chunk_iterator = self.data.yield_chunk(chunk_size=chunk_size)
         else:
-            group_map = self.data.get_group_map(column_name=id_feature_name)  # type: ignore
+            group_map = self.data.get_group_map(column_name=id_feature_name)
             groups = get_chunk_groups(group_map=group_map, chunk_size=chunk_size)
-            chunk_iterator = self.data.yield_grouped_chunk(  # type: ignore
+            chunk_iterator = self.data.yield_grouped_chunk(
                 column_name=id_feature_name,
                 groups=groups,
                 feature_attributes=features,


### PR DESCRIPTION
### Problem

- `infer_feature_attributes` crashed with `IndexError: list index out of range` at
  `IFATimeSeriesADC._aggregate_chunk_results` when run on time series data via an
  AbstractData source large enough to be split into multiple chunks.
- `_aggregate_chunk_results` read the number of derivative orders off the *first* chunk only
  (`num_orders = len(aggregated[key][0])`) and then indexed that position in every other chunk's
  list, assuming all chunks produce lists of equal length.
- That assumption breaks for a feature that is entirely null within a chunk.
  `_infer_delta_min_max_from_chunk` creates `rate_min`/`rate_max`/`delta_min`/`delta_max` as empty
  lists and then `continue`s without appending when a chunk yields no valid values, so the key is
  present but empty and the per-chunk lists are ragged.
- Separately, some connectors (MongoDB, SQL) return a column that is
  entirely null within a chunk as `object` dtype, so `deltas.values` was an object array of `NaN`
  and `np.isnan(rates)` raised `TypeError: ufunc 'isnan' not supported for the input types`.

### Fix

- `_aggregate_chunk_results` now aggregates element-wise over only the chunks that actually
  contributed values, sizing the result from the longest contribution instead of the first one.
  This fixes both the `IndexError` and the silently-empty-bounds case.
- `_infer_delta_min_max_from_chunk` coerces the deltas to a float array when they come back as
  `object` dtype, so an all-null-in-chunk feature no longer crashes the rate path.

Additionally, enforces typing (with helpful error messages) around `lags` vs. `num_lags` arguments as they are easily confused.