### PR TITLE
25957: fixes and enhancements to progress - MINOR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,7 @@ jobs:
       config-pretty: 'MT'
       upstream-details: ${{ needs.metadata.outputs.upstream-details }}
       debug: ${{ inputs.debug-mode }}
+      enable-utf8: true
 
   pytest-macos-3-12-mt-arm64:
     needs: ['metadata', 'build']

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -1,10 +1,10 @@
 Faker
-40.37.0
+40.38.0
 MIT License
 joke2k
 https://github.com/joke2k/faker
 Faker is a Python package that generates fake data for you.
-/home/runner/.pyenv/versions/3.14.7/lib/python3.14/site-packages/faker-40.37.0.dist-info/licenses/LICENSE.txt
+/home/runner/.pyenv/versions/3.14.7/lib/python3.14/site-packages/faker-40.38.0.dist-info/licenses/LICENSE.txt
 Copyright (c) 2012 Daniele Faraglia
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/howso/client/base.py
+++ b/howso/client/base.py
@@ -15,6 +15,7 @@ from collections.abc import (
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Literal, TYPE_CHECKING
 from uuid import UUID
 import warnings
@@ -66,6 +67,7 @@ from howso.utilities.feature_attributes.base import (
 )
 from howso.utilities.features import serialize_cases
 from howso.utilities.monitors import ProgressTimer
+from howso.utilities.progress import auto_progress
 
 if TYPE_CHECKING:
     from .cache import TraineeCache
@@ -75,26 +77,26 @@ if TYPE_CHECKING:
 class AbstractHowsoClient(ABC):
     """The base definition of the Howso client interface."""
 
-    configuration: "HowsoConfiguration"
+    configuration: "HowsoConfiguration"  # pyright: ignore[reportMissingTypeArgument]  # noqa: UP037
     """The client configuration options."""
 
-    ERROR_MESSAGES = {
+    ERROR_MESSAGES: Mapping[str, str] = MappingProxyType({
         "missing_session": "There is currently no active session. Begin a new session to continue.",
         "train_series_generator": (
             "When training from a series, the provided cases cannot come from "
             "a generator.  Use a list or DataFrame instead."
-        )
-    }
+        ),
+    })
     """Mapping of error code to default error message."""
 
-    WARNING_MESSAGES = {
+    WARNING_MESSAGES: Mapping[str, str] = MappingProxyType({
         "invalid_precision": (
             'Supported values for `precision` are "exact" and "similar". The operation will be completed as '
             'if the value of `%s` is "exact".')
-    }
+    })
     """Mapping of warning type to default warning message."""
 
-    SUPPORTED_PRECISION_VALUES = ["exact", "similar"]
+    SUPPORTED_PRECISION_VALUES = ("exact", "similar")
     """Allowed values for precision."""
 
     @property
@@ -461,7 +463,7 @@ class AbstractHowsoClient(ABC):
         """Persist a trainee in the Howso service."""
 
     @abstractmethod
-    def begin_session(self, name: str | None = 'default', metadata: Mapping | None = None) -> Session:
+    def begin_session(self, name: str | None = "default", metadata: Mapping | None = None) -> Session:
         """Begin a new session."""
 
     @abstractmethod
@@ -496,10 +498,11 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         if self.configuration.verbose:
-            print(f'Setting random seed for Trainee with id: {trainee_id}')
+            print(f"Setting random seed for Trainee with id: {trainee_id}")
         self.execute(trainee_id, "set_random_seed", {"seed": seed})
         self._auto_persist_trainee(trainee_id)
 
+    @auto_progress("Train")
     def train(  # noqa: C901
         self,
         trainee_id: str,
@@ -640,9 +643,9 @@ class AbstractHowsoClient(ABC):
         if not isinstance(cases, list):
             for feature in unsupported_features:
                 warnings.warn(
-                    f'Ignoring feature {feature} as it contains values that are too '
-                    'large or small for your operating system. Please evaluate the '
-                    'bounds for this feature.')
+                    f"Ignoring feature {feature} as it contains values that are too "
+                    "large or small for your operating system. Please evaluate the "
+                    "bounds for this feature.")
                 if isinstance(cases, DataFrame):
                     cases.drop(feature, axis=1, inplace=True)
 
@@ -689,7 +692,7 @@ class AbstractHowsoClient(ABC):
         status: TrainStatus = {}
 
         if self.configuration.verbose:
-            print(f'Training session(s) on Trainee with id: {trainee_id}')
+            print(f"Training session(s) on Trainee with id: {trainee_id}")
 
         with ProgressTimer(num_cases) as progress:
             # TODO: this could fail if the generator produces nothing at all,
@@ -741,10 +744,10 @@ class AbstractHowsoClient(ABC):
                 end_time = datetime.now(timezone.utc)
                 start_index = None
 
-                if response and response.get('status') == 'analyze':
-                    status['needs_analyze'] = True
-                if response and response.get('status') == 'reduce_data':
-                    status['needs_data_reduction'] = True
+                if response and response.get("status") == "analyze":
+                    status["needs_analyze"] = True
+                if response and response.get("status") == "reduce_data":
+                    status["needs_data_reduction"] = True
 
                 progress.update(num_batch_cases)
                 batch_scaler.update(end_time - start_time, (in_size, out_size))
@@ -768,7 +771,7 @@ class AbstractHowsoClient(ABC):
         Validate a batch of cases as passed to `train()`.
 
         If `train()` was passed a `pd.DataFrame` or a list of cases, this
-        expects the entire set of casses passed up front.  If it was passed a
+        expects the entire set of cases passed up front.  If it was passed a
         generator, then it expects a single batch out of the generator.
 
         Other parameters are generally passed through from `train()`.
@@ -780,6 +783,7 @@ class AbstractHowsoClient(ABC):
             with suppress(NotImplementedError):
                 feature_attributes.validate(cases)
 
+    @auto_progress("Impute", indeterminate=True)
     def impute(
         self,
         trainee_id: str,
@@ -829,7 +833,7 @@ class AbstractHowsoClient(ABC):
         util.validate_list_shape(features_to_impute, 1, "features_to_impute", "str")
 
         if self.configuration.verbose:
-            print(f'Imputing Trainee with id: {trainee_id}')
+            print(f"Imputing Trainee with id: {trainee_id}")
         self.execute(trainee_id, "impute", {
             "batch_size": batch_size,
             "features": features,
@@ -931,20 +935,20 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         if num_cases is not None and num_cases < 1:
-            raise ValueError('`num_cases` must be a value greater than 0 if specified.')
+            raise ValueError("`num_cases` must be a value greater than 0 if specified.")
 
         if precision is not None and precision not in self.SUPPORTED_PRECISION_VALUES:
-            warnings.warn(self.WARNING_MESSAGES['invalid_precision'].format("precision"))
+            warnings.warn(self.WARNING_MESSAGES["invalid_precision"].format("precision"))
 
         # Convert session instance to id
         if (
             isinstance(condition, MutableMapping) and
-            isinstance(condition.get('.session'), Session)
+            isinstance(condition.get(".session"), Session)
         ):
-            condition['.session'] = condition['.session'].id
+            condition[".session"] = condition[".session"].id
 
         if self.configuration.verbose:
-            print(f'Removing case(s) from Trainee with id: {trainee_id}')
+            print(f"Removing case(s) from Trainee with id: {trainee_id}")
 
         result = self.execute(trainee_id, "remove_cases", {
             "case_indices": case_indices,
@@ -957,7 +961,7 @@ class AbstractHowsoClient(ABC):
         self._auto_persist_trainee(trainee_id)
         if not result:
             return 0
-        return result.get('count', 0)
+        return result.get("count", 0)
 
     def move_cases(
         self,
@@ -1066,20 +1070,20 @@ class AbstractHowsoClient(ABC):
             raise HowsoError(self.ERROR_MESSAGES["missing_session"], code="missing_session")
 
         if num_cases < 1:
-            raise ValueError('num_cases must be a value greater than 0')
+            raise ValueError("num_cases must be a value greater than 0")
 
         if precision is not None and precision not in self.SUPPORTED_PRECISION_VALUES:
-            warnings.warn(self.WARNING_MESSAGES['invalid_precision'].format("precision"))
+            warnings.warn(self.WARNING_MESSAGES["invalid_precision"].format("precision"))
 
         # Convert session instance to id
         if (
             isinstance(condition, MutableMapping) and
-            isinstance(condition.get('.session'), Session)
+            isinstance(condition.get(".session"), Session)
         ):
-            condition['.session'] = condition['.session'].id
+            condition[".session"] = condition[".session"].id
 
         if self.configuration.verbose:
-            print(f'Moving case(s) from Trainee with id: {trainee_id}')
+            print(f"Moving case(s) from Trainee with id: {trainee_id}")
 
         result = self.execute(trainee_id, "move_cases", {
             "case_indices": case_indices,
@@ -1097,7 +1101,7 @@ class AbstractHowsoClient(ABC):
         self._auto_persist_trainee(trainee_id)
         if not result:
             return 0
-        return result.get('count', 0)
+        return result.get("count", 0)
 
     def edit_cases(
         self,
@@ -1172,7 +1176,7 @@ class AbstractHowsoClient(ABC):
             raise HowsoError(self.ERROR_MESSAGES["missing_session"], code="missing_session")
 
         if precision is not None and precision not in self.SUPPORTED_PRECISION_VALUES:
-            warnings.warn(self.WARNING_MESSAGES['invalid_precision'].format("precision"))
+            warnings.warn(self.WARNING_MESSAGES["invalid_precision"].format("precision"))
 
         if case_indices is not None:
             util.validate_case_indices(case_indices)
@@ -1182,7 +1186,7 @@ class AbstractHowsoClient(ABC):
         if isinstance(feature_values, Collection | DataFrame):
             feature_attributes = self.resolve_feature_attributes(trainee_id)
             if features is None:
-                features = internals.get_features_from_data(feature_values, data_parameter='feature_values')
+                features = internals.get_features_from_data(feature_values, data_parameter="feature_values")
             serialized_feature_values = serialize_cases(feature_values, features, feature_attributes,
                                                         tokenizer=self._tokenizer)  # pyright: ignore[reportAttributeAccessIssue]
             if serialized_feature_values:
@@ -1192,12 +1196,12 @@ class AbstractHowsoClient(ABC):
         # Convert session instance to id
         if (
             isinstance(condition, MutableMapping) and
-            isinstance(condition.get('.session'), Session)
+            isinstance(condition.get(".session"), Session)
         ):
-            condition['.session'] = condition['.session'].id
+            condition[".session"] = condition[".session"].id
 
         if self.configuration.verbose:
-            print(f'Editing case(s) in Trainee with id: {trainee_id}')
+            print(f"Editing case(s) in Trainee with id: {trainee_id}")
 
         result = self.execute(trainee_id, "edit_cases", {
             "case_indices": case_indices,
@@ -1212,7 +1216,7 @@ class AbstractHowsoClient(ABC):
         self._auto_persist_trainee(trainee_id)
         if not result:
             return 0
-        return result.get('count', 0)
+        return result.get("count", 0)
 
     def remove_series_store(self, trainee_id: str, series: str | None = None):
         """
@@ -1228,7 +1232,7 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         if self.configuration.verbose:
-            print(f'Removing stored series from Trainee with id: {trainee_id} and series: {series}')
+            print(f"Removing stored series from Trainee with id: {trainee_id} and series: {series}")
         self.execute(trainee_id, "remove_series_store", {"series": series})
 
     def append_to_series_store(
@@ -1266,8 +1270,8 @@ class AbstractHowsoClient(ABC):
         if context_features is None:
             context_features = internals.get_features_from_data(
                 contexts,
-                data_parameter='contexts',
-                features_parameter='context_features'
+                data_parameter="contexts",
+                features_parameter="context_features"
             )
 
         # Preprocess contexts
@@ -1275,7 +1279,7 @@ class AbstractHowsoClient(ABC):
                                               tokenizer=self._tokenizer)  # pyright: ignore[reportAttributeAccessIssue]
 
         if self.configuration.verbose:
-            print(f'Appending to series store for Trainee with id: {trainee_id}, and series: {series}')
+            print(f"Appending to series store for Trainee with id: {trainee_id}, and series: {series}")
 
         self.execute(trainee_id, "append_to_series_store", {
             "context_features": context_features,
@@ -1297,7 +1301,7 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         if self.configuration.verbose:
-            print(f'Setting substitute feature values for Trainee with id: {trainee_id}')
+            print(f"Setting substitute feature values for Trainee with id: {trainee_id}")
         self.execute(trainee_id, "set_substitute_feature_values", {
             "substitution_value_map": substitution_value_map
         })
@@ -1327,7 +1331,7 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         if self.configuration.verbose:
-            print(f'Getting substitute feature values from Trainee with id: {trainee_id}')
+            print(f"Getting substitute feature values from Trainee with id: {trainee_id}")
         result = self.execute(trainee_id, "get_substitute_feature_values", {})
         if clear_on_get:
             self.execute(trainee_id, "set_substitute_feature_values", {
@@ -1373,7 +1377,7 @@ class AbstractHowsoClient(ABC):
         if not isinstance(feature_attributes, Mapping):
             raise ValueError("`feature_attributes` must be a dict")
         if self.configuration.verbose:
-            print(f'Setting feature attributes for Trainee with id: {trainee_id}')
+            print(f"Setting feature attributes for Trainee with id: {trainee_id}")
 
         updated_feature_attributes = self.execute(trainee_id, "set_feature_attributes", {
             "feature_attributes": internals.preprocess_feature_attributes(feature_attributes),
@@ -1402,7 +1406,7 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         if self.configuration.verbose:
-            print(f'Getting feature attributes from Trainee with id: {trainee_id}')
+            print(f"Getting feature attributes from Trainee with id: {trainee_id}")
         feature_attributes = self.execute(trainee_id, "get_feature_attributes", {})
         return internals.postprocess_feature_attributes(feature_attributes)
 
@@ -1428,8 +1432,8 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         if self.configuration.verbose:
-            print(f'Getting sessions from Trainee with id: {trainee_id}')
-        result = self.execute(trainee_id, "get_sessions", {"attributes": ['name', ]})
+            print(f"Getting sessions from Trainee with id: {trainee_id}")
+        result = self.execute(trainee_id, "get_sessions", {"attributes": ["name", ]})
         if not result:
             return []
         return result
@@ -1449,7 +1453,7 @@ class AbstractHowsoClient(ABC):
         if isinstance(target_session, Session):
             target_session = target_session.id
         if self.configuration.verbose:
-            print(f'Deleting session {target_session} from Trainee with id: {trainee_id}')
+            print(f"Deleting session {target_session} from Trainee with id: {trainee_id}")
         self.execute(trainee_id, "delete_session", {"target_session": target_session})
         self._auto_persist_trainee(trainee_id)
 
@@ -1473,7 +1477,7 @@ class AbstractHowsoClient(ABC):
         if isinstance(session, Session):
             session = session.id
         if self.configuration.verbose:
-            print(f'Getting session {session} indices from Trainee with id: {trainee_id}')
+            print(f"Getting session {session} indices from Trainee with id: {trainee_id}")
         result = self.execute(trainee_id, "get_session_indices", {"session": session})
         if result is None:
             return []
@@ -1499,7 +1503,7 @@ class AbstractHowsoClient(ABC):
         if isinstance(session, Session):
             session = session.id
         if self.configuration.verbose:
-            print(f'Getting session {session} training indices from Trainee with id: {trainee_id}')
+            print(f"Getting session {session} training indices from Trainee with id: {trainee_id}")
         result = self.execute(trainee_id, "get_session_training_indices", {"session": session})
         if result is None:
             return []
@@ -1563,17 +1567,17 @@ class AbstractHowsoClient(ABC):
         trainee_id = self._resolve_trainee(trainee_id).id
 
         if precision is not None and precision not in self.SUPPORTED_PRECISION_VALUES:
-            warnings.warn(self.WARNING_MESSAGES['invalid_precision'].format("precision"))
+            warnings.warn(self.WARNING_MESSAGES["invalid_precision"].format("precision"))
 
         # Convert session instance to id
         if (
             isinstance(condition, MutableMapping) and
-            isinstance(condition.get('.session'), Session)
+            isinstance(condition.get(".session"), Session)
         ):
-            condition['.session'] = condition['.session'].id
+            condition[".session"] = condition[".session"].id
 
         if self.configuration.verbose:
-            print(f'Getting feature marginal stats for trainee with id: {trainee_id}')
+            print(f"Getting feature marginal stats for trainee with id: {trainee_id}")
 
         stats = self.execute(trainee_id, "get_marginal_stats", {
             "features": features,
@@ -1648,17 +1652,17 @@ class AbstractHowsoClient(ABC):
         trainee_id = self._resolve_trainee(trainee_id).id
 
         if precision is not None and precision not in self.SUPPORTED_PRECISION_VALUES:
-            warnings.warn(self.WARNING_MESSAGES['invalid_precision'].format("precision"))
+            warnings.warn(self.WARNING_MESSAGES["invalid_precision"].format("precision"))
 
         # Convert session instance to id
         if (
             isinstance(condition, MutableMapping) and
-            isinstance(condition.get('.session'), Session)
+            isinstance(condition.get(".session"), Session)
         ):
-            condition['.session'] = condition['.session'].id
+            condition[".session"] = condition[".session"].id
 
         if self.configuration.verbose:
-            print(f'Getting value masses for trainee with id: {trainee_id}')
+            print(f"Getting value masses for trainee with id: {trainee_id}")
 
         value_masses = self.execute(trainee_id, "get_value_masses", {
             "condition": condition,
@@ -1671,6 +1675,7 @@ class AbstractHowsoClient(ABC):
             return dict()
         return value_masses.get("masses", {})
 
+    @auto_progress("React")
     def react(  # noqa: C901
         self,
         trainee_id: str,
@@ -2415,12 +2420,12 @@ class AbstractHowsoClient(ABC):
         if post_process_values is not None and post_process_features is None:
             post_process_features = internals.get_features_from_data(
                 post_process_values,
-                data_parameter='post_process_values',
-                features_parameter='post_process_features')
+                data_parameter="post_process_values",
+                features_parameter="post_process_features")
         post_process_values = serialize_cases(post_process_values, post_process_features, feature_attributes,
                                               tokenizer=self._tokenizer)  # pyright: ignore[reportAttributeAccessIssue]
 
-        if post_process_values is not None and contexts is not None:
+        if post_process_values is not None and contexts is not None:  # noqa: SIM102
             if (len(contexts) > 1 and len(post_process_values) > 1 and
                     len(contexts) != len(post_process_values)):
                 raise ValueError(
@@ -2429,11 +2434,11 @@ class AbstractHowsoClient(ABC):
                     "length."
                 )
 
-        if action_features is not None and derived_action_features is not None:
+        if action_features is not None and derived_action_features is not None:  # noqa: SIM102
             if not set(derived_action_features).issubset(set(action_features)):
                 raise ValueError(
-                    'Specified `derived_action_features` must be a subset of '
-                    '`action_features`.')
+                    "Specified `derived_action_features` must be a subset of "
+                    "`action_features`.")
 
         if new_case_threshold not in [None, "min", "max", "most_similar"]:
             raise ValueError(
@@ -2442,23 +2447,23 @@ class AbstractHowsoClient(ABC):
                 " following values - ['min', 'max', 'most_similar',]"
             )
 
-        if details is not None and 'local_case_feature_residual_conviction_robust' in details:
+        if details is not None and "local_case_feature_residual_conviction_robust" in details:
             details = dict(details)
-            details['case_feature_residual_conviction_robust'] = details.pop(
-                'local_case_feature_residual_conviction_robust')
+            details["case_feature_residual_conviction_robust"] = details.pop(
+                "local_case_feature_residual_conviction_robust")
             warnings.warn(
                 'The detail "local_case_feature_residual_conviction_robust" is deprecated and will be '
                 'removed in a future release. Please use "case_feature_residual_conviction_robust" instead',
-                DeprecationWarning)
+                DeprecationWarning, stacklevel=2)
 
-        if details is not None and 'local_case_feature_residual_conviction_full' in details:
+        if details is not None and "local_case_feature_residual_conviction_full" in details:
             details = dict(details)
-            details['case_feature_residual_conviction_full'] = details.pop(
-                'local_case_feature_residual_conviction_full')
+            details["case_feature_residual_conviction_full"] = details.pop(
+                "local_case_feature_residual_conviction_full")
             warnings.warn(
                 'The detail "local_case_feature_residual_conviction_full" is deprecated and will be '
                 'removed in a future release. Please use "case_feature_residual_conviction_full" instead',
-                DeprecationWarning)
+                DeprecationWarning, stacklevel=2)
 
         if desired_conviction is None:
             if contexts is not None:
@@ -2564,7 +2569,7 @@ class AbstractHowsoClient(ABC):
         if batch_size or self._should_react_batch(react_params, total_size):
             # Run in batch
             if self.configuration.verbose:
-                print(f'Batch reacting to context on Trainee with id: {trainee_id}')
+                print(f"Batch reacting to context on Trainee with id: {trainee_id}")
             response = internals.ReactInBatches.run(
                 trainee_id=trainee_id,
                 params=react_params,
@@ -2582,7 +2587,7 @@ class AbstractHowsoClient(ABC):
         else:
             # Run as a single react request
             if self.configuration.verbose:
-                print(f'Reacting to context on Trainee with id: {trainee_id}')
+                print(f"Reacting to context on Trainee with id: {trainee_id}")
             with ProgressTimer(total_size) as progress:
                 if isinstance(progress_callback, Callable):
                     progress_callback(progress, None)
@@ -2598,7 +2603,7 @@ class AbstractHowsoClient(ABC):
             # If the number of cases generated is less then requested, raise
             # warning (only for generative reacts)
             internals.insufficient_generation_check(
-                num_cases_to_generate, len(response['action']),
+                num_cases_to_generate, len(response["action"]),
                 suppress_warning=suppress_warning
             )
 
@@ -2624,13 +2629,13 @@ class AbstractHowsoClient(ABC):
         int
             The response payload size.
         """
-        ret, in_size, out_size = self.execute_sized(trainee_id, 'react', params)
+        ret, in_size, out_size = self.execute_sized(trainee_id, "react", params)
 
         # Action values and features should always be defined
-        if not ret.get('action_values'):
-            ret['action_values'] = []
-        if not ret.get('action_features'):
-            ret['action_features'] = []
+        if not ret.get("action_values"):
+            ret["action_values"] = []
+        if not ret.get("action_features"):
+            ret["action_features"] = []
 
         return ret, in_size, out_size
 
@@ -2705,8 +2710,8 @@ class AbstractHowsoClient(ABC):
         if context_values is not None and context_features is None:
             context_features = internals.get_features_from_data(
                 context_values,
-                data_parameter='contexts',
-                features_parameter='context_features')
+                data_parameter="contexts",
+                features_parameter="context_features")
         serialized_contexts = serialize_cases(context_values, context_features, feature_attributes,
                                               tokenizer=self._tokenizer)  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -2715,8 +2720,8 @@ class AbstractHowsoClient(ABC):
             util.validate_list_shape(action_values, 2, "actions", "object")
             action_features = internals.get_features_from_data(
                 action_values,
-                data_parameter='actions',
-                features_parameter='action_features')
+                data_parameter="actions",
+                features_parameter="action_features")
         serialized_actions = serialize_cases(action_values, action_features, feature_attributes,
                                              tokenizer=self._tokenizer)  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -2805,7 +2810,7 @@ class AbstractHowsoClient(ABC):
             raise HowsoError("Desired conviction must be greater than 0.")
 
         if self.configuration.verbose:
-            print(f'Generating case from trainee with id: {trainee_id}')
+            print(f"Generating case from trainee with id: {trainee_id}")
 
         for i in range(num_cases_to_generate):
             target_context_values = None
@@ -2827,6 +2832,7 @@ class AbstractHowsoClient(ABC):
 
         return context_features, context_values
 
+    @auto_progress("React Series")
     def react_series(  # noqa: C901
         self,
         trainee_id: str,
@@ -3135,7 +3141,7 @@ class AbstractHowsoClient(ABC):
         if action_features is not None and derived_action_features is not None:
             if not set(derived_action_features).issubset(set(action_features)):
                 raise ValueError(
-                    'Specified `derived_action_features` must be a subset of `action_features`.')
+                    "Specified `derived_action_features` must be a subset of `action_features`.")
 
         serialized_series_context_values = None
         if series_context_values:
@@ -3201,11 +3207,11 @@ class AbstractHowsoClient(ABC):
                 # Raise error if any of the params have different lengths
                 # greater than 1
                 raise ValueError(
-                    'When providing any of '
-                    '`series_context_values`, `series_id_values`, '
-                    '`max_series_lengths`, '
-                    'or `series_stop_maps`, each must be of length 1 or the same '
-                    'length as each other.')
+                    "When providing any of "
+                    "`series_context_values`, `series_id_values`, "
+                    "`max_series_lengths`, "
+                    "or `series_stop_maps`, each must be of length 1 or the same "
+                    "length as each other.")
         else:
             param_lengths = {1}
 
@@ -3254,9 +3260,9 @@ class AbstractHowsoClient(ABC):
                                  "greater than 0.")
             if max(param_lengths) not in [1, num_series_to_generate]:
                 raise ValueError(
-                    'For generative reacts, when specifying parameters with '
-                    'values for each series they must be of length 1 or the '
-                    'value specified by `num_series_to_generate`.')
+                    "For generative reacts, when specifying parameters with "
+                    "values for each series they must be of length 1 or the "
+                    "value specified by `num_series_to_generate`.")
             total_size = num_series_to_generate
 
             _ = self._preprocess_generate_parameters(
@@ -3309,7 +3315,7 @@ class AbstractHowsoClient(ABC):
 
         if batch_size or self._should_react_batch(react_params, total_size):
             if self.configuration.verbose:
-                print(f'Batch series reacting on trainee with id: {trainee_id}')
+                print(f"Batch series reacting on trainee with id: {trainee_id}")
             response = internals.ReactInBatches.run(
                 trainee_id=trainee_id,
                 params=react_params,
@@ -3326,7 +3332,7 @@ class AbstractHowsoClient(ABC):
             )
         else:
             if self.configuration.verbose:
-                print(f'Series reacting on trainee with id: {trainee_id}')
+                print(f"Series reacting on trainee with id: {trainee_id}")
             with ProgressTimer(total_size) as progress:
                 if isinstance(progress_callback, Callable):
                     progress_callback(progress, None)
@@ -3337,20 +3343,20 @@ class AbstractHowsoClient(ABC):
                 progress_callback(progress, response)
 
         # put all details under the 'details' key
-        action = response.pop('action')
-        response = {'action': action, 'details': response}
+        action = response.pop("action")
+        response = {"action": action, "details": response}
 
         # If the number of series generated is less then requested, raise
         # warning, for generative reacts
         if desired_conviction is not None:
-            len_action = len(response['action'])
+            len_action = len(response["action"])
             internals.insufficient_generation_check(
                 num_series_to_generate, len_action,
                 suppress_warning=suppress_warning
             )
 
         series_df = util.build_react_series_df(response, series_index=series_index)
-        return Reaction(series_df, response.get('details', {}), feature_attributes, tokenizer=self._tokenizer)  # pyright: ignore[reportAttributeAccessIssue]
+        return Reaction(series_df, response.get("details", {}), feature_attributes, tokenizer=self._tokenizer)  # pyright: ignore[reportAttributeAccessIssue]
 
     def _react_series(self, trainee_id: str, params: dict):
         """
@@ -3374,15 +3380,15 @@ class AbstractHowsoClient(ABC):
         """
         batch_result, in_size, out_size = self.execute_sized(trainee_id, "react_series", params)
 
-        if batch_result is None or batch_result.get('action_values') is None:
-            raise ValueError('Invalid parameters passed to react_series.')
+        if batch_result is None or batch_result.get("action_values") is None:
+            raise ValueError("Invalid parameters passed to react_series.")
 
         ret = dict()
         batch_result = util.replace_doublemax_with_infinity(batch_result)
 
         # batch_result always has action_features and action_values
-        ret['action_features'] = batch_result.pop('action_features') or []
-        ret['action'] = batch_result.pop('action_values') or []
+        ret["action_features"] = batch_result.pop("action_features") or []
+        ret["action"] = batch_result.pop("action_values") or []
 
         # ensure all the details items are output as well
         for k, v in batch_result.items():
@@ -3390,6 +3396,7 @@ class AbstractHowsoClient(ABC):
 
         return ret, in_size, out_size
 
+    @auto_progress("React Series (stationary)")
     def react_series_stationary(
         self,
         trainee_id: str,
@@ -3566,8 +3573,8 @@ class AbstractHowsoClient(ABC):
         if series_id_values is not None and series_id_features is None:
             series_id_features = internals.get_features_from_data(
                 series_id_values,
-                data_parameter='series_id_values',
-                features_parameter='series_id_features')
+                data_parameter="series_id_values",
+                features_parameter="series_id_features")
         serialized_series_id_values = serialize_cases(series_id_values, series_id_features, feature_attributes,
                                                       tokenizer=self._tokenizer)  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -3592,7 +3599,7 @@ class AbstractHowsoClient(ABC):
 
         if self._should_react_batch(react_stationary_params, total_size):
             if self.configuration.verbose:
-                print(f'Batch stationary series reacting on trainee with id: {trainee_id}')
+                print(f"Batch stationary series reacting on trainee with id: {trainee_id}")
             response = internals.ReactInBatches.run(
                 trainee_id=trainee_id,
                 params=react_stationary_params,
@@ -3607,7 +3614,7 @@ class AbstractHowsoClient(ABC):
             )
         else:
             if self.configuration.verbose:
-                print(f'Stationary series reacting on trainee with id: {trainee_id}')
+                print(f"Stationary series reacting on trainee with id: {trainee_id}")
             with ProgressTimer(total_size) as progress:
                 if isinstance(progress_callback, Callable):
                     progress_callback(progress, None)
@@ -3644,15 +3651,15 @@ class AbstractHowsoClient(ABC):
         """
         batch_result, in_size, out_size = self.execute_sized(trainee_id, "react_series_stationary", params)
 
-        if batch_result is None or batch_result.get('action_values') is None:
-            raise ValueError('Invalid parameters passed to react_series_stationary.')
+        if batch_result is None or batch_result.get("action_values") is None:
+            raise ValueError("Invalid parameters passed to react_series_stationary.")
 
         ret = dict()
         batch_result = util.replace_doublemax_with_infinity(batch_result)
 
         # batch_result always has action_features and action_values
-        ret['action_features'] = batch_result.pop('action_features') or []
-        ret['action_values'] = batch_result.pop('action_values') or []
+        ret["action_features"] = batch_result.pop("action_features") or []
+        ret["action_values"] = batch_result.pop("action_values") or []
 
         # ensure all the details items are output as well
         for k, v in batch_result.items():
@@ -3660,6 +3667,7 @@ class AbstractHowsoClient(ABC):
 
         return ret, in_size, out_size
 
+    @auto_progress("React into features", indeterminate=True)
     def react_into_features(
         self,
         trainee_id: str,
@@ -3748,7 +3756,7 @@ class AbstractHowsoClient(ABC):
         trainee_id = self._resolve_trainee(trainee_id).id
         util.validate_list_shape(features, 1, "features", "str")
         if self.configuration.verbose:
-            print(f'Reacting into features on Trainee with id: {trainee_id}')
+            print(f"Reacting into features on Trainee with id: {trainee_id}")
         self.execute(trainee_id, "react_into_features", {
             "analyze": analyze,
             "clustering_min_cluster_mass": clustering_min_cluster_mass,
@@ -4180,11 +4188,11 @@ class AbstractHowsoClient(ABC):
         if isinstance(details, dict):
             if action_condition_precision := details.get("action_condition_precision"):
                 if action_condition_precision not in self.SUPPORTED_PRECISION_VALUES:
-                    warnings.warn(self.WARNING_MESSAGES['invalid_precision'].format("action_condition_precision"))
+                    warnings.warn(self.WARNING_MESSAGES["invalid_precision"].format("action_condition_precision"))
 
             if context_condition_precision := details.get("context_condition_precision"):
                 if context_condition_precision not in self.SUPPORTED_PRECISION_VALUES:
-                    warnings.warn(self.WARNING_MESSAGES['invalid_precision'].format("context_condition_precision"))
+                    warnings.warn(self.WARNING_MESSAGES["invalid_precision"].format("context_condition_precision"))
 
         if num_robust_influence_samples is not None:
             num_robust_accuracy_contributions_samples = num_robust_influence_samples
@@ -4210,7 +4218,7 @@ class AbstractHowsoClient(ABC):
             )
 
         if self.configuration.verbose:
-            print(f'Reacting into aggregate trained cases of Trainee with id: {trainee_id}')
+            print(f"Reacting into aggregate trained cases of Trainee with id: {trainee_id}")
 
         stats = self.execute(trainee_id, "react_aggregate", {
             "action_features": action_features,
@@ -4250,12 +4258,13 @@ class AbstractHowsoClient(ABC):
             stats = dict()
 
         elif "confusion_matrix" in stats:
-            stats['confusion_matrix'] = internals.update_confusion_matrix(stats['confusion_matrix'],
+            stats["confusion_matrix"] = internals.update_confusion_matrix(stats["confusion_matrix"],
                                                                           feature_attributes)
 
         self._auto_persist_trainee(trainee_id)
         return stats
 
+    @auto_progress("React group", indeterminate=True)
     def react_group(
         self,
         trainee_id: str,
@@ -4410,7 +4419,7 @@ class AbstractHowsoClient(ABC):
                                                         tokenizer=self._tokenizer))  # pyright: ignore[reportAttributeAccessIssue]
 
         if self.configuration.verbose:
-            print(f'Reacting to a set of cases on Trainee with id: {trainee_id}')
+            print(f"Reacting to a set of cases on Trainee with id: {trainee_id}")
         result = self.execute(trainee_id, "react_group", {
             "action_features": action_features,
             "case_indices": case_indices,
@@ -4476,12 +4485,13 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         if self.configuration.verbose:
-            print(f'Evaluating on Trainee with id: {trainee_id}')
+            print(f"Evaluating on Trainee with id: {trainee_id}")
         return self.execute(trainee_id, "evaluate", {
             "aggregation_code": aggregation_code,
             "features_to_code_map": features_to_code_map,
         })
 
+    @auto_progress("Analyze", indeterminate=True)
     def analyze(
         self,
         trainee_id: str,
@@ -4614,7 +4624,7 @@ class AbstractHowsoClient(ABC):
         util.validate_list_shape(p_values, 1, "p_values", "int")
         util.validate_list_shape(dt_values, 1, "dt_values", "float")
 
-        if targeted_model not in ['single_targeted', 'omni_targeted', 'targetless', None]:
+        if targeted_model not in ["single_targeted", "omni_targeted", "targetless", None]:
             raise ValueError(
                 f'Invalid value "{targeted_model}" for targeted_model. '
                 'Valid values include single_targeted, omni_targeted, '
@@ -4649,15 +4659,15 @@ class AbstractHowsoClient(ABC):
         analyze_params.update(kwargs)
 
         if kwargs:
-            warn_params = ', '.join(kwargs)
+            warn_params = ", ".join(kwargs)
             warnings.warn(
-                'The following parameter(s) are not officially supported by `analyze` and '
-                f'may or may not have an effect: {warn_params}',
+                "The following parameter(s) are not officially supported by `analyze` and "
+                f"may or may not have an effect: {warn_params}",
                 UnsupportedArgumentWarning)
 
         if self.configuration.verbose:
-            print(f'Analyzing Trainee with id: {trainee_id}')
-            print('Analyzing Trainee with parameters: ' + str({
+            print(f"Analyzing Trainee with id: {trainee_id}")
+            print("Analyzing Trainee with parameters: " + str({
                 k: v for k, v in analyze_params.items() if v is not None
             }))
 
@@ -4825,9 +4835,9 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
 
-        if 'targeted_model' in kwargs:
-            targeted_model = kwargs['targeted_model']
-            if targeted_model not in ['single_targeted', 'omni_targeted', 'targetless']:
+        if "targeted_model" in kwargs:
+            targeted_model = kwargs["targeted_model"]
+            if targeted_model not in ["single_targeted", "omni_targeted", "targetless"]:
                 raise ValueError(
                     f'Invalid value "{targeted_model}" for targeted_model. '
                     'Valid values include single_targeted, omni_targeted, '
@@ -4842,7 +4852,7 @@ class AbstractHowsoClient(ABC):
                 UnsupportedArgumentWarning)
 
         if self.configuration.verbose:
-            print(f'Setting auto analyze parameters for Trainee with id: {trainee_id}')
+            print(f"Setting auto analyze parameters for Trainee with id: {trainee_id}")
 
         self.execute(trainee_id, "set_auto_analyze_params", {
             "action_features": action_features,
@@ -4918,7 +4928,7 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         if self.configuration.verbose:
-            print(f'Getting rebuild recommendation for Trainee with id: {trainee_id}')
+            print(f"Getting rebuild recommendation for Trainee with id: {trainee_id}")
         params: dict[str, Any] = {}
         if new_auto_ablation_params is not None:
             params["new_auto_ablation_params"] = new_auto_ablation_params
@@ -5068,9 +5078,10 @@ class AbstractHowsoClient(ABC):
                 f"may or may not have an effect: {warn_params}",
                 UnsupportedArgumentWarning)
         if self.configuration.verbose:
-            print(f'Setting auto ablation parameters for Trainee with id: {trainee_id}')
+            print(f"Setting auto ablation parameters for Trainee with id: {trainee_id}")
         self.execute(trainee_id, "set_auto_ablation_params", params)
 
+    @auto_progress("Reduce data")
     def reduce_data(
         self,
         trainee_id: str,
@@ -5136,7 +5147,7 @@ class AbstractHowsoClient(ABC):
                 f"may or may not have an effect: {warn_params}",
                 UnsupportedArgumentWarning)
         if self.configuration.verbose:
-            print(f'Reducing data on Trainee with id: {trainee_id}')
+            print(f"Reducing data on Trainee with id: {trainee_id}")
         result = self.execute(trainee_id, "reduce_data", params)
 
         if result is None:
@@ -5261,19 +5272,19 @@ class AbstractHowsoClient(ABC):
             util.validate_case_indices(case_indices)
 
         if precision is not None and precision not in self.SUPPORTED_PRECISION_VALUES:
-            warnings.warn(self.WARNING_MESSAGES['invalid_precision'].format("precision"))
+            warnings.warn(self.WARNING_MESSAGES["invalid_precision"].format("precision"))
 
         util.validate_list_shape(features, 1, "features", "str")
 
         # Convert session instance to id
         if (
             isinstance(condition, MutableMapping) and
-            isinstance(condition.get('.session'), Session)
+            isinstance(condition.get(".session"), Session)
         ):
-            condition['.session'] = condition['.session'].id
+            condition[".session"] = condition[".session"].id
 
         if self.configuration.verbose:
-            print(f'Retrieving cases for Trainee with id {trainee_id}.')
+            print(f"Retrieving cases for Trainee with id {trainee_id}.")
         result = self.execute(trainee_id, "get_cases", {
             "case_indices": case_indices,
             "condition": condition,
@@ -5287,8 +5298,8 @@ class AbstractHowsoClient(ABC):
         if result is None:
             result = dict()
         return Cases(
-            features=result.get('features') or [],
-            cases=result.get('cases') or [],
+            features=result.get("features") or [],
+            cases=result.get("cases") or [],
         )
 
     def get_extreme_cases(
@@ -5321,7 +5332,7 @@ class AbstractHowsoClient(ABC):
         util.validate_list_shape(features, 1, "features", "str")
 
         if self.configuration.verbose:
-            print(f'Getting extreme cases for trainee with id: {trainee_id}')
+            print(f"Getting extreme cases for trainee with id: {trainee_id}")
         result = self.execute(trainee_id, "get_extreme_cases", {
             "features": features,
             "num": num,
@@ -5330,8 +5341,8 @@ class AbstractHowsoClient(ABC):
         if result is None:
             result = dict()
         return Cases(
-            features=result.get('features') or [],
-            cases=result.get('cases') or [],
+            features=result.get("features") or [],
+            cases=result.get("cases") or [],
         )
 
     def get_num_training_cases(self, trainee_id: str) -> int:
@@ -5351,7 +5362,7 @@ class AbstractHowsoClient(ABC):
         trainee_id = self._resolve_trainee(trainee_id).id
         ret = self.execute(trainee_id, "get_num_training_cases", {})
         if isinstance(ret, dict):
-            return ret.get('count', 0)
+            return ret.get("count", 0)
         return 0
 
     def get_num_lags_needed(
@@ -5384,7 +5395,7 @@ class AbstractHowsoClient(ABC):
             "context_features": context_features,
         })
         if isinstance(ret, dict):
-            return ret.get('num_lags', 1)
+            return ret.get("num_lags", 1)
         return 1
 
     def get_feature_conviction(
@@ -5439,7 +5450,7 @@ class AbstractHowsoClient(ABC):
         util.validate_list_shape(features, 1, "features", "str")
         util.validate_list_shape(action_features, 1, "action_features", "str")
         if self.configuration.verbose:
-            print(f'Getting conviction of features for Trainee with id: {trainee_id}')
+            print(f"Getting conviction of features for Trainee with id: {trainee_id}")
         return self.execute(trainee_id, "get_feature_conviction", {
             "action_features": action_features,
             "familiarity_conviction_addition": familiarity_conviction_addition,
@@ -5537,9 +5548,9 @@ class AbstractHowsoClient(ABC):
         # Convert session instance to id
         if (
             isinstance(condition, MutableMapping) and
-            isinstance(condition.get('.session'), Session)
+            isinstance(condition.get(".session"), Session)
         ):
-            condition['.session'] = condition['.session'].id
+            condition[".session"] = condition[".session"].id
 
         if self.configuration.verbose:
             print(f'Adding feature "{feature_name}" to Trainee with id {trainee_id}.')
@@ -5622,9 +5633,9 @@ class AbstractHowsoClient(ABC):
         # Convert session instance to id
         if (
             isinstance(condition, MutableMapping) and
-            isinstance(condition.get('.session'), Session)
+            isinstance(condition.get(".session"), Session)
         ):
-            condition['.session'] = condition['.session'].id
+            condition[".session"] = condition[".session"].id
 
         if self.configuration.verbose:
             print(f'Removing feature "{feature}" from Trainee with id: {trainee_id}')
@@ -5737,16 +5748,16 @@ class AbstractHowsoClient(ABC):
         if from_values is not None:
             if features is None:
                 features = internals.get_features_from_data(
-                    from_values, data_parameter='from_values')
+                    from_values, data_parameter="from_values")
             from_values = serialize_cases(from_values, features, feature_attributes, tokenizer=self._tokenizer)  # pyright: ignore[reportAttributeAccessIssue]
         if to_values is not None:
             if features is None:
                 features = internals.get_features_from_data(
-                    to_values, data_parameter='to_values')
+                    to_values, data_parameter="to_values")
             to_values = serialize_cases(to_values, features, feature_attributes, tokenizer=self._tokenizer)  # pyright: ignore[reportAttributeAccessIssue]
 
         if self.configuration.verbose:
-            print(f'Getting pairwise distances for Trainee with id: {trainee_id}')
+            print(f"Getting pairwise distances for Trainee with id: {trainee_id}")
 
         result = self.execute(trainee_id, "get_pairwise_distances", {
             "action_feature": action_feature,
@@ -5838,7 +5849,7 @@ class AbstractHowsoClient(ABC):
                              "least 2 cases for computation.")
 
         if self.configuration.verbose:
-            print(f'Getting distances between cases for Trainee with id: {trainee_id}')
+            print(f"Getting distances between cases for Trainee with id: {trainee_id}")
 
         matrix_ndarray = None  # Used when preallocating
         page_size = 2000
@@ -5870,9 +5881,9 @@ class AbstractHowsoClient(ABC):
 
             # Data structs to accumulate for sparse representation
             total = num_cases * num_nearest_neighbors
-            rows = np.arange(num_cases, dtype='int64').repeat(num_nearest_neighbors)
-            cols = np.zeros(total, dtype='int64')
-            vals = np.zeros(total, dtype='float64')
+            rows = np.arange(num_cases, dtype="int64").repeat(num_nearest_neighbors)
+            cols = np.zeros(total, dtype="int64")
+            vals = np.zeros(total, dtype="float64")
 
             for row_offset in range(0, num_cases, page_size):
                 result = self.execute(trainee_id, "get_distances", {
@@ -5887,16 +5898,16 @@ class AbstractHowsoClient(ABC):
                     "num_nearest_neighbors": num_nearest_neighbors
                 })
 
-                column_indices = result['column_numeric_indices']
-                row_case_indices = result['row_case_indices']
-                distances = result['distances']
+                column_indices = result["column_numeric_indices"]
+                row_case_indices = result["row_case_indices"]
+                distances = result["distances"]
 
                 indices += row_case_indices
                 try:
                     start = row_offset * num_nearest_neighbors
                     end = start + len(row_case_indices) * num_nearest_neighbors
-                    cols[start:end] = np.asarray(column_indices, dtype='int64').ravel()
-                    vals[start:end] = np.asarray(distances, dtype='float64').ravel()
+                    cols[start:end] = np.asarray(column_indices, dtype="int64").ravel()
+                    vals[start:end] = np.asarray(distances, dtype="float64").ravel()
                 except ValueError as err:
                     # Unexpected shape when populating array
                     raise HowsoError(mismatch_msg) from err
@@ -5907,7 +5918,7 @@ class AbstractHowsoClient(ABC):
         else:
             # sparse = False
             # Preallocate matrix (This will raise a numpy MemoryError if too large)
-            matrix_ndarray = np.zeros((num_cases, num_cases), dtype='float64')
+            matrix_ndarray = np.zeros((num_cases, num_cases), dtype="float64")
 
             for row_offset in range(0, num_cases, page_size):
                 for column_offset in range(0, num_cases, page_size):
@@ -5924,9 +5935,9 @@ class AbstractHowsoClient(ABC):
                         "sparse": False,
                     })
 
-                    column_case_indices = result['column_case_indices']
-                    row_case_indices = result['row_case_indices']
-                    distances = result['distances']
+                    column_case_indices = result["column_case_indices"]
+                    row_case_indices = result["row_case_indices"]
+                    distances = result["distances"]
 
                     try:
                         matrix_ndarray[
@@ -5954,8 +5965,8 @@ class AbstractHowsoClient(ABC):
             raise HowsoError(mismatch_msg)
 
         return {
-            'case_indices': indices,
-            'distances': out_df # Could be sparse or not sparse
+            "case_indices": indices,
+            "distances": out_df # Could be sparse or not sparse
         }
 
     def get_params(
@@ -6016,7 +6027,7 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         if self.configuration.verbose:
-            print(f'Getting model attributes from Trainee with id: {trainee_id}')
+            print(f"Getting model attributes from Trainee with id: {trainee_id}")
         return self.execute(trainee_id, "get_params", {
             "action_feature": action_feature,
             "context_features": context_features,
@@ -6058,7 +6069,7 @@ class AbstractHowsoClient(ABC):
         """
         trainee_id = self._resolve_trainee(trainee_id).id
         if self.configuration.verbose:
-            print(f'Setting model attributes for Trainee with id: {trainee_id}')
+            print(f"Setting model attributes for Trainee with id: {trainee_id}")
 
         parameters = dict(params)
 

--- a/howso/direct/client.py
+++ b/howso/direct/client.py
@@ -43,6 +43,7 @@ from howso.client.schemas import (
 from howso.client.typing import LibraryType, Persistence
 from howso.direct.schemas import CombineTraineesResult, DirectTrainee
 from howso.utilities import HowsoTokenizer, internals, TokenizerProtocol
+from howso.utilities.progress import auto_progress
 from howso.utilities.random import get_random_seed
 
 # Client version
@@ -1899,6 +1900,7 @@ class HowsoDirectClient(AbstractHowsoClient):
             trainee_path = list(trainee_path)
         return self.execute(trainee_id, "get_hierarchy", {"path_list": trainee_path})
 
+    @auto_progress("Merge trainees", indeterminate=True)
     def combine_trainee_with_subtrainees(
         self,
         trainee_id: str,

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -1099,7 +1099,7 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the 'set_auto_analyze_params' method.")
 
-    @auto_progress("Analyze")
+    @auto_progress("Analyze", indeterminate=True)
     def analyze(
         self,
         context_features: Collection[str] | None = None,
@@ -1862,7 +1862,7 @@ class Trainee(BaseTrainee):
 
                 - "goal": "min" or "max", will make a prediction while minimizing or
                   maximizing the value for the feature.
-                - "value" : somevalue, will make a prediction while approaching the
+                - "value" : some_value, will make a prediction while approaching the
                   specified value.
 
             .. NOTE::
@@ -2483,7 +2483,7 @@ class Trainee(BaseTrainee):
         else:
             raise ValueError("Trainee ID is needed for react_series_stationary.")
 
-    @auto_progress("Impute")
+    @auto_progress("Impute", indeterminate=True)
     def impute(
         self,
         *,
@@ -3290,7 +3290,7 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the 'get_substitute_feature_values' method.")
 
-    @auto_progress("React group")
+    @auto_progress("React group", indeterminate=True)
     def react_group(
         self,
         *,
@@ -3681,7 +3681,7 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the `get_value_masses` method.")
 
-    @auto_progress("React into features")
+    @auto_progress("React into features", indeterminate=True)
     def react_into_features(
         self,
         *,
@@ -3788,7 +3788,7 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the 'react_into_features' method.")
 
-    @auto_progress("React aggregate")
+    @auto_progress("React aggregate", indeterminate=True)
     def react_aggregate(
         self,
         *,

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -66,10 +66,10 @@ from howso.utilities.progress import auto_progress, engine_polling_supported
 
 __all__ = [
     "Trainee",
+    "delete_trainee",
+    "get_trainee",
     "list_trainees",
     "load_trainee",
-    "get_trainee",
-    "delete_trainee",
     "query_trainees",
 ]
 
@@ -996,6 +996,7 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the 'set_auto_ablation_params' method.")
 
+    @auto_progress("Reduce data")
     def reduce_data(
         self,
         features: Collection[str] | None = None,

--- a/howso/engine/trainee.py
+++ b/howso/engine/trainee.py
@@ -62,7 +62,7 @@ from howso.engine.client import get_client
 from howso.engine.project import Project
 from howso.engine.session import Session
 from howso.utilities.feature_attributes.base import SingleTableFeatureAttributes
-from howso.utilities.progress import auto_progress, engine_polling_supported
+from howso.utilities.progress import engine_polling_supported
 
 __all__ = [
     "Trainee",
@@ -692,7 +692,6 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have 'set_random_seed' method")
 
-    @auto_progress("Train")
     def train(
         self,
         cases: TabularData2D | Generator[DataFrame, int],
@@ -996,7 +995,6 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the 'set_auto_ablation_params' method.")
 
-    @auto_progress("Reduce data")
     def reduce_data(
         self,
         features: Collection[str] | None = None,
@@ -1100,7 +1098,6 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the 'set_auto_analyze_params' method.")
 
-    @auto_progress("Analyze", indeterminate=True)
     def analyze(
         self,
         context_features: Collection[str] | None = None,
@@ -1333,7 +1330,6 @@ class Trainee(BaseTrainee):
 
         return results['action']
 
-    @auto_progress("React")
     def react(
         self,
         contexts: TabularData2D | None = None,
@@ -2019,7 +2015,6 @@ class Trainee(BaseTrainee):
             weight_feature=weight_feature,
         )
 
-    @auto_progress("React Series")
     def react_series(
         self,
         *,
@@ -2330,7 +2325,6 @@ class Trainee(BaseTrainee):
         else:
             raise ValueError("Trainee ID is needed for react_series.")
 
-    @auto_progress("React Series (stationary)")
     def react_series_stationary(
         self,
         action_features: Collection[str],
@@ -2484,7 +2478,6 @@ class Trainee(BaseTrainee):
         else:
             raise ValueError("Trainee ID is needed for react_series_stationary.")
 
-    @auto_progress("Impute", indeterminate=True)
     def impute(
         self,
         *,
@@ -3291,7 +3284,6 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the 'get_substitute_feature_values' method.")
 
-    @auto_progress("React group", indeterminate=True)
     def react_group(
         self,
         *,
@@ -3682,7 +3674,6 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the `get_value_masses` method.")
 
-    @auto_progress("React into features", indeterminate=True)
     def react_into_features(
         self,
         *,
@@ -3789,7 +3780,6 @@ class Trainee(BaseTrainee):
         else:
             raise AssertionError("Client must have the 'react_into_features' method.")
 
-    @auto_progress("React aggregate", indeterminate=True)
     def react_aggregate(
         self,
         *,

--- a/howso/utilities/__init__.py
+++ b/howso/utilities/__init__.py
@@ -22,6 +22,8 @@ from howso.utilities.monitors import (
 from howso.utilities.progress import (
     ProgressEvent,
     ProgressReporter,
+    RichDisplayProgressReporter,
+    RichNotebookProgressReporter,
     RichProgressReporter,
     SimpleProgressReporter,
     auto_progress,
@@ -93,6 +95,8 @@ __all__ = [
     "ProgressEvent",
     "ProgressReporter",
     "ProgressTimer",
+    "RichDisplayProgressReporter",
+    "RichNotebookProgressReporter",
     "RichProgressReporter",
     "SimpleProgressReporter",
     "SingleTableFeatureAttributes",

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -55,7 +55,7 @@ from rich.progress import (
     TimeElapsedColumn,
 )
 from rich.segment import Segment
-from rich.table import Column, Table
+from rich.table import Table
 from rich.text import Text
 
 from howso.utilities.monitors import ProgressTimer
@@ -126,17 +126,6 @@ NOTEBOOK_DETAIL_LIMIT = 48
 # longest label, a comma-grouped 100,000,000-row counter (23 characters), the
 # details, elapsed and an estimate, all inside NOTEBOOK_COLUMNS.
 BAR_WIDTH = 24
-
-_AUTO_PROGRESS_LABELS: set[str] = set()
-"""
-Every label :func:`auto_progress` has registered, for sizing the label column.
-
-Populated at decoration time, so it grows as modules are imported — including
-downstream packages that decorate their own methods. Sizing from this rather
-than a hard-coded number means renaming or adding a method keeps the columns
-aligned without anyone remembering to update a constant.
-"""
-
 
 @dataclass
 class ProgressEvent:
@@ -249,7 +238,7 @@ class BaseProgressReporter:
 
     def _eta_text(self, eta: timedelta | None) -> str:
         """
-        Render an estimate, labelled to fit this reporter's console.
+        Render an estimate, labeled to fit this reporter's console.
 
         Parameters
         ----------
@@ -335,37 +324,85 @@ class BaseProgressReporter:
 
 
 class RichProgressReporter(BaseProgressReporter):
-    """
-    Rich-based reporter that renders one bar per progress source.
+    r"""
+    Rich-based reporter that renders every progress source as one merged bar.
 
-    When started with both the ``batch`` and ``engine`` sources, two bars are
-    rendered: the ``batch`` (outer) bar carries the session label, and the
-    ``engine`` (inner) bar is indented beneath it so the two read as nested.
-    Which sources are present is decided upstream by :func:`with_progress`
-    from the wrapped method's ``progress_callback`` / ``task_id`` hooks. With
-    no sources at all, nothing is rendered until the final completion line.
+    A session declares its sources upstream, in :func:`with_progress`, from the
+    wrapped method's ``progress_callback`` / ``task_id`` hooks. However many
+    there are, they share a single bar: ``batch`` owns it whenever it is live,
+    because it is the meaningful outer measure, and ``engine`` is folded into
+    the details column beside it::
+
+        React ---------------->  2/4  engine 1/3 - reacting        0:00:09
+
+    One bar rather than a nested pair is what lets this render identically in a
+    terminal and in a notebook. A notebook front-end renders SGR color codes
+    and treats ``\r`` as a real line rewind, but *discards* cursor-motion codes
+    rather than acting on them, so any layout taller than one line would append
+    a fresh copy of itself on every refresh instead of redrawing in place.
+    Rather than keep two layouts in step, there is one.
+
+    Subclasses vary only in **delivery** -- how a rendered frame reaches the
+    reader. The lifecycle around it (build the model, apply events, settle the
+    tracks, print the completion line) lives here and is not overridden;
+    :meth:`_make_console`, :meth:`_open_delivery`, :meth:`_deliver` and
+    :meth:`_close_delivery` are the seams.
+
+    With no sources at all, nothing is rendered until the final completion line.
 
     Parameters
     ----------
     console : Console, optional
-        Console to render into. Defaults to a fresh :class:`rich.console.Console`.
-    transient : bool, default True
-        When ``True``, the progress bars are cleared once the session
-        finishes, leaving only the final completion line.
+        Console to render into. Defaults to :meth:`_make_console`.
+    transient : bool, optional
+        Override :attr:`_transient` for this instance.
+    """
+
+    _refresh_hz: float = 10.0
+    """Frames per second for the live region. rich's own default."""
+
+    _transient: bool = True
+    """
+    Which route a *successful* session takes to hand its line to the summary.
+
+    Cleared, and the summary is printed where the region was; kept, and the
+    summary is repainted *into* the region as its last frame. The reader ends
+    up with the same single line either way — this only picks how. Clearing is
+    the natural fit for a terminal and is the default, but it costs a
+    cursor-up, so a front-end that discards those turns it off.
+
+    A failed session ignores this and keeps its bar, whichever route the
+    reporter would normally take. See :meth:`_close_delivery`.
     """
 
     def __init__(  # pyright: ignore[reportMissingSuperCall]
         self,
         *,
         console: Console | None = None,
-        transient: bool = True,
+        transient: bool | None = None,
     ) -> None:
         """Initialize the reporter."""
-        self._console = console or Console()
-        self._transient = transient
-        self._progress: Progress | None = None
+        self._console = console if console is not None else self._make_console()
+        if transient is not None:
+            self._transient = transient
+        self._progress: _SummarizingProgress | None = None
         self._tasks: dict[ProgressSource, TaskID] = {}
         self._label: str = ""
+        self._primary: ProgressSource | None = None
+        self._secondary: ProgressSource | None = None
+        self._detail: str = ""
+        self._engine: tuple[int, int, str] | None = None
+
+    def _make_console(self) -> Console:
+        """
+        Build the console to render into when the caller supplies none.
+
+        Returns
+        -------
+        Console
+            A stock console, which measures the attached terminal.
+        """
+        return Console()
 
     def _bar_column(self) -> BarColumn:
         """
@@ -374,25 +411,20 @@ class RichProgressReporter(BaseProgressReporter):
         Returns
         -------
         BarColumn
-            rich's stock bar.
+            A bar that colors itself from the session's state.
         """
         return _StateBarColumn(bar_width=BAR_WIDTH)
 
-    def _make_columns(
-        self, *, activity: bool = False, label_width: int | None = None
-    ) -> tuple[ProgressColumn, ...]:
+    def _make_columns(self, *, activity: bool = False) -> tuple[ProgressColumn, ...]:
         """
         Build the column layout shared by every bar this reporter renders.
 
-        Subclasses that lay tracks out differently reuse this so a bar reads
-        the same wherever it is rendered.
+        The label column sizes itself from the one label it holds. Nothing has
+        to line up across sessions: only one bar is ever on screen, since a
+        successful session hands its line to the summary on the way out.
 
         Parameters
         ----------
-        label_width : int, optional
-            Pin the label column to this width. Leaving it unset lets rich size
-            the column from its content, which makes labels and bars land in
-            different columns from one session to the next.
         activity : bool, default False
             Drop the counter, details and estimate columns. An activity track
             measures nothing, so they would render a meaningless ``0/?`` and
@@ -403,12 +435,7 @@ class RichProgressReporter(BaseProgressReporter):
         tuple of ProgressColumn
             The columns to hand to :class:`rich.progress.Progress`.
         """
-        label = (
-            TextColumn("[bold cyan]{task.description}")
-            if label_width is None
-            else TextColumn("[bold cyan]{task.description}",
-                            table_column=Column(width=label_width))
-        )
+        label = TextColumn("[bold cyan]{task.description}")
         if activity:
             # No details column either: an activity track carries none, and an
             # empty column still takes its padding on both sides, leaving a
@@ -430,81 +457,226 @@ class RichProgressReporter(BaseProgressReporter):
             TextColumn("[green]{task.fields[eta]}"),
         )
 
-    @staticmethod
-    def _track_descriptions(
-        label: str, sources: Sequence[ProgressSource]
-    ) -> dict[ProgressSource, str]:
+    def _compose_details(self) -> str:
         """
-        Name each track so the nesting reads visually.
+        Render the details column from whichever sources have reported.
 
-        When both sources are present the outer (batch) bar carries the method
-        name and the inner (engine) bar gets an indented hint. When engine is
-        the only source (e.g. ``analyze``), it uses the method label directly —
-        no orphan indent.
+        Returns
+        -------
+        str
+            The primary source's own details, with the secondary source's
+            progress prepended when it has reported any.
+        """
+        if self._engine is None:
+            return self._detail
+        step, total, detail = self._engine
+        note = f"engine {step}/{total or '?'}"
+        return _one_line(f"{note} · {detail}" if detail else note)
+
+    def _prepare_merged(self, label: str, sources: Sequence[ProgressSource]) -> bool:
+        """
+        Build the single-bar model, without delivering anything.
+
+        Splitting this from delivery is what lets every reporter share one
+        rendering: whether frames are repainted over stdout or pushed into a
+        display slot, they are frames of the same model.
 
         Parameters
         ----------
         label : str
             Session label.
         sources : sequence of ProgressSource
-            The declared progress sources.
+            Declared sources, all of which share one bar.
 
         Returns
         -------
-        dict
-            Description text keyed by source.
+        bool
+            False when there is nothing to track, so the caller can bail out
+            rather than open a live region or claim a display slot for nothing.
         """
-        both = "batch" in sources and "engine" in sources
-        fallback = label or "Working"
-        return {"batch": fallback, "engine": "  engine" if both else fallback}
+        self._label = label
+        self._detail = ""
+        self._engine = None
+        # ``batch`` is the outer measure when it is live, so it owns the bar and
+        # ``engine`` is demoted to the details text. Otherwise the first declared
+        # source owns it, which matters for ``activity``: it is neither, and
+        # would otherwise leave the session blank.
+        if "batch" in sources:
+            self._primary = "batch"
+        elif "engine" in sources:
+            self._primary = "engine"
+        else:
+            self._primary = sources[0] if sources else None
+        self._secondary = (
+            "engine" if (self._primary == "batch" and "engine" in sources) else None
+        )
+        if self._primary is None:
+            return False
+        self._progress = _SummarizingProgress(
+            *self._make_columns(activity=tuple(sources) == ("activity",)),
+            console=self._console,
+            transient=self._transient,
+            # Each column takes exactly the width its content needs. Letting
+            # rich expand to fill the console redistributes the slack between
+            # them, which moves the bar every time the details text changes
+            # length.
+            expand=False,
+            refresh_per_second=self._refresh_hz,
+        )
+        return True
 
-    def start(self, label: str, *, sources: Sequence[ProgressSource]) -> None:
+    def _add_merged_task(self, label: str, sources: Sequence[ProgressSource]) -> None:
         """
-        Begin a reporting session and add one bar per progress source.
+        Create the one shared track and point every declared source at it.
 
         Parameters
         ----------
         label : str
-            Short description shown on the batch (outer) bar.
+            Session label, shown on the bar.
         sources : sequence of ProgressSource
-            Which progress sources will emit events; one bar is created for
-            each, in the given order. May be empty, in which case no bars are
-            created.
+            Sources to register against the single track.
 
         Returns
         -------
         None
         """
-        self._label = label
-        self._progress = Progress(
-            *self._make_columns(
-                activity=tuple(sources) == ("activity",),
-                label_width=_label_column_width(label, *self._track_descriptions(label, sources).values()),
-            ),
-            console=self._console,
-            transient=self._transient,
+        if self._progress is None:
+            return
+        task = self._progress.add_task(
+            label or "Working", total=None, details="", eta="", done=False, ok=False
         )
-        # Flush both stderr and stdout
-        self._flush_all()
-
-        self._progress.start()
-        descriptions = self._track_descriptions(label, sources)
-        fallback = label or "Working"
+        # Registering every declared source against the one track is what makes
+        # the "an undeclared source is ignored" guard in update() work.
         for source in sources:
-            self._tasks[source] = self._progress.add_task(
-                descriptions.get(source, fallback),
-                total=None,
-                details="",
-                eta="",
-                done=False,
-                ok=False,
-            )
+            self._tasks[source] = task
+
+    def _open_delivery(self) -> None:
+        """
+        Begin delivering frames to the reader.
+
+        Called once per session, after the model and its track exist, so an
+        implementation is free to render a first frame immediately.
+
+        Returns
+        -------
+        None
+        """
+        if self._progress is not None:
+            self._progress.start()
+
+    def _deliver(self) -> None:
+        """
+        Push the current frame, if this delivery is not self-driving.
+
+        A no-op here: rich's ``Live`` runs its own refresh thread.
+
+        Returns
+        -------
+        None
+        """
+
+    def _close_delivery(self, line: str, *, success: bool) -> None:
+        """
+        Stop delivering frames and emit the completion line.
+
+        The summary takes the bar's line over, by whichever route this
+        reporter's front-end supports — see :attr:`_transient`. Two cases keep
+        the bar instead and put the summary beneath it:
+
+        * **A failed session.** The settled bar is the only record of how far
+          the call got — ``batch 7``, ``engine 2/5`` — and the summary has room
+          for none of that. Losing it on the one run where it matters most
+          would be a poor trade for a saved line.
+        * **An unlabeled session**, which has no summary to take the line over
+          with. Clearing there would leave nothing at all.
+
+        Both are decided here rather than per reporter, so the two routes agree
+        on what a reader ends up with.
+
+        Parameters
+        ----------
+        line : str
+            Console markup for the completion line, or ``""`` when there is
+            nothing worth printing.
+        success : bool
+            Whether the wrapped call completed without raising.
+
+        Returns
+        -------
+        None
+        """
+        # Clearing only makes sense when a summary is taking the line over.
+        clearing = success and self._transient and bool(line)
+        if self._progress is not None:
+            if success and line and not clearing:
+                # Repaint the region with the summary so it lands *on* the
+                # bar's line. Printing it instead would put it underneath, and
+                # reclaiming the bar's line needs a cursor-up that a notebook
+                # discards — which is what would split the two paths again.
+                self._progress.summary = Text.from_markup(line)
+            # rich reads this at stop time, so a failed session can withdraw
+            # the clearing its reporter would normally do.
+            self._progress.live.transient = clearing
+            self._progress.stop()
+        if line and not (success and not clearing):
+            # Either the region was cleared on the way out, taking the summary
+            # with it, or the bar is being kept and the summary goes below it.
+            self._console.print(line)
+        self._unwind_rich_proxies()
+
+    @staticmethod
+    def _unwind_rich_proxies() -> None:
+        """
+        Put ``sys.stdout``/``sys.stderr`` back if rich's ``Live`` left a proxy.
+
+        ``Live`` swaps both streams for a ``FileProxy`` so stray prints render
+        above the bar, and restores them in a ``finally``. A ``KeyboardInterrupt``
+        landing inside that teardown can still leak one, which in a notebook
+        kernel is sticky: every later cell would write into a dead console until
+        the user restarts it.
+
+        Returns
+        -------
+        None
+        """
+        for name in ("stdout", "stderr"):
+            stream = getattr(sys, name)
+            proxied = getattr(stream, "rich_proxied_file", None)
+            if proxied is not None and proxied is not stream:
+                setattr(sys, name, proxied)
+
+    def start(self, label: str, *, sources: Sequence[ProgressSource]) -> None:
+        """
+        Begin a reporting session, mapping every source onto a single bar.
+
+        Parameters
+        ----------
+        label : str
+            Short description shown on the bar.
+        sources : sequence of ProgressSource
+            Which progress sources will emit events. All of them share one
+            bar. May be empty, in which case nothing is rendered and no
+            delivery is opened.
+
+        Returns
+        -------
+        None
+        """
+        if not self._prepare_merged(label, sources):
+            return
+        self._add_merged_task(label, sources)
+        # Drain both stderr and stdout, so anything already buffered lands
+        # above the region about to be painted rather than through it.
+        self._flush_all()
+        self._open_delivery()
 
     def update(self, event: ProgressEvent) -> None:
         """
-        Apply a single progress event to its corresponding bar.
+        Apply an event to the shared bar, routing by source.
 
-        Events for an unknown source, or events arriving before
+        The primary source drives the bar's position; the secondary source
+        only contributes text, so it can never move a bar it does not own.
+        Events for an undeclared source, or events arriving before
         :meth:`start`, are ignored.
 
         Parameters
@@ -518,17 +690,24 @@ class RichProgressReporter(BaseProgressReporter):
         """
         if self._progress is None or event.source not in self._tasks:
             return
-        self._progress.update(
-            self._tasks[event.source],
-            completed=event.step,
-            total=event.total or None,
-            details=event.details,
-            eta=self._eta_text(event.eta),
-        )
+        task = self._tasks[event.source]
+        if event.source == self._secondary:
+            self._engine = (event.step, event.total, _one_line(event.details))
+            self._progress.update(task, details=self._compose_details())
+        else:
+            self._detail = _one_line(event.details)
+            self._progress.update(
+                task,
+                completed=event.step,
+                total=event.total or None,
+                details=self._compose_details(),
+                eta=self._eta_text(event.eta),
+            )
+        self._deliver()
 
     def finish(self, *, success: bool, duration: timedelta) -> None:
         """
-        Tear down the live renderer and print a final completion line.
+        Settle the bar, close delivery and emit a final completion line.
 
         Parameters
         ----------
@@ -541,14 +720,20 @@ class RichProgressReporter(BaseProgressReporter):
         -------
         None
         """
-        if self._progress is not None:
+        line = self._completion_markup(success=success, duration=duration)
+        if self._progress is None:
+            # No session was ever rendered, so there is nothing to close.
+            if line:
+                self._console.print(line)
+        else:
             self._mark_done(success=success)
-            self._progress.stop()
+            self._close_delivery(line, success=success)
             self._progress = None
             self._tasks.clear()
-        line = self._completion_markup(success=success, duration=duration)
-        if line:
-            self._console.print(line)
+        self._primary = None
+        self._secondary = None
+        self._engine = None
+        self._detail = ""
         self._flush_all()
 
 
@@ -753,7 +938,7 @@ class _StateBarColumn(BarColumn):
     DONE_STYLE = "green"
     # The unfilled track. rich's default is ``grey23``, a 256-cube index that no
     # theme remaps — roughly #3a3a3a, which reads as *filled* on a light
-    # background. A named ANSI colour lands in the palette the front-end themes.
+    # background. A named ANSI color lands in the palette the front-end themes.
     TRACK_STYLE = "bright_black"
 
     def render(self, task: Any) -> Any:
@@ -865,12 +1050,41 @@ class _OverwriteSafeWriter(io.TextIOBase):
             shortfall = self._written - len(line)
             if shortfall > 0:
                 line += self._PAD * shortfall
-            # The region ends at a newline; after that nothing is overwritten.
-            self._written = 0 if newline else len(line)
             text = f"{head}\r{line}{newline}{rest}"
-        elif "\n" in text:
-            self._written = 0
+            # A carriage return puts the cursor back at column zero, so only
+            # what follows the last one is on the line now.
+            self._written = self._line_length(f"{line}{newline}{rest}", 0)
+        else:
+            # No carriage return: this appends to whatever is already there.
+            # Tracking it matters — rich emits its *first* frame with no cursor
+            # positioning at all, since it has no previous frame to rewind over.
+            # Leaving that one untracked is what let a session ending before the
+            # second frame (a call fast enough to finish inside one refresh
+            # interval) leave the whole bar standing behind its own summary.
+            self._written = self._line_length(text, self._written)
         return self._wrapped.write(text)
+
+    @staticmethod
+    def _line_length(text: str, start: int) -> int:
+        """
+        Return how much is on the line once ``text`` is written from ``start``.
+
+        Parameters
+        ----------
+        text : str
+            The text being written, with no carriage returns before it matters.
+        start : int
+            Raw characters already on the line.
+
+        Returns
+        -------
+        int
+            Raw characters on the line the cursor ends up on. A newline starts
+            a fresh line, so only what follows the last one counts.
+        """
+        if "\n" in text:
+            return len(text.rpartition("\n")[2])
+        return start + len(text)
 
     def flush(self) -> None:
         """Flush the underlying file."""
@@ -881,32 +1095,55 @@ class _OverwriteSafeWriter(io.TextIOBase):
         return bool(getattr(self._wrapped, "isatty", bool)())
 
 
+class _SummarizingProgress(Progress):
+    """
+    A ``Progress`` whose live region can be handed a closing line to render.
+
+    Progress reporting ends with two things to say — the bar's final state and
+    a one-line summary — and only one line to say them on. Printing the summary
+    separately puts it *beneath* the bar, and reclaiming the bar's line then
+    needs a cursor-up, which a notebook front-end discards. Rendering the
+    summary as the region's own last frame repaints it exactly where the bar
+    was, using nothing but the carriage return every front-end honors.
+
+    ``get_renderable`` is rich's documented hook for exactly this.
+    """
+
+    summary: Text | None = None
+    """Renders in place of the bars once set. ``None`` while the session runs."""
+
+    def get_renderable(self) -> Any:
+        """
+        Return the summary once there is one, else the bars.
+
+        Returns
+        -------
+        Any
+            A rich renderable for the current frame.
+        """
+        if self.summary is not None:
+            return self.summary
+        return super().get_renderable()
+
+
 class RichNotebookProgressReporter(RichProgressReporter):
     r"""
-    Rich reporter for notebook front-ends, which render ANSI but not cursor motion.
+    Rich reporter delivering frames to a notebook front-end's stdout.
 
-    JupyterLab, VS Code, Databricks and Colab all render SGR color codes and
-    treat ``\r`` as a real line rewind, but they *discard* cursor-motion codes
-    rather than acting on them. :class:`RichProgressReporter` repaints an
-    ``H``-line region with ``\r`` + erase-line followed by ``H - 1``
-    cursor-ups, so its nested two-bar layout would append a fresh copy of the
-    bars on every refresh instead of redrawing them.
+    The layout is the parent's, unchanged — that is the point. What differs is
+    the two things a kernel demands of the stream underneath it:
 
-    This reporter therefore renders **one** bar and keeps it non-transient —
-    measured against rich 15.0.0, that is the only configuration emitting zero
-    cursor-up sequences. When both progress sources are live, ``batch`` owns
-    the bar (it is the meaningful outer measure) and ``engine`` is folded into
-    the details column::
+    * The console must be built to reach rich's plain-ANSI path from inside a
+      kernel, which :func:`_notebook_console` does; a stock ``Console()`` there
+      silently renders nothing.
+    * The repaint must survive a front-end that implements ``\r`` as a raw-index
+      overwrite and drops the erase-line code, so a frame shorter than its
+      predecessor would leave that predecessor's tail on screen.
+      :class:`_OverwriteSafeWriter` pads over it.
 
-        Train ---------------->        4/10 engine 2/5 - analyzing   0:00:04
-
-    Two consequences worth knowing:
-
-    * The finished bar stays in the cell output beneath the completion line,
-      rather than being cleared as in a terminal. That is deliberate, and is
-      what keeps the cursor-up count at zero.
-    * ``transient`` is not exposed. A caller who wants the terminal behavior
-      should construct :class:`RichProgressReporter` directly.
+    ``transient`` is not exposed. Clearing the finished bar needs the cursor
+    motion a notebook discards, so a caller who wants that should construct
+    :class:`RichProgressReporter` directly.
 
     Parameters
     ----------
@@ -914,238 +1151,74 @@ class RichNotebookProgressReporter(RichProgressReporter):
         Console to render into. Defaults to :func:`_notebook_console`. A
         console supplied here is used as-is, so it must already be built with
         ``force_jupyter=False`` and ``force_terminal=True`` — rich exposes no
-        way to retrofit those, and a stock ``Console()`` inside a kernel
-        silently renders nothing.
+        way to retrofit those.
+    """
+
+    _refresh_hz: float = NOTEBOOK_REFRESH_HZ
+    """Slower than a terminal: every frame is a message over the kernel's IOPub."""
+
+    _transient: bool = False
+    """
+    Never clear: rich clears a one-line region with ``\r ESC[1A ESC[2K``, and a
+    notebook honors only the first of those three. The bar would survive and the
+    summary would land beneath it, indented by the overwrite padding. Repainting
+    the region with the summary reaches the same place using only ``\r``.
     """
 
     def __init__(self, *, console: Console | None = None) -> None:
         """Initialize the reporter."""
-        super().__init__(console=console or _notebook_console(), transient=False)
-        self._primary: ProgressSource | None = None
-        self._secondary: ProgressSource | None = None
-        self._detail: str = ""
-        self._engine: tuple[int, int, str] | None = None
+        super().__init__(console=console)
         self._unwrapped_file: Any = None
 
-    def _bar_column(self) -> BarColumn:
+    def _make_console(self) -> Console:
         """
-        Build a bar that never pulses.
+        Build a console that renders ANSI from inside a kernel.
 
         Returns
         -------
-        BarColumn
-            A :class:`_QuietBarColumn`, whose narrow frame-length spread keeps
-            the carriage-return repaint's padding to a few characters.
+        Console
+            A console on rich's plain-ANSI path, pinned to a fixed width.
         """
-        return _StateBarColumn(bar_width=BAR_WIDTH)
+        return _notebook_console()
 
-    def _compose_details(self) -> str:
-        """Render the details column from whichever sources have reported."""
-        if self._engine is None:
-            return self._detail
-        step, total, detail = self._engine
-        note = f"engine {step}/{total or '?'}"
-        return _one_line(f"{note} \u00b7 {detail}" if detail else note)
-
-    def _prepare_merged(self, label: str, sources: Sequence[ProgressSource]) -> bool:
+    def _open_delivery(self) -> None:
         """
-        Build the single-bar model, without delivering anything.
-
-        The caller decides how frames reach the reader -- repainted over stdout,
-        or pushed into a display slot. Sharing this is what makes a notebook
-        rendered by nbconvert or papermill look like the interactive one.
-
-        Parameters
-        ----------
-        label : str
-            Session label.
-        sources : sequence of ProgressSource
-            Declared sources, all of which share one bar.
-
-        Returns
-        -------
-        bool
-            False when there is nothing to track, so the caller can bail out
-            rather than open a live region or claim a display slot for nothing.
-        """
-        self._label = label
-        self._detail = ""
-        self._engine = None
-        # ``batch`` is the outer measure when it is live, so it owns the bar and
-        # ``engine`` is demoted to the details text. Otherwise the first declared
-        # source owns it, which matters for ``activity``: it is neither, and
-        # would otherwise leave this reporter blank.
-        if "batch" in sources:
-            self._primary = "batch"
-        elif "engine" in sources:
-            self._primary = "engine"
-        else:
-            self._primary = sources[0] if sources else None
-        self._secondary = (
-            "engine" if (self._primary == "batch" and "engine" in sources) else None
-        )
-        if self._primary is None:
-            return False
-        self._progress = Progress(
-            *self._make_columns(
-                activity=tuple(sources) == ("activity",),
-                label_width=_label_column_width(
-                    label, *self._track_descriptions(label, sources).values()
-                ),
-            ),
-            console=self._console,
-            transient=self._transient,
-            # Columns are pinned instead: letting rich redistribute slack put
-            # labels and bars in different columns from one session to the next.
-            expand=False,
-            refresh_per_second=NOTEBOOK_REFRESH_HZ,
-        )
-        return True
-
-    def start(self, label: str, *, sources: Sequence[ProgressSource]) -> None:
-        """
-        Begin a reporting session, mapping every source onto a single bar.
-
-        Parameters
-        ----------
-        label : str
-            Short description shown on the bar.
-        sources : sequence of ProgressSource
-            Which progress sources will emit events. All of them share one
-            bar. May be empty, in which case no bar and no live region are
-            created at all.
+        Wrap the stream against short frames, then start the live region.
 
         Returns
         -------
         None
         """
-        if not self._prepare_merged(label, sources):
-            return
-        self._flush_all()
-        # Wrap for the repainting region only, so the completion line and
-        # anything the caller prints afterwards go straight to the real file.
         self._unwrapped_file = self._console.file
         self._console.file = _OverwriteSafeWriter(self._unwrapped_file)  # pyright: ignore[reportAttributeAccessIssue]
-        self._progress.start()
-        self._add_merged_task(label, sources)
+        super()._open_delivery()
 
-    def _add_merged_task(self, label: str, sources: Sequence[ProgressSource]) -> None:
+    def _close_delivery(self, line: str, *, success: bool) -> None:
         """
-        Create the one shared track and point every declared source at it.
+        Stop the live region, then put the plain stream back.
 
-        Split out so the display-slot reporter can build the same single-bar
-        model without the ANSI machinery around it -- a batch-rendered notebook
-        should look like the interactive one.
+        The wrapper must stay in place across the ``super()`` call, because
+        that is what calls ``Progress.stop()`` — which emits one final frame.
+        Restoring first left that frame un-padded against a much longer
+        predecessor, which was the whole visible bug.
 
         Parameters
         ----------
-        label : str
-            Session label, shown on the bar.
-        sources : sequence of ProgressSource
-            Sources to register against the single track.
-
-        Returns
-        -------
-        None
-        """
-        if self._progress is None:
-            return
-        task = self._progress.add_task(
-            label or "Working", total=None, details="", eta="", done=False, ok=False
-        )
-        # Registering every declared source against the one track keeps the
-        # inherited "an undeclared source is ignored" guard working unchanged.
-        for source in sources:
-            self._tasks[source] = task
-
-    def update(self, event: ProgressEvent) -> None:
-        """
-        Apply an event to the shared bar, routing by source.
-
-        The primary source drives the bar's position; the secondary source
-        only contributes text, so it can never move a bar it does not own.
-
-        Parameters
-        ----------
-        event : ProgressEvent
-            The progress update to render.
-
-        Returns
-        -------
-        None
-        """
-        if self._progress is None or event.source not in self._tasks:
-            return
-        task = self._tasks[event.source]
-        if event.source == self._secondary:
-            self._engine = (event.step, event.total, _one_line(event.details))
-            self._progress.update(task, details=self._compose_details())
-            return
-        self._detail = _one_line(event.details)
-        self._progress.update(
-            task,
-            completed=event.step,
-            total=event.total or None,
-            details=self._compose_details(),
-            eta=self._eta_text(event.eta),
-        )
-
-    def finish(self, *, success: bool, duration: timedelta) -> None:
-        """
-        End the session and make certain the kernel's stdio is back in place.
-
-        Parameters
-        ----------
+        line : str
+            Console markup for the completion line.
         success : bool
             Whether the wrapped call completed without raising.
-        duration : timedelta
-            Total elapsed time, shown in the completion line.
 
         Returns
         -------
         None
         """
         try:
-            # The wrapper must stay in place across super().finish(), because
-            # that is what calls Progress.stop() — which emits one final frame.
-            # Restoring first left that frame un-padded against a much longer
-            # predecessor, which was the whole visible bug.
-            super().finish(success=success, duration=duration)
+            super()._close_delivery(line, success=success)
         finally:
             if self._unwrapped_file is not None:
                 self._console.file = self._unwrapped_file
                 self._unwrapped_file = None
-        self._primary = None
-        self._secondary = None
-        self._engine = None
-        # rich's Live swaps sys.stdout/sys.stderr for a FileProxy so stray
-        # prints render above the bar, and restores them in a ``finally``. A
-        # KeyboardInterrupt landing inside that teardown can still leak one,
-        # which in a kernel is sticky: every later cell would write into a
-        # dead console until the user restarts it. Unwind defensively.
-        for name in ("stdout", "stderr"):
-            stream = getattr(sys, name)
-            proxied = getattr(stream, "rich_proxied_file", None)
-            if proxied is not None and proxied is not stream:
-                setattr(sys, name, proxied)
-
-
-def _experimental_notebook_reporter() -> bool:
-    """
-    Report whether rich progress in a notebook is opted into.
-
-    Rich progress in a notebook rests on behavior no front-end documents — an
-    in-place carriage-return repaint, or the display-update protocol — so the
-    whole notebook branch is opt-in. With the flag unset a notebook takes the
-    same path it always did: :class:`SimpleProgressReporter`. A real terminal
-    is unaffected either way and keeps :class:`RichProgressReporter`.
-
-    Returns
-    -------
-    bool
-        True when the environment variable is set to a truthy value.
-    """
-    return _parse_tristate(os.environ.get("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER")) is True
 
 
 def _interactive_frontend() -> bool:
@@ -1256,46 +1329,69 @@ class RichDisplayProgressReporter(RichNotebookProgressReporter):
     """
     Rich reporter that repaints via IPython's display-update protocol.
 
-    Where :class:`RichNotebookProgressReporter` gives up the nested layout to
-    stay within the control codes a notebook honors, this reporter sidesteps
-    the problem entirely: it never starts rich's ``Live`` at all. Instead it
-    claims one display slot with ``display(..., display_id=True)`` and replaces
-    its contents wholesale on each refresh. Because the whole slot is
-    rewritten, a multi-line renderable needs no cursor motion, so the full
-    ``batch`` + ``engine`` pair renders exactly as it does in a terminal.
+    This exists for notebooks rendered *headlessly* — by ``nbconvert``,
+    ``papermill``, anything built on ``nbclient``. Those exports handle SGR
+    color codes but do not implement carriage-return overwrite at all, so the
+    parent's in-place repaint would be committed to the saved document one
+    frame per line. Here the reporter claims one display slot with
+    ``display(..., display_id=True)`` and replaces its contents wholesale, so
+    only the last frame survives into the notebook.
 
     This rides ``update_display_data``, part of the core Jupyter messaging
     spec since 5.1 — notably *not* ``ipywidgets``, which cannot work here: a
     kernel cannot learn whether its front-end renders widgets, and a front-end
     that does not leaves the cell showing the string ``Output()``.
 
-    One caveat: the frame is turned into HTML by rich's ``JupyterMixin``, which
-    renders through the *global* console rather than this reporter's. In a
-    kernel that is a Jupyter console and the output matches the stdout reporter
-    exactly; a colorless or narrower global console would render the bar's
-    unfilled track as blanks instead.
+    When something *is* watching, it stays on the parent's stdout delivery
+    instead. A notebook merges consecutive stdout writes into one block but
+    never merges display blocks, so a display slot is fenced off from the lines
+    around it — including the caller's own prints — by the notebook's padding.
+    The frame is identical either way; only the block it lands in differs.
 
-    Colors are baked to literal hex on this path, since the frame is delivered
-    as HTML rather than ANSI. That is not a loss for us: rich's stock styles
-    bake to exactly the RGB a truecolor terminal displays (``#f92672``
-    in-progress, ``#729c1f`` finished, ``#3a3a3a`` track), so the bar matches
-    the terminal. Do not restyle it.
+    Two things to know about the slot path. The frame is turned into HTML by
+    rich's ``JupyterMixin``, which renders through the *global* console rather
+    than this reporter's; in a kernel that is a Jupyter console and the output
+    matches the stdout path exactly, while a colorless or narrower global
+    console would render the bar's unfilled track as blanks instead. And colors
+    are baked to literal hex, since the frame is delivered as HTML rather than
+    ANSI. This is the one route whose palette is *not* theme-mapped: the others
+    emit ``red``/``green``/``bright_black`` as ANSI codes for the front-end to
+    resolve against its own theme, while here they freeze at render time to
+    that palette's values (``#800000``, ``#008000``, ``#808080``). There is no
+    back-channel from HTML to a theme, and this route only ever serves headless
+    renders, where there is no live theme to honor in the first place.
 
     Parameters
     ----------
     console : Console, optional
-        Console used for the completion line. Defaults to
-        :func:`_notebook_console`, so that line is written as ANSI to stdout
-        and collates with surrounding cell output.
+        Console used for the completion line, and for the whole render when a
+        front-end is watching. Defaults to :func:`_notebook_console`.
+    """
+
+    _slot_when_headless: bool = False
+    """
+    Whether a headless render claims an updatable display slot.
+
+    Off, the default: nothing is rendered until the session ends, and the final
+    state is written to stdout in one go. Nobody is watching a headless run and
+    nbconvert cannot animate the frames it would receive, so the intermediate
+    ones buy nothing — and a notebook merges consecutive stdout writes into a
+    single output block, where every display slot is its own block carrying its
+    own vertical padding. A cell of several calls reads as adjacent lines
+    instead of a stack of padded panels.
+
+    On: each session claims a slot and repaints it as events arrive. Worth
+    turning on when the headless verdict may be wrong — it rests on the
+    execute request's ``allow_stdin`` flag, and a front-end that leaves the
+    field out reads as headless while some person watches it repaint nothing.
     """
 
     def __init__(self, *, console: Console | None = None) -> None:
         """Initialize the reporter."""
-        # The parent already pins ``transient=False`` and the notebook console.
         super().__init__(console=console)
         self._handle: Any = None
         self._last_push: float = 0.0
-        self._inline: RichNotebookProgressReporter | None = None
+        self._inline: bool = False
 
     @staticmethod
     def _frame(progress: Progress) -> Any:
@@ -1341,52 +1437,28 @@ class RichDisplayProgressReporter(RichNotebookProgressReporter):
         with suppress(Exception):
             self._handle.update(_TightRenderable(self._frame(self._progress)))
 
-    def start(self, label: str, *, sources: Sequence[ProgressSource]) -> None:
+    def _open_delivery(self) -> None:
         """
-        Begin a session and claim a display slot, one bar per source.
-
-        Parameters
-        ----------
-        label : str
-            Short description shown on the outer bar.
-        sources : sequence of ProgressSource
-            Which progress sources will emit events; one bar per source. May
-            be empty, in which case no slot is claimed.
+        Claim a display slot, or fall back to the parent's stdout repaint.
 
         Returns
         -------
         None
         """
-        self._label = label
-        self._handle = None
-        self._inline = None
-        if not sources:
-            # Nothing to track: no slot, no delegate, just the completion line.
+        if self._progress is None:
             return
         if _interactive_frontend():
-            # Stay on stdout whenever something is watching. A notebook merges
-            # consecutive stdout writes into one block but never merges display
-            # blocks, so a display group is fenced off from the lines around it
-            # — including the caller's own prints — by the notebook's padding.
-            # That cost is not worth a second bar: the stdout reporter folds the
-            # engine into the outer bar's details instead, which keeps the whole
-            # cell in one block. The in-place repaint this needs is made safe by
-            # :class:`_OverwriteSafeWriter`.
-            #
-            # Headless runs still take the display slot below, where separate
-            # blocks are the only thing that survives into the saved notebook.
-            self._inline = RichNotebookProgressReporter(console=self._console)
-            self._inline.start(label, sources=sources)
+            # Someone is watching: stay in the caller's own output block.
+            self._inline = True
+            super()._open_delivery()
             return
-        # The same single-bar model the stdout reporter builds, so a notebook
-        # rendered by nbconvert or papermill looks like the interactive one.
+        if not self._slot_when_headless:
+            # Render nothing until the close, which writes the final state.
+            return
         # Deliberately no ``Progress.start()``: that would install rich's Live
-        # renderer and with it the cursor-up repaint this class exists to avoid.
-        # The Progress here is only a model that knows how to render.
-        if not self._prepare_merged(label, sources):
-            return
-        self._add_merged_task(label, sources)
-        self._flush_all()
+        # renderer and with it the repaint this path exists to avoid. The
+        # Progress here is only a model that knows how to render itself.
+        #
         # Imported here rather than at module scope: IPython is not a
         # dependency, and this class is only ever selected once
         # ``_display_handle_available()`` has confirmed a live shell.
@@ -1399,72 +1471,85 @@ class RichDisplayProgressReporter(RichNotebookProgressReporter):
             )
         self._last_push = monotonic()
 
-    def update(self, event: ProgressEvent) -> None:
+    def _deliver(self) -> None:
         """
-        Apply an event to its own bar, then repaint the slot.
-
-        Parameters
-        ----------
-        event : ProgressEvent
-            The progress update to render.
+        Repaint the slot, unless the parent's live region is driving this.
 
         Returns
         -------
         None
         """
-        if self._inline is not None:
-            self._inline.update(event)
+        if self._inline:
+            super()._deliver()
             return
-        super().update(event)
         self._push()
 
-    def finish(self, *, success: bool, duration: timedelta) -> None:
+    def _close_delivery(self, line: str, *, success: bool) -> None:
         """
-        Push the final frame, then print the completion line.
+        Leave the reader with what the other routes leave on the bar's line.
+
+        On success that is the summary alone, in place of the bar; on failure
+        the bar is kept with the summary under it. When a slot is in play both
+        go into the *same* renderable, because a notebook shows a stream block
+        and a display block as two outputs, each with its own vertical padding,
+        and printing the summary would open a conspicuous gap under the bar.
+        Writing to stdout has no such constraint — consecutive writes land in
+        one block — so that path simply prints them.
 
         Parameters
         ----------
+        line : str
+            Console markup for the completion line.
         success : bool
             Whether the wrapped call completed without raising.
-        duration : timedelta
-            Total elapsed time, shown in the completion line.
 
         Returns
         -------
         None
         """
-        if self._inline is not None:
-            self._inline.finish(success=success, duration=duration)
-            self._inline = None
+        if self._inline:
+            # The parent is delivering; it owns the close too.
+            self._inline = False
+            super()._close_delivery(line, success=success)
             return
-        line = self._completion_markup(success=success, duration=duration)
-        if self._handle is None or self._progress is None:
-            # No slot was ever claimed (no sources, or no shell to render
-            # into), so there is nothing to fold the line into.
-            super().finish(success=success, duration=duration)
+        if self._handle is None:
+            # No slot: write the final state to stdout in one go. Two prints
+            # rather than one stacked renderable — consecutive stdout writes
+            # merge into a single output block, which is the point of this
+            # path, so nothing has to hold them together.
+            if self._progress is not None and not (success and line):
+                self._console.print(self._frame(self._progress))
+            if line:
+                self._console.print(line)
             return
-        # Render the bars and the completion line as ONE renderable. Printing
-        # the line separately would send it to stdout, and a notebook shows a
-        # stream block and a display block as two outputs, each with its own
-        # vertical padding — leaving a conspicuous gap under the bars.
-        self._mark_done(success=success)
-        frame = self._frame(self._progress)
-        if line:
-            # ``Table.grid`` rather than ``Group``: only a JupyterMixin carries
-            # the ``_repr_mimebundle_`` that makes IPython render HTML, and
-            # Group is not one — it would reach the notebook as a bare repr.
-            stacked = Table.grid()
-            stacked.add_row(frame)
-            stacked.add_row(Text.from_markup(line))
-            frame = stacked
-        with suppress(Exception):
-            self._handle.update(_TightRenderable(frame))
+        frame: Any
+        if success and line:
+            frame = Text.from_markup(line)
+        elif self._progress is not None:
+            # A failed or unlabeled session keeps its bar.
+            frame = self._frame(self._progress)
+            if line:
+                # ``Table.grid`` rather than ``Group``: only a JupyterMixin
+                # carries the ``_repr_mimebundle_`` that makes IPython render
+                # HTML, and Group is not one — it would reach the notebook as
+                # a bare repr.
+                #
+                # ``expand`` is load-bearing. A grid sizes its column to the
+                # child's *maximum* measurement, and a bar measures narrower
+                # than it lays out — so the default sizing squeezed the frame
+                # and wrapped the details onto a second row, which no other
+                # route does. Expanding hands the frame the same width it gets
+                # when pushed on its own.
+                stacked = Table.grid(expand=True)
+                stacked.add_row(frame)
+                stacked.add_row(Text.from_markup(line))
+                frame = stacked
+        else:
+            frame = None
+        if frame is not None:
+            with suppress(Exception):
+                self._handle.update(_TightRenderable(frame))
         self._handle = None
-        # ``Progress.stop()`` would be a no-op here — Live.stop() returns early
-        # when it was never started — so tear down directly instead.
-        self._progress = None
-        self._tasks.clear()
-        self._flush_all()
 
 
 class SimpleProgressReporter(BaseProgressReporter):
@@ -1637,19 +1722,21 @@ def auto_reporter(*, console: Console | None = None) -> ProgressReporter:
     1. ``HOWSO_SIMPLE_PROGRESS`` set to a truthy value
        (``1``/``on``/``true``/``yes``) forces the line-printing reporter. This
        is the escape hatch from everything below.
-    2. A tty gets :class:`RichProgressReporter` — the full nested layout.
-    3. A notebook kernel gets a rich reporter **only** when
-       ``HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER`` is set. With a live IPython
-       shell, :class:`RichDisplayProgressReporter`, which repaints a display
-       slot and so renders the full nested layout; without one — a Databricks
-       runtime where ``IPython`` was never imported, for instance —
-       :class:`RichNotebookProgressReporter`, a single bar drawn with only the
-       control codes those front-ends honor.
-    4. Anything else — a pipe, a redirect, a CI log — gets
-       :class:`SimpleProgressReporter`.
+    2. A tty gets :class:`RichProgressReporter`, repainting a live region.
+    3. A notebook kernel gets a rich reporter when it passes the checks each
+       one needs. With a live IPython shell,
+       :class:`RichDisplayProgressReporter`, which repaints stdout while a
+       front-end is watching and falls back to a display slot for a headless
+       render; with an interactive front-end but no importable
+       ``IPython.display``, :class:`RichNotebookProgressReporter`, which
+       repaints stdout using only the control codes those front-ends honor.
+    4. Anything else — a notebook that passes neither check, a pipe, a
+       redirect, a CI log — gets :class:`SimpleProgressReporter`.
 
-    The tty check deliberately precedes the notebook check: ``_in_notebook()``
-    is also true for *terminal* IPython, which should keep the full layout.
+    All three rich reporters render the same merged bar and differ only in how
+    a frame reaches the reader. The tty check deliberately precedes the
+    notebook check: ``_in_notebook()`` is also true for *terminal* IPython,
+    which has a real terminal underneath it.
 
     Parameters
     ----------
@@ -1668,7 +1755,7 @@ def auto_reporter(*, console: Console | None = None) -> ProgressReporter:
         return SimpleProgressReporter(console=console)
     if sys.stdout.isatty():
         return RichProgressReporter(console=console)
-    if _in_notebook() and _experimental_notebook_reporter():
+    if _in_notebook():
         # The display slot survives headless execution: nbclient replaces the
         # output's data in place for each update, so an nbconvert/papermill run
         # stores the final frame as ordinary HTML and exports it faithfully.
@@ -2136,7 +2223,7 @@ class _CountColumn(MofNCompleteColumn):
             # The label's hue, un-bolded: the details describe the same task, so
             # they read as subordinate to it rather than as a separate signal.
             # Not rich's ``progress.data.speed``, which resolves to plain red —
-            # the colour a pending bar uses, meaning something else entirely.
+            # the color a pending bar uses, meaning something else entirely.
             text.append(f" {details}", style="cyan")
         return text
 
@@ -2171,38 +2258,9 @@ class _ElapsedColumn(TimeElapsedColumn):
         return Text(_format_duration(timedelta(seconds=elapsed)), style="progress.elapsed")
 
 
-def _label_column_width(*labels: str) -> int:
-    """
-    Width to pin the label column to, so every session lines up.
-
-    Sized from every label the decorator has registered, plus the one in hand —
-    a caller may pass a bespoke label straight to :func:`with_progress` without
-    ever going through the decorator, and that must not be clipped.
-
-    Without a pinned width, rich re-measures the column from its content each
-    frame and ``expand`` redistributes the slack, so labels and bars land in
-    different columns from one session to the next and shift again when the
-    content changes.
-
-    Parameters
-    ----------
-    *labels : str
-        Every description this session will actually render. Pass the derived
-        track descriptions, not just the session label: the nested engine track
-        renders as ``"  engine"``, which is wider than a short label like
-        ``"Train"`` and would otherwise be clipped to ``"en…"``.
-
-    Returns
-    -------
-    int
-        Column width in characters.
-    """
-    return max({len(name) for name in _AUTO_PROGRESS_LABELS} | {len(name) for name in labels})
-
-
 def _format_eta(eta: timedelta | None, *, long: bool = True) -> str:
     """
-    Render an estimate, labelled to fit the space available.
+    Render an estimate, labeled to fit the space available.
 
     Sub-second precision is dropped: a ``timedelta`` stringifies with
     microseconds (``0:01:23.456789``), which is false precision on a figure
@@ -2356,7 +2414,6 @@ def auto_progress(label_or_method: Any = None, /, *, indeterminate: bool = False
             finally:
                 _state.depth = depth
         wrapper._auto_progress_label = label  # type: ignore[attr-defined]
-        _AUTO_PROGRESS_LABELS.add(label)
         return wrapper
 
     if callable(label_or_method):

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -34,6 +34,7 @@ from datetime import timedelta
 from functools import wraps
 import importlib.util
 import inspect
+import io
 import os
 import sys
 import threading
@@ -42,6 +43,7 @@ from typing import Any, Literal, overload, Protocol, TypeVar
 from uuid import uuid4
 
 from rich.console import Console
+from rich.measure import Measurement
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -52,7 +54,8 @@ from rich.progress import (
     TextColumn,
     TimeElapsedColumn,
 )
-from rich.table import Table
+from rich.segment import Segment
+from rich.table import Column, Table
 from rich.text import Text
 
 from howso.utilities.monitors import ProgressTimer
@@ -81,11 +84,18 @@ __all__ = [
 _M = TypeVar("_M", bound=Callable[..., Any])
 
 
-ProgressSource = Literal["engine", "batch"]
+ProgressSource = Literal["engine", "batch", "activity"]
+"""
+Which mechanism a progress event came from.
+
+``activity`` is not a measurement — it is declared when a method opts into
+:func:`auto_progress`'s ``indeterminate`` and offers no real progress hook, so
+that a long call still reads as alive rather than silent.
+"""
 
 
 def _env_number(name: str, default: float) -> float:
-    """Read a numeric environment variable, falling back on anything unparseable."""
+    """Read a numeric environment variable, falling back on anything unparsable."""
     with suppress(TypeError, ValueError):
         return float(os.environ[name]) if name in os.environ else default
     return default
@@ -99,7 +109,7 @@ HEARTBEAT_INTERVAL = _env_number("HOWSO_HEARTBEAT_INTERVAL", 15.0)
 # ``Console.size`` probes ``os.get_terminal_size()`` on the std file descriptors
 # before falling back to 80 — so a kernel launched from a terminal would
 # silently inherit *that* terminal's width.
-NOTEBOOK_COLUMNS = int(_env_number("HOWSO_PROGRESS_COLUMNS", 100.0))
+NOTEBOOK_COLUMNS = int(_env_number("HOWSO_PROGRESS_COLUMNS", 120.0))
 
 # Refresh rate for notebook bars. Every frame is a full-width write over the
 # kernel's IOPub channel, so this stays well below rich's default of 10 and
@@ -111,6 +121,21 @@ NOTEBOOK_REFRESH_HZ = _env_number("HOWSO_PROGRESS_FPS", 4.0)
 # a second rendered line would reintroduce the cursor-up codes that
 # :class:`RichNotebookProgressReporter` exists to avoid.
 NOTEBOOK_DETAIL_LIMIT = 48
+
+# Bar width in columns. Sized from the worst case that must not clip: the
+# longest label, a comma-grouped 100,000,000-row counter (23 characters), the
+# details, elapsed and an estimate, all inside NOTEBOOK_COLUMNS.
+BAR_WIDTH = 24
+
+_AUTO_PROGRESS_LABELS: set[str] = set()
+"""
+Every label :func:`auto_progress` has registered, for sizing the label column.
+
+Populated at decoration time, so it grows as modules are imported — including
+downstream packages that decorate their own methods. Sizing from this rather
+than a hard-coded number means renaming or adding a method keeps the columns
+aligned without anyone remembering to update a constant.
+"""
 
 
 @dataclass
@@ -180,6 +205,48 @@ class BaseProgressReporter:
     _label: str
     """Current session label. Set by each subclass in ``start``."""
 
+    def _mark_done(self, *, success: bool) -> None:
+        """
+        Settle every track before the final frame is rendered.
+
+        Marks the session ended either way — which stops the spinner — and
+        records whether it succeeded, which is what decides the bar's color: a
+        failed session stays in the pending color, reading correctly beside the
+        red mark on the completion line.
+
+        The estimate is always cleared — a finished bar should not advertise a
+        time remaining. The details are cleared only on success, where
+        ``batch 7`` is merely the last chunk index and the counter already says
+        ``120/120``. On a failure the same text says *where* it stopped, which
+        is worth keeping.
+
+        Parameters
+        ----------
+        success : bool
+            Whether the wrapped call completed without raising.
+
+        Returns
+        -------
+        None
+        """
+        progress = getattr(self, "_progress", None)
+        if progress is None:
+            return
+        totals = {task.id: task.total for task in progress.tasks}
+        for task_id in set(getattr(self, "_tasks", {}).values()):
+            with suppress(Exception):
+                fields: dict[str, Any] = {"done": True, "ok": success, "eta": ""}
+                if success:
+                    fields["details"] = ""
+                    # The engine stops reporting the moment the call returns, so
+                    # its last step is usually short of the total — leaving a
+                    # part-filled bar that reads as still running next to its own
+                    # "complete" line. The call did finish; say so.
+                    total = totals.get(task_id)
+                    if total is not None:
+                        fields["completed"] = total
+                progress.update(task_id, **fields)
+
     def _eta_text(self, eta: timedelta | None) -> str:
         """
         Render an estimate, labelled to fit this reporter's console.
@@ -217,7 +284,7 @@ class BaseProgressReporter:
             return ""
         marker = "[green]✓[/green]" if success else "[red]✗[/red]"
         status = "complete" if success else "failed"
-        return f"{marker} {self._label} {status} in {duration}"
+        return f"{marker} {self._label} {status} in {_format_duration(duration)}"
 
     def _flush_all(self) -> None:
         """
@@ -304,27 +371,55 @@ class RichProgressReporter(BaseProgressReporter):
         BarColumn
             rich's stock bar.
         """
-        return BarColumn()
+        return _StateBarColumn(bar_width=BAR_WIDTH)
 
-    def _make_columns(self) -> tuple[ProgressColumn, ...]:
+    def _make_columns(
+        self, *, activity: bool = False, label_width: int | None = None
+    ) -> tuple[ProgressColumn, ...]:
         """
         Build the column layout shared by every bar this reporter renders.
 
         Subclasses that lay tracks out differently reuse this so a bar reads
         the same wherever it is rendered.
 
+        Parameters
+        ----------
+        label_width : int, optional
+            Pin the label column to this width. Leaving it unset lets rich size
+            the column from its content, which makes labels and bars land in
+            different columns from one session to the next.
+        activity : bool, default False
+            Drop the counter, details and estimate columns. An activity track
+            measures nothing, so they would render a meaningless ``0/?`` and
+            two permanently empty columns — each still costing its padding.
+
         Returns
         -------
         tuple of ProgressColumn
             The columns to hand to :class:`rich.progress.Progress`.
         """
+        label = (
+            TextColumn("[bold cyan]{task.description}")
+            if label_width is None
+            else TextColumn("[bold cyan]{task.description}",
+                            table_column=Column(width=label_width))
+        )
+        if activity:
+            # No details column either: an activity track carries none, and an
+            # empty column still takes its padding on both sides, leaving a
+            # visible extra space between the bar and the elapsed time.
+            return (
+                _StateSpinnerColumn(),
+                label,
+                self._bar_column(),
+                _ElapsedColumn(),
+            )
         return (
-            SpinnerColumn(),
-            TextColumn("[bold cyan]{task.description}"),
+            _StateSpinnerColumn(),
+            label,
             self._bar_column(),
-            MofNCompleteColumn(),
-            TextColumn("[dim]{task.fields[details]}"),
-            TimeElapsedColumn(),
+            _CountColumn(),
+            _ElapsedColumn(),
             TextColumn("[dim]{task.fields[eta]}"),
         )
 
@@ -375,7 +470,10 @@ class RichProgressReporter(BaseProgressReporter):
         """
         self._label = label
         self._progress = Progress(
-            *self._make_columns(),
+            *self._make_columns(
+                activity=tuple(sources) == ("activity",),
+                label_width=_label_column_width(label, *self._track_descriptions(label, sources).values()),
+            ),
             console=self._console,
             transient=self._transient,
         )
@@ -391,6 +489,8 @@ class RichProgressReporter(BaseProgressReporter):
                 total=None,
                 details="",
                 eta="",
+                done=False,
+                ok=False,
             )
 
     def update(self, event: ProgressEvent) -> None:
@@ -435,6 +535,7 @@ class RichProgressReporter(BaseProgressReporter):
         None
         """
         if self._progress is not None:
+            self._mark_done(success=success)
             self._progress.stop()
             self._progress = None
             self._tasks.clear()
@@ -510,24 +611,92 @@ def _one_line(text: str, limit: int = NOTEBOOK_DETAIL_LIMIT) -> str:
     return flattened[: limit - 1] + "\u2026"
 
 
-class _QuietBarColumn(BarColumn):
-    r"""
-    A bar that renders a static empty track instead of pulsing.
+class _SolidBar:
+    """
+    A single-run bar drawn in one color, for work with no known total.
 
-    rich pulses whenever the total is unknown — ``should_pulse = self.pulse or
-    self.total is None`` in ``rich/progress_bar.py`` — and a pulse frame spends
-    ~980 characters on a 20-step colour gradient where the determinate frame
-    replacing it needs ~165. On a stream that repaints with a carriage return
-    that disparity is what has to be padded over, so removing it shrinks the
-    spread from ~819 characters to ~13.
+    The reason we don't use the default "pulsing" bar is because that pulsing
+    bar requires many times more symbols across the wire to accomplish.
 
-    Only the bar is given a total; the task keeps its ``None``, so
-    :class:`~rich.progress.MofNCompleteColumn` still honestly shows ``0/?``.
+    Parameters
+    ----------
+    style : str
+        Style to draw the whole bar in.
+    width : int, optional
+        Bar width in columns, mirroring ``BarColumn.bar_width``. ``None`` fills
+        the space available, which is rich's flexible mode. Honoring this is
+        what keeps an indeterminate bar the same length as a determinate one:
+        the activity layout drops two columns, and a bar that simply filled
+        would absorb the freed space and render visibly longer.
+    """
+
+    def __init__(self, style: str, width: int | None = None) -> None:
+        """Initialize the bar."""
+        self.style = style
+        self.width = width
+
+    def __rich_console__(self, console: Console, options: Any) -> Any:
+        """
+        Emit the bar as one styled segment spanning the available width.
+
+        Parameters
+        ----------
+        console : Console
+            Console being rendered into.
+        options : ConsoleOptions
+            Render options, which carry the width to fill.
+
+        Yields
+        ------
+        Segment
+            A single run of bar glyphs.
+        """
+        yield Segment("\u2501" * self._width(options), console.get_style(self.style))
+
+    def _width(self, options: Any) -> int:
+        """Resolve the drawn width against the space available."""
+        width = options.max_width if self.width is None else min(self.width, options.max_width)
+        return max(width, 1)
+
+    def __rich_measure__(self, console: Console, options: Any) -> Measurement:
+        """
+        Report the exact width this bar wants.
+
+        Without a measurement rich hands the column all the space left over and
+        the bar simply draws short inside it, so the blank remainder pushes
+        every following column to the right. That only shows on tracks with an
+        unknown total, since a determinate bar is rich's own ``ProgressBar``,
+        which measures itself.
+
+        Parameters
+        ----------
+        console : Console
+            Console being measured against.
+        options : ConsoleOptions
+            Render options carrying the available width.
+
+        Returns
+        -------
+        Measurement
+            The same width for minimum and maximum, so the column is exact.
+        """
+        width = self._width(options)
+        return Measurement(width, width)
+
+
+class _StateSpinnerColumn(SpinnerColumn):
+    """
+    A spinner that stops when the session ends, even with no known total.
+
+    rich blanks its spinner on ``task.finished``, which is ``completed >=
+    total`` — never true while the total is ``None``. A completed
+    indeterminate session would otherwise keep a spinner frame on screen and
+    read as though it were still running.
     """
 
     def render(self, task: Any) -> Any:
         """
-        Render the bar, substituting a static track when the total is unknown.
+        Render the spinner, or the finished marker once the session has ended.
 
         Parameters
         ----------
@@ -536,16 +705,64 @@ class _QuietBarColumn(BarColumn):
 
         Returns
         -------
-        ProgressBar
+        RenderableType
+            The spinner frame, or ``finished_text``.
+        """
+        if task.fields.get("done"):
+            return self.finished_text
+        return super().render(task)
+
+
+class _StateBarColumn(BarColumn):
+    r"""
+    A bar that shows *state* rather than motion when the total is unknown.
+
+    rich pulses whenever the total is unknown (``should_pulse = self.pulse or
+    self.total is None`` in ``rich/progress_bar.py``), coloring every cell of
+    a 20-step gradient individually: ~980 characters per frame against ~165 for
+    a determinate one. On a stream repainted with a carriage return that whole
+    gulf has to be padded over, producing a very wide blank line. Lowering the
+    color depth does not help — the cost is the per-cell coloring, not the
+    palette (measured 982 truecolor, 742 at 256, 502 at standard).
+
+    Motion is already covered: :class:`~rich.progress.SpinnerColumn` leads every
+    layout and animates from ``Live`` refreshes at constant cost. So this draws
+    a single solid run instead — red while pending, green once done — which
+    holds frame length exactly constant and uses one named-ANSI color that the
+    front-end maps onto the user's theme.
+
+    A task with no total is never ``finished`` in rich's terms, so completion is
+    read from a ``done`` field the reporter sets. A failed session simply never
+    turns green, which reads correctly beside the red mark on the completion
+    line.
+    """
+
+    PENDING_STYLE = "red"
+    DONE_STYLE = "green"
+
+    def render(self, task: Any) -> Any:
+        """
+        Render the bar, substituting a solid run when the total is unknown.
+
+        Parameters
+        ----------
+        task : Task
+            The task to render.
+
+        Returns
+        -------
+        ProgressBar or _SolidBar
             The bar to draw.
         """
-        bar = super().render(task)
         if task.total is None:
-            bar.total, bar.completed, bar.pulse = 1, 0, False
-        return bar
+            succeeded = task.fields.get("done") and task.fields.get("ok")
+            return _SolidBar(
+                self.DONE_STYLE if succeeded else self.PENDING_STYLE, self.bar_width
+            )
+        return super().render(task)
 
 
-class _OverwriteSafeWriter:
+class _OverwriteSafeWriter(io.TextIOBase):
     r"""
     Pad each repaint so it fully covers the frame it replaces.
 
@@ -557,7 +774,7 @@ class _OverwriteSafeWriter:
 
     Constant visible width does not help: what matters is raw length, and the
     two diverge wildly. rich's indeterminate pulse spends ~980 characters on a
-    20-step colour gradient occupying the same ~97 columns that a determinate
+    20-step color gradient occupying the same ~97 columns that a determinate
     frame draws in ~165.
 
     Padding uses **spaces**, deliberately. Escape sequences would occupy raw
@@ -583,8 +800,16 @@ class _OverwriteSafeWriter:
 
     def __init__(self, wrapped: Any) -> None:
         """Initialize the writer."""
+        # ``io.TextIOBase`` so this satisfies the ``IO[str]`` that
+        # ``Console.file`` is typed as. rich wraps stdout the same way for the
+        # same reason — see ``rich.file_proxy.FileProxy``.
+        super().__init__()
         self._wrapped = wrapped
         self._written = 0
+
+    def writable(self) -> bool:
+        """Report that this stream accepts writes."""
+        return True
 
     def write(self, text: str) -> int:
         r"""
@@ -688,7 +913,7 @@ class RichNotebookProgressReporter(RichProgressReporter):
             A :class:`_QuietBarColumn`, whose narrow frame-length spread keeps
             the carriage-return repaint's padding to a few characters.
         """
-        return _QuietBarColumn()
+        return _StateBarColumn(bar_width=BAR_WIDTH)
 
     def _compose_details(self) -> str:
         """Render the details column from whichever sources have reported."""
@@ -718,9 +943,16 @@ class RichNotebookProgressReporter(RichProgressReporter):
         self._label = label
         self._detail = ""
         self._engine = None
-        # ``batch`` is the outer measure whenever it is live, so it owns the
-        # bar and ``engine`` is demoted to the details column.
-        self._primary = "batch" if "batch" in sources else ("engine" if "engine" in sources else None)
+        # ``batch`` is the outer measure when it is live, so it owns the bar and
+        # ``engine`` is demoted to the details text. Otherwise the first declared
+        # source owns it — that fallback matters for ``activity``, which is
+        # neither and would otherwise leave this reporter blank.
+        if "batch" in sources:
+            self._primary = "batch"
+        elif "engine" in sources:
+            self._primary = "engine"
+        else:
+            self._primary = sources[0] if sources else None
         self._secondary = "engine" if (self._primary == "batch" and "engine" in sources) else None
         if self._primary is None:
             # Nothing to track. Skip the live region entirely rather than
@@ -728,23 +960,26 @@ class RichNotebookProgressReporter(RichProgressReporter):
             # swap sys.stdout for a FileProxy.
             return
         self._progress = Progress(
-            *self._make_columns(),
+            *self._make_columns(
+                activity=tuple(sources) == ("activity",),
+                label_width=_label_column_width(label, *self._track_descriptions(label, sources).values()),
+            ),
             console=self._console,
             transient=self._transient,
             # Pads every frame to the full console width. Notebook front-ends
             # implement ``\r`` as a length-based overwrite and ignore the
             # erase-line that rich pairs with it, so a frame shorter than its
             # predecessor would leave the previous frame's tail on screen.
-            expand=True,
+            expand=False,
             refresh_per_second=NOTEBOOK_REFRESH_HZ,
         )
         self._flush_all()
         # Wrap for the repainting region only, so the completion line and
         # anything the caller prints afterwards go straight to the real file.
         self._unwrapped_file = self._console.file
-        self._console.file = _OverwriteSafeWriter(self._unwrapped_file)
+        self._console.file = _OverwriteSafeWriter(self._unwrapped_file)  # pyright: ignore[reportAttributeAccessIssue]
         self._progress.start()
-        task = self._progress.add_task(label or "Working", total=None, details="", eta="")
+        task = self._progress.add_task(label or "Working", total=None, details="", eta="", done=False, ok=False)
         # Registering every declared source against the one track keeps the
         # inherited "an undeclared source is ignored" guard working unchanged.
         for source in sources:
@@ -800,7 +1035,7 @@ class RichNotebookProgressReporter(RichProgressReporter):
         try:
             # The wrapper must stay in place across super().finish(), because
             # that is what calls Progress.stop() — which emits one final frame.
-            # Restoring first left that frame unpadded against a much longer
+            # Restoring first left that frame un-padded against a much longer
             # predecessor, which was the whole visible bug.
             super().finish(success=success, duration=duration)
         finally:
@@ -1048,20 +1283,26 @@ class RichDisplayProgressReporter(RichProgressReporter):
         if not sources:
             # Nothing to track: no slot, no delegate, just the completion line.
             return
-        if len(sources) < 2 and _interactive_frontend():
-            # A display slot buys exactly one thing: room for more than one
-            # line. A single bar does not need it, and claiming one would split
-            # the cell — a notebook merges consecutive stdout writes into a
-            # single block but never merges display blocks, so every display
-            # group is fenced off from the lines around it, including the
-            # caller's own prints. Staying on stdout keeps this session in the
-            # same block as its neighbours. The in-place repaint that requires
-            # is made safe by :class:`_OverwriteSafeWriter`.
+        if _interactive_frontend():
+            # Stay on stdout whenever something is watching. A notebook merges
+            # consecutive stdout writes into one block but never merges display
+            # blocks, so a display group is fenced off from the lines around it
+            # — including the caller's own prints — by the notebook's padding.
+            # That cost is not worth a second bar: the stdout reporter folds the
+            # engine into the outer bar's details instead, which keeps the whole
+            # cell in one block. The in-place repaint this needs is made safe by
+            # :class:`_OverwriteSafeWriter`.
+            #
+            # Headless runs still take the display slot below, where separate
+            # blocks are the only thing that survives into the saved notebook.
             self._inline = RichNotebookProgressReporter(console=self._console)
             self._inline.start(label, sources=sources)
             return
         self._progress = Progress(
-            *self._make_columns(),
+            *self._make_columns(
+                activity=tuple(sources) == ("activity",),
+                label_width=_label_column_width(label, *self._track_descriptions(label, sources).values()),
+            ),
             console=self._console,
             transient=self._transient,
         )
@@ -1076,13 +1317,15 @@ class RichDisplayProgressReporter(RichProgressReporter):
                 total=None,
                 details="",
                 eta="",
+                done=False,
+                ok=False,
             )
         self._flush_all()
         # Imported here rather than at module scope: IPython is not a
         # dependency, and this class is only ever selected once
         # ``_display_handle_available()`` has confirmed a live shell.
         with suppress(ImportError):
-            from IPython.display import display
+            from IPython.display import display  # noqa: PLC0415
 
             # Returns None when there is no active shell to render into.
             self._handle = display(
@@ -1138,6 +1381,7 @@ class RichDisplayProgressReporter(RichProgressReporter):
         # the line separately would send it to stdout, and a notebook shows a
         # stream block and a display block as two outputs, each with its own
         # vertical padding — leaving a conspicuous gap under the bars.
+        self._mark_done(success=success)
         frame = self._frame(self._progress)
         if line:
             # ``Table.grid`` rather than ``Group``: only a JupyterMixin carries
@@ -1266,6 +1510,17 @@ class SimpleProgressReporter(BaseProgressReporter):
             return
         now = monotonic()
         prefix = self._prefixes.get(event.source, "")
+        if event.source == "activity":
+            # Nothing is being counted, so a "[0/?]" line would say nothing.
+            # Report liveness on the heartbeat cadence instead: the ticker
+            # fires far more often than a reader needs to see a line.
+            if now - self._last_output.get(event.source, 0.0) < HEARTBEAT_INTERVAL:
+                return
+            elapsed = timedelta(seconds=int(now - self._start_time))
+            detail = f" {event.details}" if event.details else ""
+            self._console.print(f"{prefix}[dim]\u00b7{detail} {elapsed} elapsed[/dim]")
+            self._last_output[event.source] = now
+            return
         total = event.total or "?"
         width = len(str(total))
         eta = self._eta_text(event.eta)
@@ -1360,7 +1615,26 @@ def auto_reporter(*, console: Console | None = None) -> ProgressReporter:
     return SimpleProgressReporter(console=console)
 
 
-def _supports_param(bound_func: Callable, name: str) -> bool:
+def _supports_param(bound_func: Callable[..., Any], name: str) -> bool:
+    """
+    Report whether ``bound_func`` accepts a parameter called ``name``.
+
+    Parameters
+    ----------
+    bound_func : callable
+        The function to inspect. Only its signature is read, never called, so
+        this is deliberately as wide as a callable annotation goes.
+    name : str
+        The parameter to look for.
+
+    Returns
+    -------
+    bool
+        True when the parameter is present. A callable whose signature cannot
+        be read — a builtin, or an object with a hostile ``__signature__`` —
+        reports False rather than raising, since the caller only uses this to
+        decide whether it is worth passing a progress hook.
+    """
     try:
         sig = inspect.signature(bound_func)
     except (TypeError, ValueError):
@@ -1455,13 +1729,14 @@ def _cached_polling_support(trainee: Any, client: Any, trainee_id: str | None) -
     return bool(supported)
 
 
-def with_progress(
+def with_progress(  # noqa: PLR0915
     label: str,
     bound_func: Callable[..., Any],
     /,
     *args: Any,
     reporter: ProgressReporter | None = None,
     polling_interval: float = 1.0,
+    indeterminate: bool = False,
     **kwargs: Any,
 ) -> Any:
     """
@@ -1573,7 +1848,7 @@ def with_progress(
                     # keep polling. Falls through to the wait below rather than
                     # ``continue`` so we don't busy-loop the engine.
                     pass
-                except Exception:
+                except Exception:  # noqa: BLE001
                     # Any other engine error means progress can't be reported —
                     # stop quietly rather than killing this daemon thread with a
                     # traceback on stderr (the wrapped call itself is
@@ -1595,20 +1870,38 @@ def with_progress(
 
         poll_thread = threading.Thread(target=_poll, daemon=True)
 
+    tick_thread: threading.Thread | None = None
+    if indeterminate and not sources:
+        # Nothing measurable to report, but the caller asked for the session to
+        # read as alive. Two of the four reporters only emit on ``update`` (the
+        # display slot pushes a frame, the line printer prints a line), so a
+        # ticker is what makes them show anything at all before completion.
+        sources.append("activity")
+
+        def _tick() -> None:
+            while not stop_event.is_set():
+                reporter.update(ProgressEvent(source="activity", step=0, total=0))
+                stop_event.wait(polling_interval)
+
+        tick_thread = threading.Thread(target=_tick, daemon=True)
+
     reporter.start(label, sources=tuple(sources))
     success = False
     try:
         if poll_thread is not None:
             poll_thread.start()
+        if tick_thread is not None:
+            tick_thread.start()
         result = bound_func(*args, **kwargs)
         success = True
         return result
     finally:
         duration = timedelta(seconds=monotonic() - start_time)
         stop_event.set()
-        if poll_thread is not None:
-            with suppress(RuntimeError):
-                poll_thread.join(timeout=max(polling_interval * 2, 2.0))
+        for thread in (poll_thread, tick_thread):
+            if thread is not None:
+                with suppress(RuntimeError):
+                    thread.join(timeout=max(polling_interval * 2, 2.0))
         reporter.finish(success=success, duration=duration)
 
 
@@ -1649,6 +1942,139 @@ def _parse_tristate(value: Any) -> bool | None:
 ETA_LABEL_MIN_WIDTH = 100
 
 
+def _format_duration(delta: timedelta) -> str:
+    """
+    Render a duration as ``H:MM:SS``, letting the hours run past a day.
+
+    ``str(timedelta)`` switches to ``"1 day, 1:00:00"`` past 24 hours and
+    ``"41 days, 16:00:00"`` past a month — 14 to 17 characters where the same
+    value was 7. In a pinned layout that silently shifts or clips a column, and
+    multi-hour runs are ordinary here. Accumulating into the hours field keeps
+    the width growing by one character per decade instead.
+
+    Parameters
+    ----------
+    delta : timedelta
+        The duration to render. Negative values clamp to zero.
+
+    Returns
+    -------
+    str
+        For example ``"0:00:09"``, ``"10:00:00"`` or ``"100:00:00"``.
+    """
+    total = max(int(delta.total_seconds()), 0)
+    hours, remainder = divmod(total, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours}:{minutes:02d}:{seconds:02d}"
+
+
+def _format_count(value: int) -> str:
+    """
+    Render a step count with thousands separators.
+
+    Batches routinely reach tens of millions of rows, where a bare
+    ``100000000`` is unreadable. Grouping costs width — ``100,000,000`` is 11
+    characters against 9 — which is why the bar is sized from this worst case
+    rather than the other way round.
+
+    Parameters
+    ----------
+    value : int
+        The count to render.
+
+    Returns
+    -------
+    str
+        For example ``"9,999"`` or ``"100,000,000"``.
+    """
+    return f"{value:,}"
+
+
+class _CountColumn(MofNCompleteColumn):
+    """
+    Step counter, carrying the details text alongside it.
+
+    The details share this column rather than occupying their own. An empty
+    column still costs its padding on both sides, so once the details are
+    cleared at completion a separate column would leave two spaces before the
+    elapsed time where every other row has one.
+    """
+
+    def render(self, task: Any) -> Any:
+        """
+        Render ``completed/total``, followed by any details.
+
+        Parameters
+        ----------
+        task : Task
+            The task to render.
+
+        Returns
+        -------
+        Text
+            The counter, and the details when there are any.
+        """
+        total = _format_count(int(task.total)) if task.total is not None else "?"
+        counter = f"{_format_count(int(task.completed))}{self.separator}{total}"
+        details = task.fields.get("details") or ""
+        text = Text(counter, style="progress.download")
+        if details:
+            text.append(f" {details}", style="progress.data.speed")
+        return text
+
+
+class _ElapsedColumn(TimeElapsedColumn):
+    """Elapsed time in the same ``H:MM:SS`` form as every other duration."""
+
+    def render(self, task: Any) -> Any:
+        """
+        Render elapsed time.
+
+        Parameters
+        ----------
+        task : Task
+            The task to render.
+
+        Returns
+        -------
+        Text
+            The elapsed time, or a placeholder before the task starts.
+        """
+        elapsed = task.finished_time if task.finished else task.elapsed
+        if elapsed is None:
+            return Text("-:--:--", style="progress.elapsed")
+        return Text(_format_duration(timedelta(seconds=elapsed)), style="progress.elapsed")
+
+
+def _label_column_width(*labels: str) -> int:
+    """
+    Width to pin the label column to, so every session lines up.
+
+    Sized from every label the decorator has registered, plus the one in hand —
+    a caller may pass a bespoke label straight to :func:`with_progress` without
+    ever going through the decorator, and that must not be clipped.
+
+    Without a pinned width, rich re-measures the column from its content each
+    frame and ``expand`` redistributes the slack, so labels and bars land in
+    different columns from one session to the next and shift again when the
+    content changes.
+
+    Parameters
+    ----------
+    *labels : str
+        Every description this session will actually render. Pass the derived
+        track descriptions, not just the session label: the nested engine track
+        renders as ``"  engine"``, which is wider than a short label like
+        ``"Train"`` and would otherwise be clipped to ``"en…"``.
+
+    Returns
+    -------
+    int
+        Column width in characters.
+    """
+    return max({len(name) for name in _AUTO_PROGRESS_LABELS} | {len(name) for name in labels})
+
+
 def _format_eta(eta: timedelta | None, *, long: bool = True) -> str:
     """
     Render an estimate, labelled to fit the space available.
@@ -1669,13 +2095,15 @@ def _format_eta(eta: timedelta | None, *, long: bool = True) -> str:
     Returns
     -------
     str
-        ``"est. remaining: 0:01:23"``, ``"ETA 0:01:23"``, or ``""`` when there
+        ``"est. rem.: 0:01:23"``, ``"ETA 0:01:23"``, or ``""`` when there
         is no usable estimate.
     """
-    if eta is None or eta.total_seconds() < 0:
+    if eta is None or int(eta.total_seconds()) <= 0:
+        # Below a second there is nothing useful left to say, and "0:00:00"
+        # on a bar that has just filled reads as a stuck clock.
         return ""
-    label = "est. remaining:" if long else "ETA"
-    return f"{label} {timedelta(seconds=int(eta.total_seconds()))}"
+    label = "est. rem.:" if long else "ETA"
+    return f"{label} {_format_duration(eta)}"
 
 
 def _default_label(name: str) -> str:
@@ -1740,8 +2168,10 @@ def _auto_progress_enabled(trainee: Any) -> bool:
 @overload
 def auto_progress(label_or_method: _M, /) -> _M: ...
 @overload
-def auto_progress(label_or_method: str | None = ..., /) -> Callable[[_M], _M]: ...
-def auto_progress(label_or_method: Any = None, /) -> Any:
+def auto_progress(
+    label_or_method: str | None = ..., /, *, indeterminate: bool = ...
+) -> Callable[[_M], _M]: ...
+def auto_progress(label_or_method: Any = None, /, *, indeterminate: bool = False) -> Any:
     """
     Decorate a ``Trainee`` method to opt into unified progress reporting.
 
@@ -1775,11 +2205,13 @@ def auto_progress(label_or_method: Any = None, /) -> Any:
                     label,
                     method.__get__(self, type(self)),
                     *args,
+                    indeterminate=indeterminate,
                     **kwargs,
                 )
             finally:
                 _state.depth = depth
         wrapper._auto_progress_label = label  # type: ignore[attr-defined]
+        _AUTO_PROGRESS_LABELS.add(label)
         return wrapper
 
     if callable(label_or_method):

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -137,7 +137,56 @@ class ProgressReporter(Protocol):
         ...
 
 
-class RichProgressReporter:
+class BaseProgressReporter:
+    """Base of all implementations of a Progress Reporter."""
+
+    _console: Console
+    """Console the concrete reporter renders into. Set by each subclass."""
+
+    def _flush_all(self) -> None:
+        """
+        Drain every stream this reporter could interleave with.
+
+        Progress is rendered either as a live region redrawn in place
+        (:class:`RichProgressReporter`) or as an append-only run of lines
+        (:class:`SimpleProgressReporter`). Either way, bytes still sitting in
+        some *other* stream's buffer — a warning written to ``stderr``, a
+        ``print`` from the wrapped call — surface whenever that buffer
+        happens to drain, which is frequently mid-redraw. Flushing at the
+        session boundaries forces that output out first, so it lands above
+        the progress region instead of through it.
+
+        Streams are deduplicated by identity (the console's file is normally
+        ``sys.stdout`` itself) and flushed newest-wrapper-first, so a stack
+        such as ipykernel's ``OutStream`` over the real ``stdout`` drains in
+        order. Every flush is individually guarded: a closed, detached, or
+        replaced stream — pytest's captured ``stdout``, a torn-down notebook
+        kernel — must not take down the reporting session.
+
+        Note that this reaches only Python-level buffers.
+
+        Returns
+        -------
+        None
+        """
+        streams = (
+            self._console.file,
+            sys.stdout,
+            sys.stderr,
+            sys.__stdout__,
+            sys.__stderr__,
+        )
+        seen: set[int] = set()
+        for stream in streams:
+            flush = getattr(stream, "flush", None)
+            if flush is None or id(stream) in seen:
+                continue
+            seen.add(id(stream))
+            with suppress(Exception):
+                flush()
+
+
+class RichProgressReporter(BaseProgressReporter):
     """
     Rich-based reporter that renders one bar per progress source.
 
@@ -198,6 +247,9 @@ class RichProgressReporter:
             console=self._console,
             transient=self._transient,
         )
+        # Flush both stderr and stdout
+        self._flush_all()
+
         self._progress.start()
         # When both sources are present, label the outer (batch) bar with the
         # method name and the inner (engine) bar with an indented hint so the
@@ -264,9 +316,10 @@ class RichProgressReporter:
         status = "complete" if success else "failed"
         if self._label:
             self._console.print(f"{marker} {self._label} {status} in {duration}")
+        self._flush_all()
 
 
-class SimpleProgressReporter:
+class SimpleProgressReporter(BaseProgressReporter):
     """
     Line-printing reporter for terminals where rich's live renderer is unreliable.
 
@@ -317,6 +370,7 @@ class SimpleProgressReporter:
         self._finished = False
         self._last_step = dict.fromkeys(sources, -1)
         self._last_output = dict.fromkeys(sources, 0.0)
+        self._flush_all()
         # Every progress line is indented under the label header for a
         # uniform "section + body" look. When both sources are present,
         # the engine bar gets an additional indent so it visually nests
@@ -390,6 +444,7 @@ class SimpleProgressReporter:
         status = "complete" if success else "failed"
         if self._label:
             self._console.print(f"{marker} {self._label} {status} in {duration}")
+        self._flush_all()
 
 
 def auto_reporter(*, console: Console | None = None) -> ProgressReporter:

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -1599,12 +1599,12 @@ def _format_eta(eta: timedelta | None, *, long: bool = True) -> str:
     Returns
     -------
     str
-        ``"Est. Remaining: 0:01:23"``, ``"ETA 0:01:23"``, or ``""`` when there
+        ``"est. remaining: 0:01:23"``, ``"ETA 0:01:23"``, or ``""`` when there
         is no usable estimate.
     """
     if eta is None or eta.total_seconds() < 0:
         return ""
-    label = "Est. Remaining:" if long else "ETA"
+    label = "est. remaining:" if long else "ETA"
     return f"{label} {timedelta(seconds=int(eta.total_seconds()))}"
 
 

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -284,7 +284,12 @@ class BaseProgressReporter:
             return ""
         marker = "[green]✓[/green]" if success else "[red]✗[/red]"
         status = "complete" if success else "failed"
-        return f"{marker} {self._label} {status} in {_format_duration(duration)}"
+        # Bold cyan to match the bar row above it, where the task name is
+        # already styled that way.
+        return (
+            f"{marker} [bold cyan]{self._label}[/bold cyan] "
+            f"{status} in {_format_duration(duration)}"
+        )
 
     def _flush_all(self) -> None:
         """
@@ -420,7 +425,9 @@ class RichProgressReporter(BaseProgressReporter):
             self._bar_column(),
             _CountColumn(),
             _ElapsedColumn(),
-            TextColumn("[dim]{task.fields[eta]}"),
+            # Green to tie it to the duration on the completion line, which is
+            # the figure this is predicting.
+            TextColumn("[green]{task.fields[eta]}"),
         )
 
     @staticmethod
@@ -2031,7 +2038,11 @@ class _CountColumn(MofNCompleteColumn):
         details = task.fields.get("details") or ""
         text = Text(counter, style="progress.download")
         if details:
-            text.append(f" {details}", style="progress.data.speed")
+            # The label's hue, unbolded: the details describe the same task, so
+            # they read as subordinate to it rather than as a separate signal.
+            # Not rich's ``progress.data.speed``, which resolves to plain red —
+            # the colour a pending bar uses, meaning something else entirely.
+            text.append(f" {details}", style="cyan")
         return text
 
 

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -129,6 +129,9 @@ class ProgressEvent:
     details: str = ""
     """Human-readable description, when available."""
 
+    eta: timedelta | None = None
+    """Estimated time until this source completes, when it can be estimated."""
+
     extras: dict[str, Any] = field(default_factory=dict)
     """Source-specific extras (e.g. batch response payload). Reserved for callers."""
 
@@ -176,6 +179,22 @@ class BaseProgressReporter:
 
     _label: str
     """Current session label. Set by each subclass in ``start``."""
+
+    def _eta_text(self, eta: timedelta | None) -> str:
+        """
+        Render an estimate, labelled to fit this reporter's console.
+
+        Parameters
+        ----------
+        eta : timedelta or None
+            The estimate to render.
+
+        Returns
+        -------
+        str
+            The rendered estimate, or ``""`` when there is none.
+        """
+        return _format_eta(eta, long=self._console.width >= ETA_LABEL_MIN_WIDTH)
 
     def _completion_markup(self, *, success: bool, duration: timedelta) -> str:
         """
@@ -306,6 +325,7 @@ class RichProgressReporter(BaseProgressReporter):
             MofNCompleteColumn(),
             TextColumn("[dim]{task.fields[details]}"),
             TimeElapsedColumn(),
+            TextColumn("[dim]{task.fields[eta]}"),
         )
 
     @staticmethod
@@ -370,6 +390,7 @@ class RichProgressReporter(BaseProgressReporter):
                 descriptions.get(source, fallback),
                 total=None,
                 details="",
+                eta="",
             )
 
     def update(self, event: ProgressEvent) -> None:
@@ -395,6 +416,7 @@ class RichProgressReporter(BaseProgressReporter):
             completed=event.step,
             total=event.total or None,
             details=event.details,
+            eta=self._eta_text(event.eta),
         )
 
     def finish(self, *, success: bool, duration: timedelta) -> None:
@@ -712,7 +734,7 @@ class RichNotebookProgressReporter(RichProgressReporter):
         self._unwrapped_file = self._console.file
         self._console.file = _OverwriteSafeWriter(self._unwrapped_file)
         self._progress.start()
-        task = self._progress.add_task(label or "Working", total=None, details="")
+        task = self._progress.add_task(label or "Working", total=None, details="", eta="")
         # Registering every declared source against the one track keeps the
         # inherited "an undeclared source is ignored" guard working unchanged.
         for source in sources:
@@ -747,6 +769,7 @@ class RichNotebookProgressReporter(RichProgressReporter):
             completed=event.step,
             total=event.total or None,
             details=self._compose_details(),
+            eta=self._eta_text(event.eta),
         )
 
     def finish(self, *, success: bool, duration: timedelta) -> None:
@@ -989,6 +1012,7 @@ class RichDisplayProgressReporter(RichProgressReporter):
                 descriptions.get(source, fallback),
                 total=None,
                 details="",
+                eta="",
             )
         self._flush_all()
         # Imported here rather than at module scope: IPython is not a
@@ -1099,6 +1123,25 @@ class SimpleProgressReporter(BaseProgressReporter):
         self._prefixes: dict[ProgressSource, str] = {}
         self._finished: bool = False
 
+    def _eta_text(self, eta: timedelta | None) -> str:
+        """
+        Render an estimate, always spelled out.
+
+        Unlike a bar, these lines have no columns competing for width — the
+        estimate cannot crowd anything out, so the label never needs shortening.
+
+        Parameters
+        ----------
+        eta : timedelta or None
+            The estimate to render.
+
+        Returns
+        -------
+        str
+            The rendered estimate, or ``""`` when there is none.
+        """
+        return _format_eta(eta)
+
     def start(self, label: str, *, sources: Sequence[ProgressSource]) -> None:
         """
         Begin a reporting session and print the session header.
@@ -1162,16 +1205,20 @@ class SimpleProgressReporter(BaseProgressReporter):
         prefix = self._prefixes.get(event.source, "")
         total = event.total or "?"
         width = len(str(total))
+        eta = self._eta_text(event.eta)
         if event.step != self._last_step.get(event.source, -1):
+            suffix = f" [dim]\u00b7 {eta}[/dim]" if eta else ""
             self._console.print(
-                f"{prefix}[dim]\\[{event.step:>{width}}/{total}][/dim] {event.details}"
+                f"{prefix}[dim]\\[{event.step:>{width}}/{total}][/dim] {event.details}{suffix}"
             )
             self._last_step[event.source] = event.step
             self._last_output[event.source] = now
         elif now - self._last_output.get(event.source, 0.0) >= HEARTBEAT_INTERVAL:
             elapsed = timedelta(seconds=int(now - self._start_time))
+            # A stalled step is exactly when a reader wants the estimate.
+            trailer = f" \u00b7 {eta}" if eta else ""
             self._console.print(
-                f"{prefix}[dim]\\[{event.step:>{width}}/{total}] · {elapsed} elapsed[/dim]"
+                f"{prefix}[dim]\\[{event.step:>{width}}/{total}] · {elapsed} elapsed{trailer}[/dim]"
             )
             self._last_output[event.source] = now
 
@@ -1418,11 +1465,20 @@ def with_progress(
 
     if has_batch_cb:
         def _batch_cb(progress: ProgressTimer, *_extra: Any, **__: Any) -> None:
+            # ``time_remaining`` divides by ``max(current_tick, 1)``, so before
+            # the first tick lands it reports roughly the whole run as still
+            # remaining. Withhold it until there is a real measurement, and
+            # tolerate the timer not having been started at all.
+            eta: timedelta | None = None
+            if progress.current_tick > 0:
+                with suppress(ValueError):
+                    eta = progress.time_remaining
             reporter.update(ProgressEvent(
                 source="batch",
                 step=progress.current_tick,
                 total=progress.total_ticks,
                 details=f"batch {progress.update_count}",
+                eta=eta,
             ))
         kwargs["progress_callback"] = _batch_cb
 
@@ -1513,6 +1569,43 @@ def _parse_tristate(value: Any) -> bool | None:
     if text in _FALSY:
         return False
     return None  # "auto", "", or anything else → fallthrough
+
+
+# Below this console width the spelled-out estimate label crowds the bar hard
+# enough to truncate real data. Measured against the longest label this module
+# generates ("React series stationary"): at 88 columns the counter and elapsed
+# time render as "12000/…" and "0:00:…", while at 96 nothing is cut and the bar
+# still holds 17 columns. 100 keeps a margin, and is what a notebook uses.
+ETA_LABEL_MIN_WIDTH = 100
+
+
+def _format_eta(eta: timedelta | None, *, long: bool = True) -> str:
+    """
+    Render an estimate, labelled to fit the space available.
+
+    Sub-second precision is dropped: a ``timedelta`` stringifies with
+    microseconds (``0:01:23.456789``), which is false precision on a figure
+    that is an estimate to begin with.
+
+    Parameters
+    ----------
+    eta : timedelta or None
+        The estimate to render.
+    long : bool, default True
+        Whether there is room to spell the label out. Callers competing for
+        horizontal space pass ``False`` when the console is narrow, so the bar
+        and counter keep their columns; see :data:`ETA_LABEL_MIN_WIDTH`.
+
+    Returns
+    -------
+    str
+        ``"Est. Remaining: 0:01:23"``, ``"ETA 0:01:23"``, or ``""`` when there
+        is no usable estimate.
+    """
+    if eta is None or eta.total_seconds() < 0:
+        return ""
+    label = "Est. Remaining:" if long else "ETA"
+    return f"{label} {timedelta(seconds=int(eta.total_seconds()))}"
 
 
 def _default_label(name: str) -> str:

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -717,7 +717,12 @@ class _StateSpinnerColumn(SpinnerColumn):
         """
         if task.fields.get("done"):
             return self.finished_text
-        return super().render(task)
+        # Not ``super().render``: rich blanks its spinner on ``task.finished``,
+        # which is ``completed >= total``. The engine reporting its last step is
+        # not the call returning, so that stops the spinner while the work
+        # carries on — the same mistake that froze the elapsed clock and turned
+        # the bar green early. Only the session ending stops it.
+        return self.spinner.render(task.get_time())
 
 
 class _StateBarColumn(BarColumn):

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -575,6 +575,12 @@ class _OverwriteSafeWriter:
 
     _PAD = " "
 
+    # Cursor show/hide, which rich emits because we force ``is_terminal``.
+    # There is no cursor to hide in a notebook, so these are pure noise: most
+    # front-ends drop them, but nbconvert's HTML export handles only SGR codes
+    # and renders the rest as literal text — a stray ``[?25l`` above the bars.
+    _CURSOR_CODES = ("\x1b[?25l", "\x1b[?25h")
+
     def __init__(self, wrapped: Any) -> None:
         """Initialize the writer."""
         self._wrapped = wrapped
@@ -595,6 +601,10 @@ class _OverwriteSafeWriter:
         int
             Characters written by the underlying file.
         """
+        for code in self._CURSOR_CODES:
+            text = text.replace(code, "")
+        if not text:
+            return 0
         if "\r" in text:
             # Pad the current line only: what is on screen is the text after the
             # last carriage return, up to the newline that ends the region. A
@@ -812,6 +822,56 @@ class RichNotebookProgressReporter(RichProgressReporter):
                 setattr(sys, name, proxied)
 
 
+def _experimental_notebook_reporter() -> bool:
+    """
+    Report whether rich progress in a notebook is opted into.
+
+    Rich progress in a notebook rests on behavior no front-end documents — an
+    in-place carriage-return repaint, or the display-update protocol — so the
+    whole notebook branch is opt-in. With the flag unset a notebook takes the
+    same path it always did: :class:`SimpleProgressReporter`. A real terminal
+    is unaffected either way and keeps :class:`RichProgressReporter`.
+
+    Returns
+    -------
+    bool
+        True when the environment variable is set to a truthy value.
+    """
+    return _parse_tristate(os.environ.get("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER")) is True
+
+
+def _interactive_frontend() -> bool:
+    """
+    Report whether a live front-end is driving this kernel.
+
+    A notebook executed headlessly — ``nbconvert``, ``papermill``, anything
+    built on ``nbclient`` — runs a real kernel with a real IPython shell, so
+    every other notebook check passes, but nothing is rendering the output
+    interactively. Its HTML export handles only SGR escape codes and does not
+    implement carriage-return overwrite at all, so an in-place repaint is
+    committed to the document one frame per line.
+
+    The signal is the execute request's ``allow_stdin`` flag, which the kernel
+    records per request. ``nbclient`` hard-codes ``self.kc.allow_stdin = False``
+    while JupyterLab's client defaults it to ``true``. Anything that omits the
+    field reads as ``False`` (``kernelbase`` does ``content.get("allow_stdin",
+    False)``), so an unrecognized front-end degrades to plain lines rather than
+    to corrupted output — the safe direction.
+
+    Returns
+    -------
+    bool
+        True when the current execution can prompt for input, and therefore has
+        someone watching it.
+    """
+    ipython_mod = sys.modules.get("IPython")
+    if ipython_mod is None:
+        return False
+    get_ipython = getattr(ipython_mod, "get_ipython", None)
+    shell = get_ipython() if callable(get_ipython) else None
+    return bool(getattr(getattr(shell, "kernel", None), "_allow_stdin", False))
+
+
 def _display_handle_available() -> bool:
     """
     Report whether an updatable IPython display slot can be created.
@@ -985,7 +1045,10 @@ class RichDisplayProgressReporter(RichProgressReporter):
         self._label = label
         self._handle = None
         self._inline = None
-        if len(sources) < 2:
+        if not sources:
+            # Nothing to track: no slot, no delegate, just the completion line.
+            return
+        if len(sources) < 2 and _interactive_frontend():
             # A display slot buys exactly one thing: room for more than one
             # line. A single bar does not need it, and claiming one would split
             # the cell — a notebook merges consecutive stdout writes into a
@@ -1254,10 +1317,11 @@ def auto_reporter(*, console: Console | None = None) -> ProgressReporter:
        (``1``/``on``/``true``/``yes``) forces the line-printing reporter. This
        is the escape hatch from everything below.
     2. A tty gets :class:`RichProgressReporter` — the full nested layout.
-    3. A notebook kernel with a live IPython shell gets
-       :class:`RichDisplayProgressReporter`, which repaints a display slot and
-       so renders the full nested layout. Without one — a Databricks runtime
-       where ``IPython`` was never imported, for instance — it falls back to
+    3. A notebook kernel gets a rich reporter **only** when
+       ``HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER`` is set. With a live IPython
+       shell, :class:`RichDisplayProgressReporter`, which repaints a display
+       slot and so renders the full nested layout; without one — a Databricks
+       runtime where ``IPython`` was never imported, for instance —
        :class:`RichNotebookProgressReporter`, a single bar drawn with only the
        control codes those front-ends honor.
     4. Anything else — a pipe, a redirect, a CI log — gets
@@ -1283,10 +1347,16 @@ def auto_reporter(*, console: Console | None = None) -> ProgressReporter:
         return SimpleProgressReporter(console=console)
     if sys.stdout.isatty():
         return RichProgressReporter(console=console)
-    if _in_notebook():
+    if _in_notebook() and _experimental_notebook_reporter():
+        # The display slot survives headless execution: nbclient replaces the
+        # output's data in place for each update, so an nbconvert/papermill run
+        # stores the final frame as ordinary HTML and exports it faithfully.
         if _display_handle_available():
             return RichDisplayProgressReporter(console=console)
-        return RichNotebookProgressReporter(console=console)
+        # An in-place carriage-return repaint does not survive: nothing applies
+        # it, so every frame is committed to the document as its own line.
+        if _interactive_frontend():
+            return RichNotebookProgressReporter(console=console)
     return SimpleProgressReporter(console=console)
 
 

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -739,6 +739,10 @@ class _StateBarColumn(BarColumn):
 
     PENDING_STYLE = "red"
     DONE_STYLE = "green"
+    # The unfilled track. rich's default is ``grey23``, a 256-cube index that no
+    # theme remaps — roughly #3a3a3a, which reads as *filled* on a light
+    # background. A named ANSI colour lands in the palette the front-end themes.
+    TRACK_STYLE = "bright_black"
 
     def render(self, task: Any) -> Any:
         """
@@ -754,12 +758,20 @@ class _StateBarColumn(BarColumn):
         ProgressBar or _SolidBar
             The bar to draw.
         """
+        succeeded = bool(task.fields.get("done") and task.fields.get("ok"))
+        style = self.DONE_STYLE if succeeded else self.PENDING_STYLE
         if task.total is None:
-            succeeded = task.fields.get("done") and task.fields.get("ok")
-            return _SolidBar(
-                self.DONE_STYLE if succeeded else self.PENDING_STYLE, self.bar_width
-            )
-        return super().render(task)
+            return _SolidBar(style, self.bar_width)
+        bar = super().render(task)
+        # Override rich's own styles rather than take them: it switches to
+        # ``finished_style`` as soon as ``completed >= total``, but the engine
+        # reporting its last step is not the call returning. A bar that goes
+        # green while the work carries on says the opposite of the elapsed time
+        # ticking beside it.
+        bar.complete_style = style
+        bar.finished_style = style
+        bar.style = self.TRACK_STYLE
+        return bar
 
 
 class _OverwriteSafeWriter(io.TextIOBase):
@@ -2040,7 +2052,14 @@ class _ElapsedColumn(TimeElapsedColumn):
         Text
             The elapsed time, or a placeholder before the task starts.
         """
-        elapsed = task.finished_time if task.finished else task.elapsed
+        # Deliberately not rich's ``finished_time if task.finished``: rich
+        # freezes that the instant ``completed >= total``, but the engine
+        # reporting its last step is not the call returning. An ``analyze``
+        # whose engine reported 1/1 after a second went on working for another
+        # seventeen, and the bar sat at 0:00:01 beside a completion line
+        # reading 0:00:18. ``elapsed`` keeps running until the Progress stops,
+        # which is the moment the session actually ends.
+        elapsed = task.elapsed
         if elapsed is None:
             return Text("-:--:--", style="progress.elapsed")
         return Text(_format_duration(timedelta(seconds=elapsed)), style="progress.elapsed")

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -947,6 +947,61 @@ class RichNotebookProgressReporter(RichProgressReporter):
         note = f"engine {step}/{total or '?'}"
         return _one_line(f"{note} \u00b7 {detail}" if detail else note)
 
+    def _prepare_merged(self, label: str, sources: Sequence[ProgressSource]) -> bool:
+        """
+        Build the single-bar model, without delivering anything.
+
+        The caller decides how frames reach the reader -- repainted over stdout,
+        or pushed into a display slot. Sharing this is what makes a notebook
+        rendered by nbconvert or papermill look like the interactive one.
+
+        Parameters
+        ----------
+        label : str
+            Session label.
+        sources : sequence of ProgressSource
+            Declared sources, all of which share one bar.
+
+        Returns
+        -------
+        bool
+            False when there is nothing to track, so the caller can bail out
+            rather than open a live region or claim a display slot for nothing.
+        """
+        self._label = label
+        self._detail = ""
+        self._engine = None
+        # ``batch`` is the outer measure when it is live, so it owns the bar and
+        # ``engine`` is demoted to the details text. Otherwise the first declared
+        # source owns it, which matters for ``activity``: it is neither, and
+        # would otherwise leave this reporter blank.
+        if "batch" in sources:
+            self._primary = "batch"
+        elif "engine" in sources:
+            self._primary = "engine"
+        else:
+            self._primary = sources[0] if sources else None
+        self._secondary = (
+            "engine" if (self._primary == "batch" and "engine" in sources) else None
+        )
+        if self._primary is None:
+            return False
+        self._progress = Progress(
+            *self._make_columns(
+                activity=tuple(sources) == ("activity",),
+                label_width=_label_column_width(
+                    label, *self._track_descriptions(label, sources).values()
+                ),
+            ),
+            console=self._console,
+            transient=self._transient,
+            # Columns are pinned instead: letting rich redistribute slack put
+            # labels and bars in different columns from one session to the next.
+            expand=False,
+            refresh_per_second=NOTEBOOK_REFRESH_HZ,
+        )
+        return True
+
     def start(self, label: str, *, sources: Sequence[ProgressSource]) -> None:
         """
         Begin a reporting session, mapping every source onto a single bar.
@@ -964,46 +1019,40 @@ class RichNotebookProgressReporter(RichProgressReporter):
         -------
         None
         """
-        self._label = label
-        self._detail = ""
-        self._engine = None
-        # ``batch`` is the outer measure when it is live, so it owns the bar and
-        # ``engine`` is demoted to the details text. Otherwise the first declared
-        # source owns it — that fallback matters for ``activity``, which is
-        # neither and would otherwise leave this reporter blank.
-        if "batch" in sources:
-            self._primary = "batch"
-        elif "engine" in sources:
-            self._primary = "engine"
-        else:
-            self._primary = sources[0] if sources else None
-        self._secondary = "engine" if (self._primary == "batch" and "engine" in sources) else None
-        if self._primary is None:
-            # Nothing to track. Skip the live region entirely rather than
-            # starting one that would emit stray control codes and needlessly
-            # swap sys.stdout for a FileProxy.
+        if not self._prepare_merged(label, sources):
             return
-        self._progress = Progress(
-            *self._make_columns(
-                activity=tuple(sources) == ("activity",),
-                label_width=_label_column_width(label, *self._track_descriptions(label, sources).values()),
-            ),
-            console=self._console,
-            transient=self._transient,
-            # Pads every frame to the full console width. Notebook front-ends
-            # implement ``\r`` as a length-based overwrite and ignore the
-            # erase-line that rich pairs with it, so a frame shorter than its
-            # predecessor would leave the previous frame's tail on screen.
-            expand=False,
-            refresh_per_second=NOTEBOOK_REFRESH_HZ,
-        )
         self._flush_all()
         # Wrap for the repainting region only, so the completion line and
         # anything the caller prints afterwards go straight to the real file.
         self._unwrapped_file = self._console.file
         self._console.file = _OverwriteSafeWriter(self._unwrapped_file)  # pyright: ignore[reportAttributeAccessIssue]
         self._progress.start()
-        task = self._progress.add_task(label or "Working", total=None, details="", eta="", done=False, ok=False)
+        self._add_merged_task(label, sources)
+
+    def _add_merged_task(self, label: str, sources: Sequence[ProgressSource]) -> None:
+        """
+        Create the one shared track and point every declared source at it.
+
+        Split out so the display-slot reporter can build the same single-bar
+        model without the ANSI machinery around it -- a batch-rendered notebook
+        should look like the interactive one.
+
+        Parameters
+        ----------
+        label : str
+            Session label, shown on the bar.
+        sources : sequence of ProgressSource
+            Sources to register against the single track.
+
+        Returns
+        -------
+        None
+        """
+        if self._progress is None:
+            return
+        task = self._progress.add_task(
+            label or "Working", total=None, details="", eta="", done=False, ok=False
+        )
         # Registering every declared source against the one track keeps the
         # inherited "an undeclared source is ignored" guard working unchanged.
         for source in sources:
@@ -1203,7 +1252,7 @@ class _TightRenderable:
         return data
 
 
-class RichDisplayProgressReporter(RichProgressReporter):
+class RichDisplayProgressReporter(RichNotebookProgressReporter):
     """
     Rich reporter that repaints via IPython's display-update protocol.
 
@@ -1219,6 +1268,12 @@ class RichDisplayProgressReporter(RichProgressReporter):
     spec since 5.1 — notably *not* ``ipywidgets``, which cannot work here: a
     kernel cannot learn whether its front-end renders widgets, and a front-end
     that does not leaves the cell showing the string ``Output()``.
+
+    One caveat: the frame is turned into HTML by rich's ``JupyterMixin``, which
+    renders through the *global* console rather than this reporter's. In a
+    kernel that is a Jupyter console and the output matches the stdout reporter
+    exactly; a colourless or narrower global console would render the bar's
+    unfilled track as blanks instead.
 
     Colors are baked to literal hex on this path, since the frame is delivered
     as HTML rather than ANSI. That is not a loss for us: rich's stock styles
@@ -1236,7 +1291,8 @@ class RichDisplayProgressReporter(RichProgressReporter):
 
     def __init__(self, *, console: Console | None = None) -> None:
         """Initialize the reporter."""
-        super().__init__(console=console or _notebook_console(), transient=False)
+        # The parent already pins ``transient=False`` and the notebook console.
+        super().__init__(console=console)
         self._handle: Any = None
         self._last_push: float = 0.0
         self._inline: RichNotebookProgressReporter | None = None
@@ -1322,28 +1378,14 @@ class RichDisplayProgressReporter(RichProgressReporter):
             self._inline = RichNotebookProgressReporter(console=self._console)
             self._inline.start(label, sources=sources)
             return
-        self._progress = Progress(
-            *self._make_columns(
-                activity=tuple(sources) == ("activity",),
-                label_width=_label_column_width(label, *self._track_descriptions(label, sources).values()),
-            ),
-            console=self._console,
-            transient=self._transient,
-        )
-        # Deliberately no ``Progress.start()``: starting it would install rich's
-        # Live renderer and with it the cursor-up repaint this class exists to
-        # avoid. The Progress here is only a model that knows how to render.
-        descriptions = self._track_descriptions(label, sources)
-        fallback = label or "Working"
-        for source in sources:
-            self._tasks[source] = self._progress.add_task(
-                descriptions.get(source, fallback),
-                total=None,
-                details="",
-                eta="",
-                done=False,
-                ok=False,
-            )
+        # The same single-bar model the stdout reporter builds, so a notebook
+        # rendered by nbconvert or papermill looks like the interactive one.
+        # Deliberately no ``Progress.start()``: that would install rich's Live
+        # renderer and with it the cursor-up repaint this class exists to avoid.
+        # The Progress here is only a model that knows how to render.
+        if not self._prepare_merged(label, sources):
+            return
+        self._add_merged_task(label, sources)
         self._flush_all()
         # Imported here rather than at module scope: IPython is not a
         # dependency, and this class is only ever selected once

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -1272,7 +1272,7 @@ class RichDisplayProgressReporter(RichNotebookProgressReporter):
     One caveat: the frame is turned into HTML by rich's ``JupyterMixin``, which
     renders through the *global* console rather than this reporter's. In a
     kernel that is a Jupyter console and the output matches the stdout reporter
-    exactly; a colourless or narrower global console would render the bar's
+    exactly; a colorless or narrower global console would render the bar's
     unfilled track as blanks instead.
 
     Colors are baked to literal hex on this path, since the frame is delivered
@@ -1795,6 +1795,56 @@ def _cached_polling_support(trainee: Any, client: Any, trainee_id: str | None) -
     return bool(supported)
 
 
+def _resolve_owner(
+    bound_func: Callable[..., Any], args: tuple[Any, ...], kwargs: Mapping[str, Any]
+) -> tuple[Any, Any, str | None]:
+    """
+    Work out who owns a decorated call, and which Trainee it concerns.
+
+    The decorators sit on client methods, but may also be applied to a facade
+    such as ``Trainee`` that delegates to one. The two differ in where the
+    information lives:
+
+    * a ``Trainee`` reaches its client through ``.client`` and knows its own
+      ``.id``;
+    * a client *is* the client, and takes ``trainee_id`` as a call argument.
+
+    Reading only the ``Trainee`` shape leaves both values ``None`` for a
+    client-bound method, which silently disables engine polling for every
+    session -- the gate cannot confirm a multi-threaded engine without them.
+
+    Parameters
+    ----------
+    bound_func : callable
+        The bound method being wrapped.
+    args : tuple
+        Positional arguments of the call.
+    kwargs : Mapping
+        Keyword arguments of the call.
+
+    Returns
+    -------
+    tuple
+        The owner, its client (or itself), and the Trainee id if known.
+    """
+    owner = getattr(bound_func, "__self__", None)
+    if owner is None:
+        return None, None, None
+    # ``get_trainee_runtime`` is the same duck-type ``engine_polling_supported``
+    # uses to interrogate a client, so anything it accepts is accepted here.
+    client = getattr(owner, "client", None)
+    if client is None and hasattr(owner, "get_trainee_runtime"):
+        client = owner
+    trainee_id = getattr(owner, "id", None)
+    if trainee_id is None:
+        # Read it from the call rather than guessing a position: these
+        # signatures take ``trainee_id`` first, but that is not ours to assume.
+        with suppress(TypeError, ValueError):
+            bound = inspect.signature(bound_func).bind_partial(*args, **kwargs)
+            trainee_id = bound.arguments.get("trainee_id")
+    return owner, client, trainee_id
+
+
 def with_progress(  # noqa: PLR0915
     label: str,
     bound_func: Callable[..., Any],
@@ -1857,9 +1907,7 @@ def with_progress(  # noqa: PLR0915
         and kwargs.get("task_id") is None
     )
 
-    trainee = getattr(bound_func, "__self__", None)
-    client = getattr(trainee, "client", None) if trainee is not None else None
-    trainee_id = getattr(trainee, "id", None) if trainee is not None else None
+    trainee, client, trainee_id = _resolve_owner(bound_func, args, kwargs)
 
     # Engine polling is only useful when we can actually reach get_progress,
     # and only safe when the engine behind it tolerates a concurrent poll. A
@@ -2085,7 +2133,7 @@ class _CountColumn(MofNCompleteColumn):
         details = task.fields.get("details") or ""
         text = Text(counter, style="progress.download")
         if details:
-            # The label's hue, unbolded: the details describe the same task, so
+            # The label's hue, un-bolded: the details describe the same task, so
             # they read as subordinate to it rather than as a separate signal.
             # Not rich's ``progress.data.speed``, which resolves to plain red —
             # the colour a pending bar uses, meaning something else entirely.
@@ -2199,9 +2247,29 @@ def _in_notebook() -> bool:
     return callable(get_ipython) and get_ipython() is not None
 
 
-def _config_auto_progress(trainee: Any) -> bool | None:
-    """Resolve the ``auto_progress`` setting from the trainee's client configuration."""
-    cfg = getattr(getattr(trainee, "client", None), "configuration", None)
+def _config_auto_progress(owner: Any) -> bool | None:
+    """
+    Resolve the ``auto_progress`` setting from the client configuration.
+
+    ``owner`` is whatever the decorated method is bound to, which may be either
+    a ``Trainee`` — reaching its client through ``.client`` — or a client
+    itself, which carries ``.configuration`` directly. Handling both matters:
+    when the decorators moved onto the client methods, reading only through
+    ``.client`` silently stopped consulting the configuration at all.
+
+    Parameters
+    ----------
+    owner : Any
+        The object the decorated method is bound to.
+
+    Returns
+    -------
+    bool or None
+        The configured value, or None to defer to the next precedence layer.
+    """
+    cfg = getattr(getattr(owner, "client", None), "configuration", None)
+    if cfg is None:
+        cfg = getattr(owner, "configuration", None)
     value = getattr(cfg, "auto_progress", None) if cfg is not None else None
     return _parse_tristate(value)
 

--- a/howso/utilities/progress.py
+++ b/howso/utilities/progress.py
@@ -32,6 +32,7 @@ from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from datetime import timedelta
 from functools import wraps
+import importlib.util
 import inspect
 import os
 import sys
@@ -45,17 +46,22 @@ from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
     Progress,
+    ProgressColumn,
     SpinnerColumn,
     TaskID,
     TextColumn,
     TimeElapsedColumn,
 )
+from rich.table import Table
+from rich.text import Text
 
 from howso.utilities.monitors import ProgressTimer
 
 __all__ = [
     "ProgressEvent",
     "ProgressReporter",
+    "RichDisplayProgressReporter",
+    "RichNotebookProgressReporter",
     "RichProgressReporter",
     "SimpleProgressReporter",
     "auto_progress",
@@ -77,9 +83,34 @@ _M = TypeVar("_M", bound=Callable[..., Any])
 
 ProgressSource = Literal["engine", "batch"]
 
+
+def _env_number(name: str, default: float) -> float:
+    """Read a numeric environment variable, falling back on anything unparseable."""
+    with suppress(TypeError, ValueError):
+        return float(os.environ[name]) if name in os.environ else default
+    return default
+
+
 # Databricks notebook cells can disconnect if no output is emitted for ~30s.
 # A heartbeat well under that window keeps the cell alive during long batches.
-HEARTBEAT_INTERVAL = float(os.environ.get("HOWSO_HEARTBEAT_INTERVAL", "15.0"))
+HEARTBEAT_INTERVAL = _env_number("HOWSO_HEARTBEAT_INTERVAL", 15.0)
+
+# Width of a notebook progress bar. Pinned rather than left to rich, whose
+# ``Console.size`` probes ``os.get_terminal_size()`` on the std file descriptors
+# before falling back to 80 — so a kernel launched from a terminal would
+# silently inherit *that* terminal's width.
+NOTEBOOK_COLUMNS = int(_env_number("HOWSO_PROGRESS_COLUMNS", 100.0))
+
+# Refresh rate for notebook bars. Every frame is a full-width write over the
+# kernel's IOPub channel, so this stays well below rich's default of 10 and
+# under Jupyter's ``iopub_data_rate_limit``, while still emitting often enough
+# to satisfy the Databricks cell keepalive noted above.
+NOTEBOOK_REFRESH_HZ = _env_number("HOWSO_PROGRESS_FPS", 4.0)
+
+# Ceiling on the details column. Long text is truncated rather than wrapped:
+# a second rendered line would reintroduce the cursor-up codes that
+# :class:`RichNotebookProgressReporter` exists to avoid.
+NOTEBOOK_DETAIL_LIMIT = 48
 
 
 @dataclass
@@ -142,6 +173,32 @@ class BaseProgressReporter:
 
     _console: Console
     """Console the concrete reporter renders into. Set by each subclass."""
+
+    _label: str
+    """Current session label. Set by each subclass in ``start``."""
+
+    def _completion_markup(self, *, success: bool, duration: timedelta) -> str:
+        """
+        Build the final status line shared by every reporter.
+
+        Parameters
+        ----------
+        success : bool
+            Whether the wrapped call completed without raising.
+        duration : timedelta
+            Total elapsed time.
+
+        Returns
+        -------
+        str
+            Console markup for the line, or ``""`` when there is no label to
+            name and so nothing worth printing.
+        """
+        if not self._label:
+            return ""
+        marker = "[green]✓[/green]" if success else "[red]✗[/red]"
+        status = "complete" if success else "failed"
+        return f"{marker} {self._label} {status} in {duration}"
 
     def _flush_all(self) -> None:
         """
@@ -219,6 +276,66 @@ class RichProgressReporter(BaseProgressReporter):
         self._tasks: dict[ProgressSource, TaskID] = {}
         self._label: str = ""
 
+    def _bar_column(self) -> BarColumn:
+        """
+        Build the bar itself, so subclasses can substitute one.
+
+        Returns
+        -------
+        BarColumn
+            rich's stock bar.
+        """
+        return BarColumn()
+
+    def _make_columns(self) -> tuple[ProgressColumn, ...]:
+        """
+        Build the column layout shared by every bar this reporter renders.
+
+        Subclasses that lay tracks out differently reuse this so a bar reads
+        the same wherever it is rendered.
+
+        Returns
+        -------
+        tuple of ProgressColumn
+            The columns to hand to :class:`rich.progress.Progress`.
+        """
+        return (
+            SpinnerColumn(),
+            TextColumn("[bold cyan]{task.description}"),
+            self._bar_column(),
+            MofNCompleteColumn(),
+            TextColumn("[dim]{task.fields[details]}"),
+            TimeElapsedColumn(),
+        )
+
+    @staticmethod
+    def _track_descriptions(
+        label: str, sources: Sequence[ProgressSource]
+    ) -> dict[ProgressSource, str]:
+        """
+        Name each track so the nesting reads visually.
+
+        When both sources are present the outer (batch) bar carries the method
+        name and the inner (engine) bar gets an indented hint. When engine is
+        the only source (e.g. ``analyze``), it uses the method label directly —
+        no orphan indent.
+
+        Parameters
+        ----------
+        label : str
+            Session label.
+        sources : sequence of ProgressSource
+            The declared progress sources.
+
+        Returns
+        -------
+        dict
+            Description text keyed by source.
+        """
+        both = "batch" in sources and "engine" in sources
+        fallback = label or "Working"
+        return {"batch": fallback, "engine": "  engine" if both else fallback}
+
     def start(self, label: str, *, sources: Sequence[ProgressSource]) -> None:
         """
         Begin a reporting session and add one bar per progress source.
@@ -238,12 +355,7 @@ class RichProgressReporter(BaseProgressReporter):
         """
         self._label = label
         self._progress = Progress(
-            SpinnerColumn(),
-            TextColumn("[bold cyan]{task.description}"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            TextColumn("[dim]{task.fields[details]}"),
-            TimeElapsedColumn(),
+            *self._make_columns(),
             console=self._console,
             transient=self._transient,
         )
@@ -251,16 +363,8 @@ class RichProgressReporter(BaseProgressReporter):
         self._flush_all()
 
         self._progress.start()
-        # When both sources are present, label the outer (batch) bar with the
-        # method name and the inner (engine) bar with an indented hint so the
-        # nesting reads visually. When engine is the only source (e.g.
-        # ``analyze``), use the method label directly — no orphan indent.
-        both = "batch" in sources and "engine" in sources
+        descriptions = self._track_descriptions(label, sources)
         fallback = label or "Working"
-        descriptions: dict[ProgressSource, str] = {
-            "batch": fallback,
-            "engine": "  engine" if both else fallback,
-        }
         for source in sources:
             self._tasks[source] = self._progress.add_task(
                 descriptions.get(source, fallback),
@@ -312,10 +416,657 @@ class RichProgressReporter(BaseProgressReporter):
             self._progress.stop()
             self._progress = None
             self._tasks.clear()
-        marker = "[green]✓[/green]" if success else "[red]✗[/red]"
-        status = "complete" if success else "failed"
-        if self._label:
-            self._console.print(f"{marker} {self._label} {status} in {duration}")
+        line = self._completion_markup(success=success, duration=duration)
+        if line:
+            self._console.print(line)
+        self._flush_all()
+
+
+def _notebook_console(*, width: int | None = None) -> Console:
+    """
+    Build a console that reaches rich's plain-ANSI path from inside a kernel.
+
+    Every flag here is load-bearing:
+
+    * ``force_jupyter=False`` is the essential one. ``Live.refresh()`` tests
+      ``console.is_jupyter`` *before* its terminal branch, and that branch
+      hard-requires ``ipywidgets`` — which is not a dependency. Without this
+      flag a notebook session emits one ``UserWarning`` and renders nothing.
+    * ``force_terminal=True`` because a kernel's stdout is not a tty, and
+      ``is_terminal`` otherwise gates the live repaint off.
+    * ``legacy_windows=False`` because rich computes
+      ``detect_legacy_windows() and not self.is_jupyter`` — forcing
+      ``is_jupyter`` off *removes* that guard, so a Windows kernel could
+      otherwise fall into the Win32 render path.
+    * ``color_system`` because with ``is_jupyter`` off rich detects color from
+      ``TERM``/``COLORTERM``, which a kernel leaves unset — that would drop us
+      to 8 colors, where rich itself uses truecolor for Jupyter.
+
+    Parameters
+    ----------
+    width : int, optional
+        Bar width in columns. Defaults to :data:`NOTEBOOK_COLUMNS`.
+
+    Returns
+    -------
+    Console
+        A console that renders ANSI progress into the kernel's stdout stream.
+    """
+    return Console(
+        force_jupyter=False,
+        force_terminal=True,
+        legacy_windows=False,
+        color_system="truecolor",
+        width=width or NOTEBOOK_COLUMNS,
+    )
+
+
+def _one_line(text: str, limit: int = NOTEBOOK_DETAIL_LIMIT) -> str:
+    """
+    Flatten text to a single bounded line.
+
+    Sanitizing here is mandatory rather than defensive: ``details`` arrives
+    straight off an arbitrary engine payload, and a single embedded newline
+    makes the bar render two lines high — which immediately reintroduces the
+    cursor-up codes notebooks cannot honor.
+
+    Parameters
+    ----------
+    text : str
+        Raw text to flatten.
+    limit : int, default NOTEBOOK_DETAIL_LIMIT
+        Maximum length; longer text is truncated with an ellipsis.
+
+    Returns
+    -------
+    str
+        A single line of at most ``limit`` characters.
+    """
+    flattened = " ".join(str(text).split())
+    if len(flattened) <= limit:
+        return flattened
+    return flattened[: limit - 1] + "\u2026"
+
+
+class _QuietBarColumn(BarColumn):
+    r"""
+    A bar that renders a static empty track instead of pulsing.
+
+    rich pulses whenever the total is unknown — ``should_pulse = self.pulse or
+    self.total is None`` in ``rich/progress_bar.py`` — and a pulse frame spends
+    ~980 characters on a 20-step colour gradient where the determinate frame
+    replacing it needs ~165. On a stream that repaints with a carriage return
+    that disparity is what has to be padded over, so removing it shrinks the
+    spread from ~819 characters to ~13.
+
+    Only the bar is given a total; the task keeps its ``None``, so
+    :class:`~rich.progress.MofNCompleteColumn` still honestly shows ``0/?``.
+    """
+
+    def render(self, task: Any) -> Any:
+        """
+        Render the bar, substituting a static track when the total is unknown.
+
+        Parameters
+        ----------
+        task : Task
+            The task to render.
+
+        Returns
+        -------
+        ProgressBar
+            The bar to draw.
+        """
+        bar = super().render(task)
+        if task.total is None:
+            bar.total, bar.completed, bar.pulse = 1, 0, False
+        return bar
+
+
+class _OverwriteSafeWriter:
+    r"""
+    Pad each repaint so it fully covers the frame it replaces.
+
+    Notebook front-ends implement ``\r`` as a raw-index overwrite and strip the
+    erase-line code rich pairs with it. A frame that is shorter *in characters*
+    than its predecessor therefore leaves that predecessor's tail on screen,
+    and because the tail usually starts mid-escape-sequence it renders as
+    literal text — ``;112m`` and the like.
+
+    Constant visible width does not help: what matters is raw length, and the
+    two diverge wildly. rich's indeterminate pulse spends ~980 characters on a
+    20-step colour gradient occupying the same ~97 columns that a determinate
+    frame draws in ~165.
+
+    Padding uses **spaces**, deliberately. Escape sequences would occupy raw
+    length while rendering as nothing, which looks ideal until the incoming
+    frame ends part-way through one: the orphaned remainder then renders as
+    literal text (``[0m``). A cut run of spaces is still spaces, so residue
+    stays invisible no matter where the boundary falls. The pad target only
+    grows, since the screen holds the longest frame written so far.
+
+    Parameters
+    ----------
+    wrapped : Any
+        The file object to write through to.
+    """
+
+    _PAD = " "
+
+    def __init__(self, wrapped: Any) -> None:
+        """Initialize the writer."""
+        self._wrapped = wrapped
+        self._written = 0
+
+    def write(self, text: str) -> int:
+        r"""
+        Write ``text``, padding a repaint that would under-cover the last one.
+
+        Parameters
+        ----------
+        text : str
+            The text rich is emitting. A repaint arrives as a single write
+            beginning with ``\r``.
+
+        Returns
+        -------
+        int
+            Characters written by the underlying file.
+        """
+        if "\r" in text:
+            # Pad the current line only: what is on screen is the text after the
+            # last carriage return, up to the newline that ends the region. A
+            # frame's trailing newline is not always last in the write — rich
+            # appends a show-cursor code after it — so padding the whole write
+            # would spill blanks onto the following line.
+            head, _, tail = text.rpartition("\r")
+            line, newline, rest = tail.partition("\n")
+            shortfall = self._written - len(line)
+            if shortfall > 0:
+                line += self._PAD * shortfall
+            # The region ends at a newline; after that nothing is overwritten.
+            self._written = 0 if newline else len(line)
+            text = f"{head}\r{line}{newline}{rest}"
+        elif "\n" in text:
+            self._written = 0
+        return self._wrapped.write(text)
+
+    def flush(self) -> None:
+        """Flush the underlying file."""
+        self._wrapped.flush()
+
+    def isatty(self) -> bool:
+        """Report whether the underlying file is a terminal."""
+        return bool(getattr(self._wrapped, "isatty", bool)())
+
+
+class RichNotebookProgressReporter(RichProgressReporter):
+    r"""
+    Rich reporter for notebook front-ends, which render ANSI but not cursor motion.
+
+    JupyterLab, VS Code, Databricks and Colab all render SGR color codes and
+    treat ``\r`` as a real line rewind, but they *discard* cursor-motion codes
+    rather than acting on them. :class:`RichProgressReporter` repaints an
+    ``H``-line region with ``\r`` + erase-line followed by ``H - 1``
+    cursor-ups, so its nested two-bar layout would append a fresh copy of the
+    bars on every refresh instead of redrawing them.
+
+    This reporter therefore renders **one** bar and keeps it non-transient —
+    measured against rich 15.0.0, that is the only configuration emitting zero
+    cursor-up sequences. When both progress sources are live, ``batch`` owns
+    the bar (it is the meaningful outer measure) and ``engine`` is folded into
+    the details column::
+
+        Train ---------------->        4/10 engine 2/5 - analyzing   0:00:04
+
+    Two consequences worth knowing:
+
+    * The finished bar stays in the cell output beneath the completion line,
+      rather than being cleared as in a terminal. That is deliberate, and is
+      what keeps the cursor-up count at zero.
+    * ``transient`` is not exposed. A caller who wants the terminal behavior
+      should construct :class:`RichProgressReporter` directly.
+
+    Parameters
+    ----------
+    console : Console, optional
+        Console to render into. Defaults to :func:`_notebook_console`. A
+        console supplied here is used as-is, so it must already be built with
+        ``force_jupyter=False`` and ``force_terminal=True`` — rich exposes no
+        way to retrofit those, and a stock ``Console()`` inside a kernel
+        silently renders nothing.
+    """
+
+    def __init__(self, *, console: Console | None = None) -> None:
+        """Initialize the reporter."""
+        super().__init__(console=console or _notebook_console(), transient=False)
+        self._primary: ProgressSource | None = None
+        self._secondary: ProgressSource | None = None
+        self._detail: str = ""
+        self._engine: tuple[int, int, str] | None = None
+        self._unwrapped_file: Any = None
+
+    def _bar_column(self) -> BarColumn:
+        """
+        Build a bar that never pulses.
+
+        Returns
+        -------
+        BarColumn
+            A :class:`_QuietBarColumn`, whose narrow frame-length spread keeps
+            the carriage-return repaint's padding to a few characters.
+        """
+        return _QuietBarColumn()
+
+    def _compose_details(self) -> str:
+        """Render the details column from whichever sources have reported."""
+        if self._engine is None:
+            return self._detail
+        step, total, detail = self._engine
+        note = f"engine {step}/{total or '?'}"
+        return _one_line(f"{note} \u00b7 {detail}" if detail else note)
+
+    def start(self, label: str, *, sources: Sequence[ProgressSource]) -> None:
+        """
+        Begin a reporting session, mapping every source onto a single bar.
+
+        Parameters
+        ----------
+        label : str
+            Short description shown on the bar.
+        sources : sequence of ProgressSource
+            Which progress sources will emit events. All of them share one
+            bar. May be empty, in which case no bar and no live region are
+            created at all.
+
+        Returns
+        -------
+        None
+        """
+        self._label = label
+        self._detail = ""
+        self._engine = None
+        # ``batch`` is the outer measure whenever it is live, so it owns the
+        # bar and ``engine`` is demoted to the details column.
+        self._primary = "batch" if "batch" in sources else ("engine" if "engine" in sources else None)
+        self._secondary = "engine" if (self._primary == "batch" and "engine" in sources) else None
+        if self._primary is None:
+            # Nothing to track. Skip the live region entirely rather than
+            # starting one that would emit stray control codes and needlessly
+            # swap sys.stdout for a FileProxy.
+            return
+        self._progress = Progress(
+            *self._make_columns(),
+            console=self._console,
+            transient=self._transient,
+            # Pads every frame to the full console width. Notebook front-ends
+            # implement ``\r`` as a length-based overwrite and ignore the
+            # erase-line that rich pairs with it, so a frame shorter than its
+            # predecessor would leave the previous frame's tail on screen.
+            expand=True,
+            refresh_per_second=NOTEBOOK_REFRESH_HZ,
+        )
+        self._flush_all()
+        # Wrap for the repainting region only, so the completion line and
+        # anything the caller prints afterwards go straight to the real file.
+        self._unwrapped_file = self._console.file
+        self._console.file = _OverwriteSafeWriter(self._unwrapped_file)
+        self._progress.start()
+        task = self._progress.add_task(label or "Working", total=None, details="")
+        # Registering every declared source against the one track keeps the
+        # inherited "an undeclared source is ignored" guard working unchanged.
+        for source in sources:
+            self._tasks[source] = task
+
+    def update(self, event: ProgressEvent) -> None:
+        """
+        Apply an event to the shared bar, routing by source.
+
+        The primary source drives the bar's position; the secondary source
+        only contributes text, so it can never move a bar it does not own.
+
+        Parameters
+        ----------
+        event : ProgressEvent
+            The progress update to render.
+
+        Returns
+        -------
+        None
+        """
+        if self._progress is None or event.source not in self._tasks:
+            return
+        task = self._tasks[event.source]
+        if event.source == self._secondary:
+            self._engine = (event.step, event.total, _one_line(event.details))
+            self._progress.update(task, details=self._compose_details())
+            return
+        self._detail = _one_line(event.details)
+        self._progress.update(
+            task,
+            completed=event.step,
+            total=event.total or None,
+            details=self._compose_details(),
+        )
+
+    def finish(self, *, success: bool, duration: timedelta) -> None:
+        """
+        End the session and make certain the kernel's stdio is back in place.
+
+        Parameters
+        ----------
+        success : bool
+            Whether the wrapped call completed without raising.
+        duration : timedelta
+            Total elapsed time, shown in the completion line.
+
+        Returns
+        -------
+        None
+        """
+        try:
+            # The wrapper must stay in place across super().finish(), because
+            # that is what calls Progress.stop() — which emits one final frame.
+            # Restoring first left that frame unpadded against a much longer
+            # predecessor, which was the whole visible bug.
+            super().finish(success=success, duration=duration)
+        finally:
+            if self._unwrapped_file is not None:
+                self._console.file = self._unwrapped_file
+                self._unwrapped_file = None
+        self._primary = None
+        self._secondary = None
+        self._engine = None
+        # rich's Live swaps sys.stdout/sys.stderr for a FileProxy so stray
+        # prints render above the bar, and restores them in a ``finally``. A
+        # KeyboardInterrupt landing inside that teardown can still leak one,
+        # which in a kernel is sticky: every later cell would write into a
+        # dead console until the user restarts it. Unwind defensively.
+        for name in ("stdout", "stderr"):
+            stream = getattr(sys, name)
+            proxied = getattr(stream, "rich_proxied_file", None)
+            if proxied is not None and proxied is not stream:
+                setattr(sys, name, proxied)
+
+
+def _display_handle_available() -> bool:
+    """
+    Report whether an updatable IPython display slot can be created.
+
+    This checks only for a live IPython shell and an importable
+    ``IPython.display``. It deliberately does **not** try to establish whether
+    the front-end honors ``update_display_data`` — like widget support, that is
+    unknowable from the kernel, which has no back-channel and may be serving
+    several front-ends at once. The difference is the failure mode: a
+    front-end that ignores the message appends frames instead of updating,
+    which is visible and recoverable, rather than rendering nothing.
+
+    Returns
+    -------
+    bool
+        True when :class:`RichDisplayProgressReporter` can obtain a handle.
+    """
+    ipython_mod = sys.modules.get("IPython")
+    if ipython_mod is None:
+        return False
+    get_ipython = getattr(ipython_mod, "get_ipython", None)
+    if not callable(get_ipython) or get_ipython() is None:
+        return False
+    return importlib.util.find_spec("IPython.display") is not None
+
+
+class _TightRenderable:
+    """
+    Wrap a rich renderable so its notebook HTML carries no outer margin.
+
+    rich emits its Jupyter HTML as a bare ``<pre>`` with no margin reset
+    (``rich/jupyter.py`` ``JUPYTER_HTML_FORMAT``), which browsers give a
+    default ``margin: 1em 0``. Every progress group is its own notebook output
+    block, so those margins stack between groups and read as a large gap.
+
+    Parameters
+    ----------
+    renderable : Any
+        The rich renderable to delegate to. Must itself be a ``JupyterMixin``.
+    """
+
+    def __init__(self, renderable: Any) -> None:
+        """Initialize the wrapper."""
+        self._renderable = renderable
+
+    def _repr_mimebundle_(
+        self, include: Sequence[str], exclude: Sequence[str], **kwargs: Any
+    ) -> dict[str, str]:
+        """
+        Return the delegate's mimebundle with the ``<pre>`` margin stripped.
+
+        Parameters
+        ----------
+        include : sequence of str
+            Mime types to keep, per the IPython protocol.
+        exclude : sequence of str
+            Mime types to drop, per the IPython protocol.
+        **kwargs : Any
+            Forwarded to the delegate.
+
+        Returns
+        -------
+        dict
+            Mime type to rendered content.
+        """
+        data = self._renderable._repr_mimebundle_(include, exclude, **kwargs)
+        html = data.get("text/html")
+        if html is not None:
+            data["text/html"] = html.replace('<pre style="', '<pre style="margin:0;', 1)
+        return data
+
+
+class RichDisplayProgressReporter(RichProgressReporter):
+    """
+    Rich reporter that repaints via IPython's display-update protocol.
+
+    Where :class:`RichNotebookProgressReporter` gives up the nested layout to
+    stay within the control codes a notebook honors, this reporter sidesteps
+    the problem entirely: it never starts rich's ``Live`` at all. Instead it
+    claims one display slot with ``display(..., display_id=True)`` and replaces
+    its contents wholesale on each refresh. Because the whole slot is
+    rewritten, a multi-line renderable needs no cursor motion, so the full
+    ``batch`` + ``engine`` pair renders exactly as it does in a terminal.
+
+    This rides ``update_display_data``, part of the core Jupyter messaging
+    spec since 5.1 — notably *not* ``ipywidgets``, which cannot work here: a
+    kernel cannot learn whether its front-end renders widgets, and a front-end
+    that does not leaves the cell showing the string ``Output()``.
+
+    Colors are baked to literal hex on this path, since the frame is delivered
+    as HTML rather than ANSI. That is not a loss for us: rich's stock styles
+    bake to exactly the RGB a truecolor terminal displays (``#f92672``
+    in-progress, ``#729c1f`` finished, ``#3a3a3a`` track), so the bar matches
+    the terminal. Do not restyle it.
+
+    Parameters
+    ----------
+    console : Console, optional
+        Console used for the completion line. Defaults to
+        :func:`_notebook_console`, so that line is written as ANSI to stdout
+        and collates with surrounding cell output.
+    """
+
+    def __init__(self, *, console: Console | None = None) -> None:
+        """Initialize the reporter."""
+        super().__init__(console=console or _notebook_console(), transient=False)
+        self._handle: Any = None
+        self._last_push: float = 0.0
+        self._inline: RichNotebookProgressReporter | None = None
+
+    @staticmethod
+    def _frame(progress: Progress) -> Any:
+        """
+        Render the current state of every track as one renderable.
+
+        Parameters
+        ----------
+        progress : Progress
+            The progress model to snapshot.
+
+        Returns
+        -------
+        Any
+            A rich renderable carrying one row per track.
+        """
+        return progress.make_tasks_table(progress.tasks)
+
+    def _push(self, *, force: bool = False) -> None:
+        """
+        Replace the display slot's contents, throttled.
+
+        Unlike the ``Live`` path there is no refresh thread here — repaints are
+        driven by incoming events, which arrive far faster than a reader can
+        follow and each cost a full HTML payload over IOPub. ``force`` bypasses
+        the throttle so the final frame always lands on 100%.
+
+        Parameters
+        ----------
+        force : bool, default False
+            Push regardless of how recently the last frame was sent.
+
+        Returns
+        -------
+        None
+        """
+        if self._handle is None or self._progress is None:
+            return
+        now = monotonic()
+        if not force and now - self._last_push < 1.0 / NOTEBOOK_REFRESH_HZ:
+            return
+        self._last_push = now
+        with suppress(Exception):
+            self._handle.update(_TightRenderable(self._frame(self._progress)))
+
+    def start(self, label: str, *, sources: Sequence[ProgressSource]) -> None:
+        """
+        Begin a session and claim a display slot, one bar per source.
+
+        Parameters
+        ----------
+        label : str
+            Short description shown on the outer bar.
+        sources : sequence of ProgressSource
+            Which progress sources will emit events; one bar per source. May
+            be empty, in which case no slot is claimed.
+
+        Returns
+        -------
+        None
+        """
+        self._label = label
+        self._handle = None
+        self._inline = None
+        if len(sources) < 2:
+            # A display slot buys exactly one thing: room for more than one
+            # line. A single bar does not need it, and claiming one would split
+            # the cell — a notebook merges consecutive stdout writes into a
+            # single block but never merges display blocks, so every display
+            # group is fenced off from the lines around it, including the
+            # caller's own prints. Staying on stdout keeps this session in the
+            # same block as its neighbours. The in-place repaint that requires
+            # is made safe by :class:`_OverwriteSafeWriter`.
+            self._inline = RichNotebookProgressReporter(console=self._console)
+            self._inline.start(label, sources=sources)
+            return
+        self._progress = Progress(
+            *self._make_columns(),
+            console=self._console,
+            transient=self._transient,
+        )
+        # Deliberately no ``Progress.start()``: starting it would install rich's
+        # Live renderer and with it the cursor-up repaint this class exists to
+        # avoid. The Progress here is only a model that knows how to render.
+        descriptions = self._track_descriptions(label, sources)
+        fallback = label or "Working"
+        for source in sources:
+            self._tasks[source] = self._progress.add_task(
+                descriptions.get(source, fallback),
+                total=None,
+                details="",
+            )
+        self._flush_all()
+        # Imported here rather than at module scope: IPython is not a
+        # dependency, and this class is only ever selected once
+        # ``_display_handle_available()`` has confirmed a live shell.
+        with suppress(ImportError):
+            from IPython.display import display
+
+            # Returns None when there is no active shell to render into.
+            self._handle = display(
+                _TightRenderable(self._frame(self._progress)), display_id=True
+            )
+        self._last_push = monotonic()
+
+    def update(self, event: ProgressEvent) -> None:
+        """
+        Apply an event to its own bar, then repaint the slot.
+
+        Parameters
+        ----------
+        event : ProgressEvent
+            The progress update to render.
+
+        Returns
+        -------
+        None
+        """
+        if self._inline is not None:
+            self._inline.update(event)
+            return
+        super().update(event)
+        self._push()
+
+    def finish(self, *, success: bool, duration: timedelta) -> None:
+        """
+        Push the final frame, then print the completion line.
+
+        Parameters
+        ----------
+        success : bool
+            Whether the wrapped call completed without raising.
+        duration : timedelta
+            Total elapsed time, shown in the completion line.
+
+        Returns
+        -------
+        None
+        """
+        if self._inline is not None:
+            self._inline.finish(success=success, duration=duration)
+            self._inline = None
+            return
+        line = self._completion_markup(success=success, duration=duration)
+        if self._handle is None or self._progress is None:
+            # No slot was ever claimed (no sources, or no shell to render
+            # into), so there is nothing to fold the line into.
+            super().finish(success=success, duration=duration)
+            return
+        # Render the bars and the completion line as ONE renderable. Printing
+        # the line separately would send it to stdout, and a notebook shows a
+        # stream block and a display block as two outputs, each with its own
+        # vertical padding — leaving a conspicuous gap under the bars.
+        frame = self._frame(self._progress)
+        if line:
+            # ``Table.grid`` rather than ``Group``: only a JupyterMixin carries
+            # the ``_repr_mimebundle_`` that makes IPython render HTML, and
+            # Group is not one — it would reach the notebook as a bare repr.
+            stacked = Table.grid()
+            stacked.add_row(frame)
+            stacked.add_row(Text.from_markup(line))
+            frame = stacked
+        with suppress(Exception):
+            self._handle.update(_TightRenderable(frame))
+        self._handle = None
+        # ``Progress.stop()`` would be a no-op here — Live.stop() returns early
+        # when it was never started — so tear down directly instead.
+        self._progress = None
+        self._tasks.clear()
         self._flush_all()
 
 
@@ -440,10 +1191,9 @@ class SimpleProgressReporter(BaseProgressReporter):
         None
         """
         self._finished = True
-        marker = "[green]✓[/green]" if success else "[red]✗[/red]"
-        status = "complete" if success else "failed"
-        if self._label:
-            self._console.print(f"{marker} {self._label} {status} in {duration}")
+        line = self._completion_markup(success=success, duration=duration)
+        if line:
+            self._console.print(line)
         self._flush_all()
 
 
@@ -451,30 +1201,46 @@ def auto_reporter(*, console: Console | None = None) -> ProgressReporter:
     """
     Choose the reporter that best fits the current environment.
 
-    A simple line-printing reporter is selected when running under Databricks
-    (which can drop live-rendered output), when ``HOWSO_SIMPLE_PROGRESS`` is
-    set to a truthy value (``1``/``on``/``true``/``yes``), or when stdout is
-    not a tty. Otherwise rich's live renderer is used.
+    Selection runs in this order:
+
+    1. ``HOWSO_SIMPLE_PROGRESS`` set to a truthy value
+       (``1``/``on``/``true``/``yes``) forces the line-printing reporter. This
+       is the escape hatch from everything below.
+    2. A tty gets :class:`RichProgressReporter` — the full nested layout.
+    3. A notebook kernel with a live IPython shell gets
+       :class:`RichDisplayProgressReporter`, which repaints a display slot and
+       so renders the full nested layout. Without one — a Databricks runtime
+       where ``IPython`` was never imported, for instance — it falls back to
+       :class:`RichNotebookProgressReporter`, a single bar drawn with only the
+       control codes those front-ends honor.
+    4. Anything else — a pipe, a redirect, a CI log — gets
+       :class:`SimpleProgressReporter`.
+
+    The tty check deliberately precedes the notebook check: ``_in_notebook()``
+    is also true for *terminal* IPython, which should keep the full layout.
 
     Parameters
     ----------
     console : Console, optional
         Console the chosen reporter renders into. Defaults to a fresh
-        :class:`rich.console.Console` created by the reporter.
+        :class:`rich.console.Console` created by the reporter. Note that
+        :class:`RichNotebookProgressReporter` needs specific console flags, so
+        prefer leaving this unset when a notebook is in play.
 
     Returns
     -------
     ProgressReporter
-        A :class:`SimpleProgressReporter` in degraded environments, otherwise
-        a :class:`RichProgressReporter`.
+        The reporter matching the environment, per the order above.
     """
-    if "DATABRICKS_RUNTIME_VERSION" in os.environ:
-        return SimpleProgressReporter(console=console)
     if _parse_tristate(os.environ.get("HOWSO_SIMPLE_PROGRESS")) is True:
         return SimpleProgressReporter(console=console)
-    if not sys.stdout.isatty():
-        return SimpleProgressReporter(console=console)
-    return RichProgressReporter(console=console)
+    if sys.stdout.isatty():
+        return RichProgressReporter(console=console)
+    if _in_notebook():
+        if _display_handle_available():
+            return RichDisplayProgressReporter(console=console)
+        return RichNotebookProgressReporter(console=console)
+    return SimpleProgressReporter(console=console)
 
 
 def _supports_param(bound_func: Callable, name: str) -> bool:

--- a/howso/utilities/tests/test_progress.py
+++ b/howso/utilities/tests/test_progress.py
@@ -789,62 +789,69 @@ def test_notebook_reporter_bar_never_pulses():
     assert len(colors) <= 6, f"gradient detected, {len(colors)} colors"
 
 
-@pytest.mark.parametrize("sources", [("batch", "engine")])
-def test_display_reporter_uses_a_slot_for_every_bar(monkeypatch, sources):
+def test_display_reporter_matches_the_stdout_reporter(monkeypatch):
     """
-    Verify even a lone bar is rendered through a display slot.
+    Verify a headless render looks like the interactive one.
 
-    Sending a single bar to stdout instead would close the vertical gap between
-    groups, but stdout repaints in place with a carriage return, and rich's
-    frames shrink drastically — a ~980 character pulse frame is replaced by a
-    ~165 character determinate one. The survivors begin mid-escape-sequence and
-    render as literal text. A display slot replaces its content outright, so
-    that cannot happen.
+    This reporter exists so notebooks rendered en masse by nbconvert or
+    papermill show what a person sees in the notebook. It therefore builds the
+    same single-bar model as the stdout reporter and differs only in delivery —
+    a display slot instead of a carriage-return repaint.
     """
+    events = [
+        ProgressEvent(source="batch", step=2, total=4, details="batch 2"),
+        ProgressEvent(source="engine", step=1, total=3, details="reacting"),
+    ]
+
+    inline = RichNotebookProgressReporter()
+    sink = io.StringIO()
+    inline._console.file = sink
+    inline.start("React", sources=("batch", "engine"))
+    for event in events:
+        inline.update(event)
+    _require_progress(inline).refresh()
+    expected = _ANSI.sub("", [f for f in sink.getvalue().split("\r")
+                              if "\u2501" in f][-1]).split("\n")[0].rstrip()
+    inline.finish(success=True, duration=timedelta(seconds=9))
+
+    # ``_repr_mimebundle_`` renders through rich's *global* console, which this
+    # process leaves colourless and 80 wide. A kernel's is a Jupyter console, so
+    # pin an equivalent or the comparison measures the test rig, not the code.
+    import rich
+
+    monkeypatch.setattr(
+        rich, "_console",
+        Console(force_terminal=True, color_system="truecolor", width=NOTEBOOK_COLUMNS),
+        raising=False,
+    )
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
+    handle = _fake_display(monkeypatch)
+    display = RichDisplayProgressReporter()
+    display._console.file = io.StringIO()
+    display.start("React", sources=("batch", "engine"))
+    for event in events:
+        display.update(event)
+    display._push(force=True)
+    rows = [_ANSI.sub("", row) for row in _rows(handle.frames[-1])]
+    display.finish(success=True, duration=timedelta(seconds=9))
+
+    assert len(rows) == 1, f"expected one merged bar, got {rows}"
+    assert rows[0].rstrip() == expected
+
+
+@pytest.mark.parametrize("sources", [("batch",), ("batch", "engine")])
+def test_display_reporter_uses_one_bar_whatever_the_sources(monkeypatch, sources):
+    """One merged bar, so the layout does not change with the engine's presence."""
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
     handle = _fake_display(monkeypatch)
     reporter = RichDisplayProgressReporter()
     reporter._console.file = io.StringIO()
-    reporter.start("Train", sources=sources)
+    reporter.start("React", sources=sources)
     for source in sources:
-        reporter.update(ProgressEvent(source=source, step=5, total=5, details="b"))
-    reporter.finish(success=True, duration=timedelta(seconds=1))
-    assert handle.frames                       # a slot was claimed
-    assert len(_rows(handle.frames[-1])) == len(sources) + 1   # bars + completion
-
-
-def test_two_sources_merge_onto_one_bar_when_inline(monkeypatch):
-    """The engine rides in the details text rather than getting its own line."""
-    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: True)
-    reporter = RichNotebookProgressReporter()
-    sink = io.StringIO()          # keep our own handle: start() wraps the file
-    reporter._console.file = sink
-    reporter.start("React", sources=("batch", "engine"))
-    try:
-        reporter.update(ProgressEvent(source="batch", step=12, total=30, details="batch 3"))
-        reporter.update(ProgressEvent(source="engine", step=1, total=3, details="reacting"))
-        _require_progress(reporter).refresh()
-        assert len(_require_progress(reporter).tasks) == 1
-        line = _ANSI.sub("", [f for f in sink.getvalue().split("\r") if "\u2501" in f][-1])
-        assert "12/30" in line          # the batch owns the bar
-        assert "engine 1/3" in line     # the engine rides along
-    finally:
-        reporter.finish(success=True, duration=timedelta(seconds=1))
-
-
-def test_display_reporter_renders_both_bars(monkeypatch):
-    """The headline feature: the nested layout the ANSI path had to give up."""
-    handle = _fake_display(monkeypatch)
-    reporter = RichDisplayProgressReporter()
-    reporter._console.file = io.StringIO()
-    reporter.start("Train", sources=("batch", "engine"))
-    reporter.update(ProgressEvent(source="batch", step=1, total=5, details="batch 1"))
-    reporter.update(ProgressEvent(source="engine", step=2, total=5, details="step 2"))
-    reporter.finish(success=True, duration=timedelta(seconds=1))
+        reporter.update(ProgressEvent(source=source, step=1, total=4, details="x"))
+    reporter.finish(success=True, duration=timedelta(seconds=9))
     rows = _rows(handle.frames[-1])
-    assert len(rows) == 3               # two bars plus the completion line
-    assert "Train" in rows[0]
-    assert "engine" in rows[1]          # the indented inner track
-    assert "engine" not in rows[0]
+    assert len(rows) == 2      # the bar, plus the folded-in completion line
 
 
 def test_display_reporter_puts_completion_line_in_the_same_block(monkeypatch):

--- a/howso/utilities/tests/test_progress.py
+++ b/howso/utilities/tests/test_progress.py
@@ -38,6 +38,7 @@ from howso.utilities import (
 from howso.utilities.monitors import ProgressTimer
 from howso.utilities.progress import (
     _auto_progress_enabled,  # pyright: ignore[reportPrivateUsage]
+    _config_auto_progress,  # pyright: ignore[reportPrivateUsage]
     _display_handle_available,  # pyright: ignore[reportPrivateUsage]
     _experimental_notebook_reporter,  # pyright: ignore[reportPrivateUsage]
     _format_duration,  # pyright: ignore[reportPrivateUsage]
@@ -48,6 +49,7 @@ from howso.utilities.progress import (
     _one_line,  # pyright: ignore[reportPrivateUsage]
     _OverwriteSafeWriter,  # pyright: ignore[reportPrivateUsage]
     _parse_tristate,  # pyright: ignore[reportPrivateUsage]
+    _resolve_owner,  # pyright: ignore[reportPrivateUsage]
     _SolidBar,  # pyright: ignore[reportPrivateUsage]
     BAR_WIDTH,
     ETA_LABEL_MIN_WIDTH,
@@ -815,9 +817,9 @@ def test_display_reporter_matches_the_stdout_reporter(monkeypatch):
     inline.finish(success=True, duration=timedelta(seconds=9))
 
     # ``_repr_mimebundle_`` renders through rich's *global* console, which this
-    # process leaves colourless and 80 wide. A kernel's is a Jupyter console, so
+    # process leaves colorless and 80 wide. A kernel's is a Jupyter console, so
     # pin an equivalent or the comparison measures the test rig, not the code.
-    import rich
+    import rich  # noqa: PLC0415
 
     monkeypatch.setattr(
         rich, "_console",
@@ -1391,7 +1393,7 @@ def test_nothing_looks_finished_while_the_session_runs():
     """
     Verify no column treats the engine's last step as the session ending.
 
-    rich keys three separate behaviours off ``completed >= total``: it freezes
+    rich keys three separate behaviors off ``completed >= total``: it freezes
     the elapsed clock, switches the bar to its finished style, and blanks the
     spinner. All three are wrong here — the engine reporting its final step
     says nothing about when the call returns. Each was found and fixed
@@ -2238,24 +2240,83 @@ def test_decorator_nested_calls_do_not_stack(capsys, monkeypatch):  # noqa: ARG0
     ("react", "React"),
     ("react_series", "React Series"),
     ("react_series_stationary", "React Series (stationary)"),
-    ("react_aggregate", "React aggregate"),
     ("react_group", "React group"),
     ("react_into_features", "React into features"),
     ("impute", "Impute"),
+    ("reduce_data", "Reduce data"),
 ])
-def test_trainee_methods_decorated_with_expected_labels(name, label):
-    from howso.engine import Trainee  # noqa: PLC0415
-    method = getattr(Trainee, name)
+def test_client_methods_decorated_with_expected_labels(name, label):
+    """
+    Verify the decorators sit on the client, which is where the work happens.
+
+    ``Trainee`` methods delegate straight through, so wrapping them as well
+    would only add a layer the re-entrancy guard has to suppress.
+    """
+    from howso.client.base import AbstractHowsoClient  # noqa: PLC0415
+    method = getattr(AbstractHowsoClient, name)
     assert getattr(method, "_auto_progress_label", None) == label
     # functools.wraps preserves original signature for with_progress's
     # signature introspection to still work.
     assert "self" in inspect.signature(method).parameters
 
 
-def test_predict_is_not_decorated():
-    """Verify ``predict`` is not wrapped — it has no progress hooks."""
+def test_trainee_methods_are_not_decorated():
+    """The Trainee facade must not double-wrap what the client already reports."""
     from howso.engine import Trainee  # noqa: PLC0415
-    assert not hasattr(Trainee.predict, "_auto_progress_label")
+    for name in ("train", "analyze", "react", "predict"):
+        method = getattr(Trainee, name)
+        assert not hasattr(method, "_auto_progress_label"), name
+
+
+class _OwnerClient:
+    """A client double: owns the runtime lookup, takes trainee_id per call."""
+
+    def get_trainee_runtime(self, trainee_id):  # noqa: ARG002
+        return {"library_type": "mt"}
+
+    def analyze(self, trainee_id, **kwargs):  # noqa: ANN003, ARG002
+        return "done"
+
+
+def test_resolve_owner_from_a_client_bound_method():
+    """
+    Verify the client and Trainee id are found when the owner is a client.
+
+    The decorators sit on client methods, where ``.client`` and ``.id`` do not
+    exist -- the client is itself the client, and the id arrives as a call
+    argument. Reading only the Trainee shape left both None, which silently
+    disabled engine polling for every session.
+    """
+    client = _OwnerClient()
+    for args, kwargs in (((("t-42"),), {}), ((), {"trainee_id": "t-42"})):
+        owner, resolved, trainee_id = _resolve_owner(client.analyze, args, kwargs)
+        assert owner is client
+        assert resolved is client
+        assert trainee_id == "t-42"
+
+
+def test_resolve_owner_from_a_trainee_bound_method():
+    """A facade that delegates still resolves through ``.client`` and ``.id``."""
+    client = _OwnerClient()
+    trainee = _FakeTrainee(client=client)
+    owner, resolved, trainee_id = _resolve_owner(trainee.cb_only, (), {})
+    assert owner is trainee
+    assert resolved is client
+    assert trainee_id == "fake-trainee"
+
+
+def test_config_reaches_a_client_bound_method():
+    """
+    Verify the ``auto_progress`` config is read when the owner is a client.
+
+    A ``Trainee`` reaches its configuration through ``.client``; a client holds
+    it directly. Reading only through ``.client`` made the config layer silently
+    inert once the decorators moved onto the client methods.
+    """
+    client = SimpleNamespace(configuration=SimpleNamespace(auto_progress="off"))
+    assert _config_auto_progress(client) is False
+    trainee = SimpleNamespace(client=client)
+    assert _config_auto_progress(trainee) is False
 
 
 def test_client_options_auto_progress_default():

--- a/howso/utilities/tests/test_progress.py
+++ b/howso/utilities/tests/test_progress.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from datetime import timedelta
 import inspect
+import sys
 import time
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -205,6 +207,70 @@ def test_simple_reporter_unknown_total_renders_question_mark(capsys):
     reporter.update(ProgressEvent(source="engine", step=0, total=0, details=""))
     out = capsys.readouterr().out
     assert "[0/?]" in out
+
+
+class _RecordingStream:
+    """Minimal file-like double that counts ``flush`` calls."""
+
+    def __init__(self, *, raises: bool = False) -> None:  # pyright: ignore[reportMissingSuperCall]
+        self.flushes = 0
+        self._raises = raises
+
+    def write(self, text: str) -> int:
+        return len(text)
+
+    def flush(self) -> None:
+        self.flushes += 1
+        if self._raises:
+            raise ValueError("underlying buffer has been detached")
+
+
+def _reporter_writing_to(monkeypatch, console_file) -> SimpleProgressReporter:
+    """Build a reporter whose console renders into ``console_file``."""
+    reporter = SimpleProgressReporter()
+    monkeypatch.setattr(reporter, "_console", SimpleNamespace(file=console_file))
+    return reporter
+
+
+def test_flush_all_drains_console_stdout_and_stderr(monkeypatch):
+    console_file, out, err = _RecordingStream(), _RecordingStream(), _RecordingStream()
+    reporter = _reporter_writing_to(monkeypatch, console_file)
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", err)
+    reporter._flush_all()  # pyright: ignore[reportPrivateUsage]
+    assert (console_file.flushes, out.flushes, err.flushes) == (1, 1, 1)
+
+
+def test_flush_all_flushes_a_shared_stream_only_once(monkeypatch):
+    """The console's file is normally ``sys.stdout`` itself — flush it once, not thrice."""
+    shared = _RecordingStream()
+    reporter = _reporter_writing_to(monkeypatch, shared)
+    monkeypatch.setattr(sys, "stdout", shared)
+    monkeypatch.setattr(sys, "stderr", shared)
+    reporter._flush_all()  # pyright: ignore[reportPrivateUsage]
+    assert shared.flushes == 1
+
+
+def test_flush_all_survives_a_detached_stream(monkeypatch):
+    """A stream that raises on flush must not abort the session, nor the remaining flushes."""
+    broken, out, err = _RecordingStream(raises=True), _RecordingStream(), _RecordingStream()
+    reporter = _reporter_writing_to(monkeypatch, broken)
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", err)
+    reporter._flush_all()  # pyright: ignore[reportPrivateUsage]
+    assert broken.flushes == 1
+    assert (out.flushes, err.flushes) == (1, 1)
+
+
+@pytest.mark.parametrize("reporter_cls", [SimpleProgressReporter, RichProgressReporter])
+def test_reporter_flushes_at_both_session_boundaries(reporter_cls, monkeypatch, capsys):  # noqa: ARG001
+    """Pending output is drained before the first render and again after the last."""
+    reporter = reporter_cls()
+    flushes: list[str] = []
+    monkeypatch.setattr(reporter, "_flush_all", lambda: flushes.append("flush"))
+    reporter.start("Train", sources=("batch",))
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert len(flushes) == 2
 
 
 def test_auto_reporter_databricks_prefers_simple(monkeypatch):

--- a/howso/utilities/tests/test_progress.py
+++ b/howso/utilities/tests/test_progress.py
@@ -1380,6 +1380,36 @@ def test_stepped_bar_stays_red_until_the_session_ends(success, final_color):
     assert _bar_color(final) == [final_color]
 
 
+def test_nothing_looks_finished_while_the_session_runs():
+    """
+    Verify no column treats the engine's last step as the session ending.
+
+    rich keys three separate behaviours off ``completed >= total``: it freezes
+    the elapsed clock, switches the bar to its finished style, and blanks the
+    spinner. All three are wrong here — the engine reporting its final step
+    says nothing about when the call returns. Each was found and fixed
+    separately; this covers the property they share.
+    """
+    reporter = RichNotebookProgressReporter()
+    sink = io.StringIO()
+    reporter._console.file = sink
+    reporter.start("Analyze", sources=("engine",))
+    reporter.update(ProgressEvent(source="engine", step=1, total=1, details=""))
+    progress = _require_progress(reporter)
+    task = progress.tasks[0]
+    assert task.finished, "rich should consider the task done — that is the trap"
+    assert task.start_time is not None
+    task.start_time -= 20
+    progress.refresh()
+    row = _ANSI.sub("", [f for f in sink.getvalue().split("\r")
+                         if "\u2501" in f][-1]).split("\n")[0]
+    raw = [f for f in sink.getvalue().split("\r") if "\u2501" in f][-1]
+    assert row.strip()[:1] != "A", "spinner must still be turning"   # not the label
+    assert _bar_color(raw) == ["31"], "bar must still read as running"
+    assert "0:00:20" in row, "clock must still be counting"
+    reporter.finish(success=True, duration=timedelta(seconds=20))
+
+
 def test_elapsed_keeps_running_after_the_engine_reports_its_last_step():
     """
     Verify the clock tracks the session, not the engine's last step.

--- a/howso/utilities/tests/test_progress.py
+++ b/howso/utilities/tests/test_progress.py
@@ -15,7 +15,7 @@ import warnings
 
 import pytest
 from rich.console import Console
-from rich.progress import BarColumn, Progress
+from rich.progress import Progress
 
 from howso.client.configuration import ClientOptions, HowsoConfiguration
 from howso.utilities import (
@@ -40,7 +40,6 @@ from howso.utilities.progress import (
     _auto_progress_enabled,  # pyright: ignore[reportPrivateUsage]
     _config_auto_progress,  # pyright: ignore[reportPrivateUsage]
     _display_handle_available,  # pyright: ignore[reportPrivateUsage]
-    _experimental_notebook_reporter,  # pyright: ignore[reportPrivateUsage]
     _format_duration,  # pyright: ignore[reportPrivateUsage]
     _format_eta,  # pyright: ignore[reportPrivateUsage]
     _in_notebook,  # pyright: ignore[reportPrivateUsage]
@@ -471,14 +470,291 @@ def test_notebook_reporter_frames_fit_the_console():
             assert visible[NOTEBOOK_COLUMNS:].strip() == ""
 
 
-def test_terminal_reporter_still_uses_cursor_up():
-    """Characterization: the terminal reporter keeps its nested layout, cursor codes and all."""
+def _notebook_view(raw: str) -> list[str]:
+    r"""
+    Replay a notebook front-end and return the non-blank lines a reader sees.
+
+    Front-ends render SGR color codes, treat ``\r`` as a rewind, and discard
+    every other CSI sequence — cursor motion and erase-line alike. That last
+    part is why the summary has to be repainted *into* the region rather than
+    printed beneath it and the region cleared.
+
+    The rewind is applied to the **raw** text, escapes included, matching
+    :func:`_overwrite_residue` and the contract ``_OverwriteSafeWriter`` pads
+    to. Stripping escapes first would model a front-end that indexes by visible
+    column, which is the more forgiving of the two — a frame that covers its
+    predecessor by raw length covers it either way, so asserting against raw is
+    what keeps this honest.
+    """
+    seen = []
+    for physical in raw.split("\n"):
+        line = ""
+        for chunk in physical.split("\r"):
+            line = chunk + line[len(chunk):]
+        visible = _ANSI.sub("", line).rstrip()
+        if visible:
+            seen.append(visible)
+    return seen
+
+
+def test_a_session_too_fast_to_repaint_still_covers_its_bar():
+    """
+    Verify a call that finishes inside one refresh interval leaves no bar behind.
+
+    rich emits its *first* frame with no cursor positioning — there is no
+    previous frame to rewind over — so that write carries neither a carriage
+    return nor a newline. The writer used to track a line's length only when it
+    saw a carriage return, so this first frame went uncounted, and a session
+    ending before the refresh thread painted a second one had nothing to pad
+    against: the summary rewound, overwrote the first 58 of 93 characters, and
+    left the rest of the bar sitting behind it.
+
+    Deliberately no ``refresh()`` here. Every other test in this file has one,
+    which is exactly why they all missed it.
+    """
+    reporter = RichNotebookProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=("batch", "engine"))
+    reporter.finish(success=True, duration=timedelta(seconds=0))
+    assert _notebook_view(buf.getvalue()) == ["✓ Train complete in 0:00:00"]
+    residue = _overwrite_residue(buf.getvalue())
+    assert set(residue) <= {" "}, f"visible residue: {residue!r}"
+
+
+def test_notebook_summary_replaces_the_bar():
+    """
+    Verify a finished session leaves one line, and it is the summary.
+
+    The bar and the summary share a line: the bar owns it while the call runs,
+    and the summary takes it over at the end. Printing the summary instead
+    would leave two lines — and reclaiming the bar's line afterwards needs a
+    cursor-up this front-end discards, which is the trap this avoids.
+    """
+    reporter = RichNotebookProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=("batch",))
+    _require_progress(reporter).refresh()
+    reporter.update(ProgressEvent(source="batch", step=120, total=120, details="batch 7"))
+    _require_progress(reporter).refresh()
+    reporter.finish(success=True, duration=timedelta(seconds=4))
+    seen = _notebook_view(buf.getvalue())
+    assert seen == ["✓ Train complete in 0:00:04"], f"reader sees {seen}"
+
+
+def test_terminal_summary_reuses_the_bar_line():
+    """
+    Verify the terminal reaches the same one line by clearing the region.
+
+    A terminal honors the codes a notebook drops, so it can take the bar's line
+    back the direct way — walk up into the region and erase it — and print the
+    summary there. Same single line, different mechanism, which is why
+    ``_transient`` is a class member rather than a constant.
+    """
     reporter = RichProgressReporter(console=_notebook_console())
-    out = _render(reporter, ("batch", "engine"), [
-        ProgressEvent(source="batch", step=1, total=10, details="b"),
-        ProgressEvent(source="engine", step=1, total=3, details="e"),
+    out = _render(reporter, ("batch",), [
+        ProgressEvent(source="batch", step=120, total=120, details="batch 7"),
     ])
-    assert "\x1b[1A" in out
+    assert reporter._transient is True
+    summary = out.index("complete in")
+    assert "\x1b[1A" in out[:summary]     # it reclaimed the bar's line
+    assert "\x1b[2K" in out[:summary]     # and blanked it before writing
+
+
+def _terminal_view(raw: str) -> list[str]:
+    r"""
+    Replay a real terminal and return the non-blank lines a reader sees.
+
+    Unlike :func:`_notebook_view`, this honors what a terminal honors: ``\r``
+    rewinds, ``ESC[2K`` blanks the line, ``ESC[<n>A`` moves up into the region.
+    Two different replays because the two front-ends genuinely differ — the
+    point of the tests below is that the *result* does not.
+    """
+    screen, row, col, i = [""], 0, 0, 0
+    while i < len(raw):
+        match = re.match(r"\x1b\[([0-9;?]*)([A-Za-z])", raw[i:])
+        if match:
+            params, code = match.group(1), match.group(2)
+            if code == "K" and params == "2":
+                screen[row] = ""
+            elif code == "A":
+                row = max(0, row - int(params or 1))
+            i += match.end()
+            continue
+        char = raw[i]
+        i += 1
+        if char == "\n":
+            row += 1
+            col = 0
+            while len(screen) <= row:
+                screen.append("")
+        elif char == "\r":
+            col = 0
+        else:
+            line = screen[row].ljust(col)
+            screen[row] = line[:col] + char + line[col + 1:]
+            col += 1
+    return [line.rstrip() for line in screen if line.strip()]
+
+
+def _closing_view(reporter, view, *, success: bool) -> list[str]:
+    """Run one labeled session to completion and return what the reader is left with."""
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=("batch",))
+    _require_progress(reporter).refresh()
+    reporter.update(ProgressEvent(source="batch", step=70, total=120, details="batch 7"))
+    _require_progress(reporter).refresh()
+    reporter.finish(success=success, duration=timedelta(seconds=4))
+    return view(buf.getvalue())
+
+
+@pytest.mark.parametrize(("reporter_cls", "view"), [
+    (lambda: RichProgressReporter(console=_notebook_console()), _terminal_view),
+    (RichNotebookProgressReporter, _notebook_view),
+])
+def test_a_failed_session_keeps_its_bar(reporter_cls, view):
+    """
+    Verify a failure leaves the bar standing, with the summary beneath it.
+
+    The settled bar is the only record of how far the call got — ``batch 7``,
+    ``70/120`` — and the summary line has room for none of it. Handing the line
+    over on the one run where that matters most would be a poor trade for a
+    saved line. Both front-ends have to agree on this, or a failure would read
+    differently depending on where it happened.
+    """
+    seen = _closing_view(reporter_cls(), view, success=False)
+    assert len(seen) == 2, f"expected the bar and the summary, got {seen}"
+    assert "\u2501" in seen[0]          # the bar, still there
+    assert "batch 7" in seen[0]         # and still saying where it stopped
+    assert seen[1].startswith("✗ Train failed in")
+
+
+@pytest.mark.parametrize(("reporter_cls", "view"), [
+    (lambda: RichProgressReporter(console=_notebook_console()), _terminal_view),
+    (RichNotebookProgressReporter, _notebook_view),
+])
+def test_a_successful_session_hands_its_line_to_the_summary(reporter_cls, view):
+    """The success case: one line, and the bar is gone from it."""
+    seen = _closing_view(reporter_cls(), view, success=True)
+    assert seen == ["✓ Train complete in 0:00:04"], f"reader sees {seen}"
+
+
+@pytest.mark.parametrize("success", [True, False])
+def test_both_closing_routes_leave_the_same_thing(success):
+    """
+    Verify clearing and repainting are interchangeable, which is the whole point.
+
+    ``_transient`` picks between taking the bar's line back by clearing the
+    region (a terminal) and repainting the summary into it (a notebook). Those
+    are different code paths through rich, and they are only worth having as a
+    choice for as long as a reader cannot tell which one ran.
+    """
+    cleared = _closing_view(
+        RichProgressReporter(console=_notebook_console(), transient=True),
+        _terminal_view, success=success)
+    repainted = _closing_view(
+        RichProgressReporter(console=_notebook_console(), transient=False),
+        _terminal_view, success=success)
+    assert cleared == repainted, f"cleared {cleared} != repainted {repainted}"
+    assert cleared, "guard: neither route rendered anything"
+
+
+def test_the_label_column_hugs_its_label():
+    """
+    Verify the label column takes the width of the label it holds, and no more.
+
+    It used to be pinned to the widest label the decorator had ever registered,
+    so that stacked bars would line up. Nothing stacks any more — a successful
+    session hands its line to the summary — so a short label paid for a long
+    one's width with a run of blanks before its bar.
+    """
+    starts = {}
+    for label in ("Go", "Train", "React series stationary"):
+        reporter = RichNotebookProgressReporter()
+        buf = io.StringIO()
+        reporter._console.file = buf
+        reporter.start(label, sources=("batch",))
+        reporter.update(ProgressEvent(source="batch", step=3, total=10, details="b"))
+        _require_progress(reporter).refresh()
+        frame = _ANSI.sub("", [f for f in buf.getvalue().split("\r")
+                               if "\u2501" in f][-1]).split("\n")[0]
+        reporter.finish(success=True, duration=timedelta(seconds=1))
+        starts[label] = frame.index("\u2501")
+        # Spinner, space, label, space, bar — one column of padding, no filler.
+        assert frame[:starts[label]].endswith(f"{label} "), f"{frame[:starts[label]]!r}"
+    assert len(set(starts.values())) == 3, f"widths did not track the labels: {starts}"
+
+
+def test_the_bar_does_not_move_while_a_session_runs():
+    """
+    Verify a growing details string never shifts the bar.
+
+    This is what the pinned label column was really protecting, and it has to
+    keep holding without it. The details column sits *after* the bar and each
+    column takes only the width its own content needs, so the bar's left edge
+    is fixed by the label alone — which does not change mid-session.
+    """
+    reporter = RichNotebookProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=("batch", "engine"))
+    starts = []
+    for step, detail in ((1, "b"), (4, "batch 44"), (9, "a considerably longer detail string")):
+        reporter.update(ProgressEvent(source="batch", step=step, total=10, details=detail))
+        reporter.update(ProgressEvent(source="engine", step=step, total=12, details=detail))
+        _require_progress(reporter).refresh()
+        frame = _ANSI.sub("", [f for f in buf.getvalue().split("\r")
+                               if "\u2501" in f][-1]).split("\n")[0]
+        starts.append(frame.index("\u2501"))
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert len(set(starts)) == 1, f"the bar moved: {starts}"
+
+
+def test_terminal_reporter_hides_the_cursor():
+    """
+    Verify the terminal path still hides the cursor for the live region.
+
+    A terminal has a real cursor, and leaving it parked in the middle of a
+    repainting bar makes the bar look like it is being typed. The notebook
+    path strips these codes instead, because nbconvert renders them literally.
+    """
+    out = _render(RichProgressReporter(console=_notebook_console()), ("batch",), [
+        ProgressEvent(source="batch", step=1, total=10, details="b"),
+    ])
+    assert "\x1b[?25l" in out
+    assert "\x1b[?25h" in out
+
+
+def test_terminal_reporter_never_wraps_its_stream():
+    """
+    Verify no overwrite-safe padding in a terminal.
+
+    A terminal honors the erase-line code rich emits, so a short frame already
+    covers its predecessor. Padding every frame out to the running maximum
+    would only cost bytes, and would defeat ``transient`` by leaving blanks
+    where the bar was.
+    """
+    reporter = RichProgressReporter(console=_notebook_console())
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch",))
+    installed = type(reporter._console.file).__name__
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert installed != "_OverwriteSafeWriter"
+
+
+def test_terminal_reporter_measures_its_console():
+    """
+    Verify the terminal path detects its environment rather than pinning it.
+
+    Width and legacy-Windows support are things a terminal can be asked about
+    and a kernel cannot, so only the notebook console hard-codes them.
+    """
+    stock = Console()
+    made = RichProgressReporter()._console
+    assert (made.width, made.is_jupyter, made.legacy_windows) == (
+        stock.width, stock.is_jupyter, stock.legacy_windows)
 
 
 def test_notebook_console_flags():
@@ -598,7 +874,6 @@ def test_one_line_truncates_with_ellipsis():
 
 
 def test_auto_reporter_notebook_picks_rich_notebook(monkeypatch):
-    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
     monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
@@ -653,6 +928,19 @@ def _fake_display(monkeypatch) -> _FakeDisplayHandle:
     monkeypatch.setitem(sys.modules, "IPython", SimpleNamespace(
         display=module, get_ipython=object))
     return handle
+
+
+def _slot_reporter(**kwargs: Any) -> RichDisplayProgressReporter:
+    """
+    Build a display reporter that claims a slot when it runs headlessly.
+
+    The class default writes the final state to stdout instead — no display
+    block, so no padding around it — which means a test about slot behavior has
+    to ask for one explicitly.
+    """
+    reporter = RichDisplayProgressReporter(**kwargs)
+    reporter._slot_when_headless = True
+    return reporter
 
 
 def _rows(renderable) -> list[str]:
@@ -731,6 +1019,36 @@ def test_overwrite_writer_pads_before_an_embedded_newline():
     assert not rest.startswith(" ")                # and nothing spilled over
 
 
+def test_overwrite_writer_tracks_a_frame_written_without_a_carriage_return():
+    """
+    Verify a write with no carriage return still counts toward the line.
+
+    rich's first frame has nothing to rewind over, so it carries no carriage
+    return. Ignoring it left the next frame with nothing to pad against.
+    """
+    sink = io.StringIO()
+    writer = _OverwriteSafeWriter(sink)
+    writer.write("THIS-FIRST-FRAME-IS-LONG")   # no \r: rich's opening frame
+    writer.write("\rshort")
+    assert sink.getvalue() == "THIS-FIRST-FRAME-IS-LONG\rshort" + " " * 19
+
+
+def test_overwrite_writer_starts_a_fresh_line_after_a_newline():
+    """
+    Verify a newline resets the width, so the next line is not over-padded.
+
+    A failed session prints its summary through this writer as a plain line —
+    no carriage return, trailing newline. Carrying the old line's width past
+    that newline would pad an unrelated line out with blanks.
+    """
+    sink = io.StringIO()
+    writer = _OverwriteSafeWriter(sink)
+    writer.write("A-VERY-LONG-FIRST-LINE-INDEED\nab")   # newline, then a short tail
+    writer.write("\rc")
+    # Padding is measured against "ab", the only thing on the current line.
+    assert sink.getvalue() == "A-VERY-LONG-FIRST-LINE-INDEED\nab\rc "
+
+
 def test_overwrite_writer_pads_only_when_the_frame_shrinks():
     """A frame at least as long as its predecessor needs no padding at all."""
     sink = io.StringIO()
@@ -791,30 +1109,44 @@ def test_notebook_reporter_bar_never_pulses():
     assert len(colors) <= 6, f"gradient detected, {len(colors)} colors"
 
 
-def test_display_reporter_matches_the_stdout_reporter(monkeypatch):
-    """
-    Verify a headless render looks like the interactive one.
+# One fixed session, replayed through every reporter by the parity test below.
+_PARITY_EVENTS = (
+    ProgressEvent(source="batch", step=2, total=4, details="batch 2"),
+    ProgressEvent(source="engine", step=1, total=3, details="reacting"),
+)
 
-    This reporter exists so notebooks rendered en masse by nbconvert or
-    papermill show what a person sees in the notebook. It therefore builds the
-    same single-bar model as the stdout reporter and differs only in delivery —
-    a display slot instead of a carriage-return repaint.
-    """
-    events = [
-        ProgressEvent(source="batch", step=2, total=4, details="batch 2"),
-        ProgressEvent(source="engine", step=1, total=3, details="reacting"),
-    ]
 
-    inline = RichNotebookProgressReporter()
+def _stdout_bar_row(reporter) -> str:
+    """Replay the parity session on a stdout-delivering reporter, returning its last bar row."""
     sink = io.StringIO()
-    inline._console.file = sink
-    inline.start("React", sources=("batch", "engine"))
-    for event in events:
-        inline.update(event)
-    _require_progress(inline).refresh()
-    expected = _ANSI.sub("", [f for f in sink.getvalue().split("\r")
-                              if "\u2501" in f][-1]).split("\n")[0].rstrip()
-    inline.finish(success=True, duration=timedelta(seconds=9))
+    reporter._console.file = sink
+    reporter.start("React", sources=("batch", "engine"))
+    for event in _PARITY_EVENTS:
+        reporter.update(event)
+    _require_progress(reporter).refresh()
+    frames = [f for f in sink.getvalue().split("\r") if "\u2501" in f]
+    reporter.finish(success=True, duration=timedelta(seconds=9))
+    assert frames, "no bar was ever painted"
+    return _ANSI.sub("", frames[-1]).split("\n")[0].rstrip()
+
+
+def test_every_reporter_renders_the_same_bar(monkeypatch):
+    """
+    Verify one session looks identical however it is delivered.
+
+    This is the guard that keeps the three reporters honest. They share a
+    lifecycle and a merged-bar model and differ only in delivery — a live
+    region over a terminal, the same over a notebook's stdout, or a display
+    slot for a headless render — so any divergence in what a reader actually
+    sees is a bug in one of them. The display reporter had already drifted to
+    a two-bar layout once, silently, for want of this.
+
+    The terminal reporter is given the notebook console so all three are
+    measuring the same width; that is the one thing they are *meant* to
+    disagree about.
+    """
+    terminal = _stdout_bar_row(RichProgressReporter(console=_notebook_console()))
+    notebook = _stdout_bar_row(RichNotebookProgressReporter())
 
     # ``_repr_mimebundle_`` renders through rich's *global* console, which this
     # process leaves colorless and 80 wide. A kernel's is a Jupyter console, so
@@ -828,17 +1160,81 @@ def test_display_reporter_matches_the_stdout_reporter(monkeypatch):
     )
     monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
     handle = _fake_display(monkeypatch)
-    display = RichDisplayProgressReporter()
+    display = _slot_reporter()
     display._console.file = io.StringIO()
     display.start("React", sources=("batch", "engine"))
-    for event in events:
+    for event in _PARITY_EVENTS:
         display.update(event)
     display._push(force=True)
-    rows = [_ANSI.sub("", row) for row in _rows(handle.frames[-1])]
+    rows = [_ANSI.sub("", row).rstrip() for row in _rows(handle.frames[-1])]
     display.finish(success=True, duration=timedelta(seconds=9))
 
-    assert len(rows) == 1, f"expected one merged bar, got {rows}"
-    assert rows[0].rstrip() == expected
+    assert notebook == terminal
+    assert rows == [terminal], f"expected one merged bar matching {terminal!r}, got {rows}"
+    # Guard against the whole comparison passing on three empty strings.
+    assert "2/4" in terminal            # the batch source drives the bar
+    assert "engine 1/3" in terminal     # and the engine is folded in beside it
+
+
+def _slot_closing_rows(monkeypatch, *, success: bool) -> list[str]:
+    """Run the parity session on the display slot and return the rows it is left holding."""
+    import rich  # noqa: PLC0415
+
+    # JupyterMixin renders through the *global* console; a kernel's is a Jupyter
+    # console, so pin an equivalent or this measures the test rig.
+    monkeypatch.setattr(
+        rich, "_console",
+        Console(force_terminal=True, color_system="truecolor", width=NOTEBOOK_COLUMNS),
+        raising=False,
+    )
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
+    handle = _fake_display(monkeypatch)
+    reporter = _slot_reporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("React", sources=("batch", "engine"))
+    for event in _PARITY_EVENTS:
+        reporter.update(event)
+    reporter.finish(success=success, duration=timedelta(seconds=9))
+    return [_ANSI.sub("", row).rstrip() for row in _rows(handle.frames[-1])]
+
+
+@pytest.mark.parametrize("success", [True, False])
+def test_every_reporter_closes_the_same_way(monkeypatch, success):
+    """
+    Verify all three routes leave the reader with the same thing.
+
+    The sibling test above compares a frame mid-session; this one compares what
+    survives the close, which is a separate code path per route — clearing the
+    region, repainting it, printing the final state once, or replacing a
+    display slot's contents.
+
+    That gap was not theoretical. The slot stacks a failed bar above its summary
+    in a ``Table.grid``, and a grid sizes its column to the child's *maximum*
+    measurement — narrower than a bar actually lays out — so the details wrapped
+    onto a third row that neither other route produced.
+    """
+    def close(reporter, view):
+        buf = io.StringIO()
+        reporter._console.file = buf
+        reporter.start("React", sources=("batch", "engine"))
+        for event in _PARITY_EVENTS:
+            reporter.update(event)
+        _require_progress(reporter).refresh()
+        reporter.finish(success=success, duration=timedelta(seconds=9))
+        return view(buf.getvalue())
+
+    terminal = close(RichProgressReporter(console=_notebook_console()), _terminal_view)
+    notebook = close(RichNotebookProgressReporter(), _notebook_view)
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
+    headless = close(RichDisplayProgressReporter(), _notebook_view)
+    slot = _slot_closing_rows(monkeypatch, success=success)
+
+    assert notebook == terminal, f"notebook {notebook} != terminal {terminal}"
+    assert headless == terminal, f"headless stdout {headless} != terminal {terminal}"
+    assert slot == terminal, f"slot {slot} != terminal {terminal}"
+    # Guard against all three agreeing on nothing.
+    expected = 1 if success else 2
+    assert len(terminal) == expected, f"expected {expected} line(s), got {terminal}"
 
 
 @pytest.mark.parametrize("sources", [("batch",), ("batch", "engine")])
@@ -846,14 +1242,17 @@ def test_display_reporter_uses_one_bar_whatever_the_sources(monkeypatch, sources
     """One merged bar, so the layout does not change with the engine's presence."""
     monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
     handle = _fake_display(monkeypatch)
-    reporter = RichDisplayProgressReporter()
+    reporter = _slot_reporter()
     reporter._console.file = io.StringIO()
     reporter.start("React", sources=sources)
     for source in sources:
         reporter.update(ProgressEvent(source=source, step=1, total=4, details="x"))
-    reporter.finish(success=True, duration=timedelta(seconds=9))
+    reporter._push(force=True)
+    # Mid-session: the closing frame is the summary, which is one row whatever
+    # the sources, so it could not tell a merged bar from a nested pair.
     rows = _rows(handle.frames[-1])
-    assert len(rows) == 2      # the bar, plus the folded-in completion line
+    reporter.finish(success=True, duration=timedelta(seconds=9))
+    assert len(rows) == 1, f"expected one merged bar, got {rows}"
 
 
 def test_display_reporter_puts_completion_line_in_the_same_block(monkeypatch):
@@ -865,7 +1264,7 @@ def test_display_reporter_puts_completion_line_in_the_same_block(monkeypatch):
     of folding it in leaves a conspicuous gap under the bars.
     """
     handle = _fake_display(monkeypatch)
-    reporter = RichDisplayProgressReporter()
+    reporter = _slot_reporter()
     buf = io.StringIO()
     reporter._console.file = buf
     reporter.start("Train", sources=("batch", "engine"))
@@ -876,10 +1275,34 @@ def test_display_reporter_puts_completion_line_in_the_same_block(monkeypatch):
     assert "complete in" not in buf.getvalue()  # and NOT printed to stdout
 
 
+def test_display_reporter_keeps_a_failed_bar_in_the_same_block(monkeypatch):
+    """
+    Verify a failure keeps its bar in the slot, with the summary stacked under.
+
+    Same rule as the other two routes — the settled bar is the only record of
+    where the call stopped. It has to stay in the *one* renderable, though:
+    printing the summary instead would put it in a separate output block, which
+    a notebook pads away from the bar.
+    """
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
+    handle = _fake_display(monkeypatch)
+    reporter = _slot_reporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=("batch",))
+    reporter.update(ProgressEvent(source="batch", step=70, total=120, details="batch 7"))
+    reporter.finish(success=False, duration=timedelta(seconds=4))
+    rows = _rows(handle.frames[-1])
+    assert len(rows) == 2, f"expected the bar and the summary, got {rows}"
+    assert "batch 7" in rows[0]                    # still saying where it stopped
+    assert "Train failed in" in rows[1]
+    assert "failed in" not in buf.getvalue()       # and not in a second block
+
+
 def test_display_reporter_emits_no_control_codes(monkeypatch):
     """Nothing is repainted in place, so no cursor motion should appear at all."""
     handle = _fake_display(monkeypatch)
-    reporter = RichDisplayProgressReporter()
+    reporter = _slot_reporter()
     buf = io.StringIO()
     reporter._console.file = buf
     reporter.start("Train", sources=("batch", "engine"))
@@ -899,7 +1322,7 @@ def test_display_reporter_strips_the_pre_margin(monkeypatch):
     between groups and show up as a large gap.
     """
     handle = _fake_display(monkeypatch)
-    reporter = RichDisplayProgressReporter()
+    reporter = _slot_reporter()
     reporter._console.file = io.StringIO()
     reporter.start("Train", sources=("batch", "engine"))
     reporter.finish(success=True, duration=timedelta(seconds=1))
@@ -915,7 +1338,7 @@ def test_display_reporter_throttles_pushes(monkeypatch):
     handle = _fake_display(monkeypatch)
     clock = iter([0.0] + [0.01 * i for i in range(1, 60)])
     monkeypatch.setattr("howso.utilities.progress.monotonic", lambda: next(clock))
-    reporter = RichDisplayProgressReporter()
+    reporter = _slot_reporter()
     reporter._console.file = io.StringIO()
     reporter.start("Train", sources=("batch", "engine"))
     for i in range(1, 21):   # 20 events across ~0.2s, well under 1/4s apart
@@ -926,14 +1349,23 @@ def test_display_reporter_throttles_pushes(monkeypatch):
 
 
 def test_display_reporter_always_pushes_the_final_frame(monkeypatch):
-    """A last event inside the throttle window must not leave the bar short of 100%."""
+    """
+    Verify the closing frame lands even when the last event was throttled.
+
+    Updates are rate-limited because each costs an HTML payload over IOPub, so
+    a final event arriving inside that window is dropped. The close must not
+    be, or the slot would keep whatever stale bar it last showed instead of the
+    summary.
+    """
     handle = _fake_display(monkeypatch)
-    reporter = RichDisplayProgressReporter()
+    clock = iter([0.0] + [0.01 * i for i in range(1, 60)])
+    monkeypatch.setattr("howso.utilities.progress.monotonic", lambda: next(clock))
+    reporter = _slot_reporter()
     reporter._console.file = io.StringIO()
     reporter.start("Train", sources=("batch", "engine"))
     reporter.update(ProgressEvent(source="batch", step=20, total=20, details="done"))
     reporter.finish(success=True, duration=timedelta(seconds=1))
-    assert "20/20" in _rows(handle.frames[-1])[0]
+    assert "Train complete in" in _rows(handle.frames[-1])[0]
 
 
 def test_display_reporter_empty_sources_claims_no_slot(monkeypatch):
@@ -947,19 +1379,44 @@ def test_display_reporter_empty_sources_claims_no_slot(monkeypatch):
     assert "Train complete in" in _ANSI.sub("", buf.getvalue())
 
 
-def test_display_reporter_keeps_rich_stock_bar_palette():
+def test_display_reporter_bakes_the_same_palette_the_other_routes_emit(monkeypatch):
     """
-    Verify the bar keeps rich's stock styles.
+    Verify the HTML frame freezes the very colors the ANSI routes send.
 
-    The HTML path bakes literal hex, and rich's stock styles bake to exactly
-    the RGB a truecolor terminal shows. Restyling the bar would break that
-    match.
+    This route delivers HTML, so the palette cannot stay theme-mapped — rich
+    resolves every style at render time. What must hold is that it resolves to
+    the *same* palette entries the other routes emit as ANSI, so a headless
+    render and a live one differ in theming only, never in meaning: a pending
+    bar is red, a finished one green.
+
+    Asserted on the rendered HTML rather than on the column's attributes,
+    because ``_StateBarColumn`` picks its style per frame from the session's
+    state — the constructor defaults never reach the screen.
     """
-    bar = next(c for c in RichDisplayProgressReporter()._make_columns()
-               if isinstance(c, BarColumn))
-    assert (bar.style, bar.complete_style, bar.finished_style, bar.pulse_style) == (
-        "bar.back", "bar.complete", "bar.finished", "bar.pulse",
+    import rich  # noqa: PLC0415
+
+    # JupyterMixin renders through the *global* console; a kernel's is a Jupyter
+    # console, so pin an equivalent or this measures the test rig.
+    monkeypatch.setattr(
+        rich, "_console",
+        Console(force_terminal=True, color_system="truecolor", width=NOTEBOOK_COLUMNS),
+        raising=False,
     )
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
+    handle = _fake_display(monkeypatch)
+    reporter = _slot_reporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch",))
+    reporter.update(ProgressEvent(source="batch", step=5, total=10, details="b"))
+    reporter._push(force=True)
+    running = handle.frames[-1]._repr_mimebundle_([], [])["text/html"]
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+
+    baked = set(re.findall(r"color: (#[0-9a-f]{6})", running))
+    assert "#800000" in baked, f"pending bar is not ANSI red; got {sorted(baked)}"
+    assert "#808080" in baked, f"track is not ANSI gray; got {sorted(baked)}"
+    # Rich's own stock bar magenta must not be what got frozen.
+    assert "#f92672" not in baked
 
 
 def test_display_handle_available_requires_a_live_shell(monkeypatch):
@@ -971,7 +1428,6 @@ def test_display_handle_available_requires_a_live_shell(monkeypatch):
 
 def test_auto_reporter_notebook_with_display_picks_display_reporter(monkeypatch):
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
-    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: True)
     monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
@@ -981,7 +1437,6 @@ def test_auto_reporter_notebook_with_display_picks_display_reporter(monkeypatch)
 
 def test_auto_reporter_notebook_without_display_falls_back_to_ansi(monkeypatch):
     """A Databricks runtime that never imported IPython still gets a working bar."""
-    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: True)
@@ -1086,15 +1541,6 @@ def test_simple_reporter_renders_the_estimate(capsys):
     assert "batch 6\n" in out          # no stray separator when there is no estimate
 
 
-def test_experimental_notebook_reporter_is_off_by_default(monkeypatch):
-    monkeypatch.delenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", raising=False)
-    assert _experimental_notebook_reporter() is False
-    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
-    assert _experimental_notebook_reporter() is True
-    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "0")
-    assert _experimental_notebook_reporter() is False
-
-
 def test_interactive_frontend_false_without_ipython(monkeypatch):
     monkeypatch.delitem(sys.modules, "IPython", raising=False)
     assert _interactive_frontend() is False
@@ -1129,7 +1575,6 @@ def test_auto_reporter_headless_notebook_still_gets_the_display_slot(monkeypatch
     every repaint overwrites the same output and the saved notebook keeps the
     final frame as ordinary HTML — which exports faithfully.
     """
-    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
@@ -1145,63 +1590,91 @@ def test_auto_reporter_headless_without_display_uses_simple(monkeypatch):
     Nothing applies it there, so each frame is committed to the document as its
     own line.
     """
-    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
     monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: False)
     monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
     assert type(auto_reporter()) is SimpleProgressReporter
+
+
+def test_headless_render_writes_one_block_to_stdout(monkeypatch):
+    """
+    Verify a headless run claims no display slot and leaves adjacent lines.
+
+    Nobody watches a headless run and nbconvert cannot animate the frames a
+    slot would receive, so the intermediate ones buy nothing. What they cost is
+    visible: a notebook merges consecutive stdout writes into one output block
+    but gives every display block its own, with its own vertical padding, so a
+    cell of several calls rendered as a stack of padded panels.
+    """
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
+    handle = _fake_display(monkeypatch)
+    buf = io.StringIO()
+    for label, success in (("Train", True), ("React", False)):
+        reporter = RichDisplayProgressReporter()
+        reporter._console.file = buf
+        reporter.start(label, sources=("batch", "engine"))
+        reporter.update(ProgressEvent(source="batch", step=2, total=4, details="batch 2"))
+        reporter.finish(success=success, duration=timedelta(seconds=3))
+
+    assert handle.frames == [], "a slot was claimed despite the default"
+    seen = _notebook_view(buf.getvalue())
+    assert seen[0] == "✓ Train complete in 0:00:03"
+    assert "\u2501" in seen[1]                     # the failure kept its bar
+    assert seen[2] == "✗ React failed in 0:00:03"
+    assert len(seen) == 3, f"expected three lines, got {seen}"
+    # No repaint anywhere: nothing rewinds, so nothing can be left behind.
+    assert "\r" not in buf.getvalue()
+
+
+def test_headless_slot_is_available_by_class_member(monkeypatch):
+    """
+    Verify the slot is still reachable for a front-end that reads as headless.
+
+    The verdict rests on the execute request's ``allow_stdin`` flag, and a
+    front-end that omits the field reads as headless while someone watches it.
+    Turning the member on gets live repaints back.
+    """
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
+    handle = _fake_display(monkeypatch)
+    reporter = _slot_reporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch",))
+    reporter.update(ProgressEvent(source="batch", step=1, total=4, details="b"))
+    reporter._push(force=True)
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert handle.frames, "the class member did not re-enable the slot"
 
 
 def test_display_reporter_uses_a_slot_headlessly_even_for_one_bar(monkeypatch):
     """A lone bar must not take the repaint path when nothing will apply it."""
     monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
     handle = _fake_display(monkeypatch)
-    reporter = RichDisplayProgressReporter()
+    reporter = _slot_reporter()
     reporter._console.file = io.StringIO()
     reporter.start("Train", sources=("batch",))
     reporter.update(ProgressEvent(source="batch", step=5, total=5, details="b"))
     reporter.finish(success=True, duration=timedelta(seconds=1))
-    assert reporter._inline is None
+    assert reporter._inline is False
     assert handle.frames
+    assert "\r" not in reporter._console.file.getvalue()   # nothing was repainted
 
 
-def test_auto_reporter_notebook_with_display_but_flag_off_uses_simple(monkeypatch):
+def test_auto_reporter_notebook_failing_every_check_uses_simple(monkeypatch):
     """
-    Verify the whole rich notebook branch is opt-in, not just the ANSI half.
+    Verify a notebook that passes neither check still gets plain lines.
 
-    Rich progress in a notebook rests on undocumented front-end behavior either
-    way — an in-place repaint, or the display-update protocol — so with the flag
-    unset a notebook takes the path it always did.
+    Rich progress in a kernel rests on front-end behavior nothing documents —
+    an in-place repaint, or the display-update protocol. Both are probed for
+    rather than assumed, and a kernel offering neither must degrade to output
+    that cannot be corrupted rather than to output that might be.
     """
-    monkeypatch.delenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", raising=False)
-    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
-    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
-    monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
-    monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: True)
-    assert type(auto_reporter()) is SimpleProgressReporter
-
-
-def test_auto_reporter_tty_is_unaffected_by_the_flag(monkeypatch):
-    """A real terminal keeps the full reporter whether or not the flag is set."""
-    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
-    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    for value in ("1", None):
-        if value is None:
-            monkeypatch.delenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", raising=False)
-        else:
-            monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", value)
-        assert type(auto_reporter()) is RichProgressReporter
-
-
-def test_auto_reporter_notebook_without_display_and_flag_off_uses_simple(monkeypatch):
-    """With no display slot and no opt-in, fall back to plain lines."""
-    monkeypatch.delenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", raising=False)
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
     monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
     monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
     assert type(auto_reporter()) is SimpleProgressReporter
 
 
@@ -1281,10 +1754,17 @@ def test_activity_ticker_does_not_outlive_the_call():
 
 
 def _indeterminate_frames(reporter, *, success: bool = True) -> list[str]:
-    """Render a source-less session and return its bar frames."""
+    """
+    Render a source-less session and return its bar frames.
+
+    Unlabeled, so the settled bar is the last frame. A labeled session ends by
+    taking the bar's line back for the summary — cleared and reprinted in a
+    terminal, repainted over in a notebook — so what the bar looks like once
+    the session ends is only observable when there is no summary to cover it.
+    """
     buf = io.StringIO()
     reporter._console.file = buf
-    reporter.start("Analyze", sources=("activity",))
+    reporter.start("", sources=("activity",))
     for _ in range(3):
         time.sleep(0.11)
         _require_progress(reporter).refresh()
@@ -1330,7 +1810,7 @@ def test_completed_indeterminate_session_stops_spinning():
     """
     frames = _indeterminate_frames(RichProgressReporter(console=_notebook_console()))
     assert _ANSI.sub("", frames[0]).strip()[:1] not in {"", "A"}   # spinning during
-    assert _ANSI.sub("", frames[-1]).lstrip().startswith("Analyze")  # blank after
+    assert _ANSI.sub("", frames[-1]).lstrip().startswith("Working")  # blank after
 
 
 @pytest.mark.parametrize("eta", [
@@ -1345,7 +1825,7 @@ def test_spent_estimate_renders_as_nothing(eta):
 
 def test_every_color_is_theme_mappable():
     """
-    Verify nothing is painted in a colour the notebook theme cannot remap.
+    Verify nothing is painted in a color the notebook theme cannot remap.
 
     Only ANSI palette indices 0-15 are themed. rich's stock track is
     ``grey23`` — a 256-cube index around #3a3a3a, which no theme touches and
@@ -1379,7 +1859,10 @@ def test_stepped_bar_stays_red_until_the_session_ends(success, final_color):
     reporter = RichNotebookProgressReporter()
     sink = io.StringIO()
     reporter._console.file = sink
-    reporter.start("Analyze", sources=("engine",))
+    # Unlabeled on purpose: that is the only session whose settled bar a reader
+    # ever sees, since a labeled one closes by repainting its summary over the
+    # bar's line — covering whatever _mark_done left there.
+    reporter.start("", sources=("engine",))
     reporter.update(ProgressEvent(source="engine", step=1, total=1, details=""))
     _require_progress(reporter).refresh()
     during = [f for f in sink.getvalue().split("\r") if "\u2501" in f][-1]
@@ -1459,7 +1942,10 @@ def test_engine_bar_completes_when_the_call_succeeds():
     """
     reporter = RichNotebookProgressReporter()
     reporter._console.file = io.StringIO()
-    reporter.start("Analyze", sources=("engine",))
+    # Unlabeled on purpose: that is the only session whose settled bar a reader
+    # ever sees, since a labeled one closes by repainting its summary over the
+    # bar's line — covering whatever _mark_done left there.
+    reporter.start("", sources=("engine",))
     reporter.update(ProgressEvent(source="engine", step=2, total=3, details=""))
     _require_progress(reporter).refresh()
     reporter.finish(success=True, duration=timedelta(seconds=1))
@@ -1511,7 +1997,10 @@ def test_completed_batch_drops_its_details_with_no_gap():
     """
     reporter = RichNotebookProgressReporter()
     reporter._console.file = io.StringIO()
-    reporter.start("Train", sources=("batch",))
+    # Unlabeled on purpose: that is the only session whose settled bar a reader
+    # ever sees, since a labeled one closes by repainting its summary over the
+    # bar's line — covering whatever _mark_done left there.
+    reporter.start("", sources=("batch",))
     reporter.update(ProgressEvent(source="batch", step=120, total=120, details="batch 7"))
     _require_progress(reporter).refresh()
     reporter.finish(success=True, duration=timedelta(seconds=8))
@@ -1686,7 +2175,6 @@ def test_simple_reporter_activity_line(capsys, monkeypatch):
 
 def test_auto_reporter_databricks_picks_rich_notebook(monkeypatch):
     """Databricks lost its carve-out and is now treated as an ordinary notebook."""
-    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
     monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "13.3.x-scala2.12")
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)

--- a/howso/utilities/tests/test_progress.py
+++ b/howso/utilities/tests/test_progress.py
@@ -1,14 +1,19 @@
 """Tests for ``howso.utilities.progress``."""
 from __future__ import annotations
 
+import builtins
 from datetime import timedelta
 import inspect
+import io
+import re
 import sys
 import time
 from types import SimpleNamespace
 from typing import Any
+import warnings
 
 import pytest
+from rich.progress import BarColumn
 
 from howso.client.configuration import ClientOptions, HowsoConfiguration
 from howso.utilities import (
@@ -22,6 +27,8 @@ from howso.utilities import (
     engine_polling_supported,
     ProgressEvent,
     reset_auto_progress,
+    RichDisplayProgressReporter,
+    RichNotebookProgressReporter,
     RichProgressReporter,
     SimpleProgressReporter,
     with_progress,
@@ -29,8 +36,13 @@ from howso.utilities import (
 from howso.utilities.monitors import ProgressTimer
 from howso.utilities.progress import (
     _auto_progress_enabled,  # pyright: ignore[reportPrivateUsage]
+    _display_handle_available,  # pyright: ignore[reportPrivateUsage]
     _in_notebook,  # pyright: ignore[reportPrivateUsage]
+    _notebook_console,  # pyright: ignore[reportPrivateUsage]
+    _one_line,  # pyright: ignore[reportPrivateUsage]
+    _OverwriteSafeWriter,  # pyright: ignore[reportPrivateUsage]
     _parse_tristate,  # pyright: ignore[reportPrivateUsage]
+    NOTEBOOK_COLUMNS,
 )
 
 
@@ -262,7 +274,10 @@ def test_flush_all_survives_a_detached_stream(monkeypatch):
     assert (out.flushes, err.flushes) == (1, 1)
 
 
-@pytest.mark.parametrize("reporter_cls", [SimpleProgressReporter, RichProgressReporter])
+@pytest.mark.parametrize(
+    "reporter_cls",
+    [SimpleProgressReporter, RichProgressReporter, RichNotebookProgressReporter],
+)
 def test_reporter_flushes_at_both_session_boundaries(reporter_cls, monkeypatch, capsys):  # noqa: ARG001
     """Pending output is drained before the first render and again after the last."""
     reporter = reporter_cls()
@@ -273,9 +288,596 @@ def test_reporter_flushes_at_both_session_boundaries(reporter_cls, monkeypatch, 
     assert len(flushes) == 2
 
 
-def test_auto_reporter_databricks_prefers_simple(monkeypatch):
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def _render(reporter, sources, events) -> str:
+    """
+    Drive a full session and return the raw bytes the console received.
+
+    Each update is followed by an explicit ``refresh()``. Rich's live display
+    is driven by a background thread at ``refresh_per_second``, so without
+    this a short session can finish before the frame under test is ever
+    painted — which would make every control-code assertion below vacuous.
+    """
+    buf = io.StringIO()
+    reporter._console.file = buf  # is_terminal is unaffected by a file swap
+    reporter.start("Train", sources=sources)
+    for event in events:
+        reporter.update(event)
+        if reporter._progress is not None:
+            reporter._progress.refresh()
+    reporter.finish(success=True, duration=timedelta(seconds=4))
+    return buf.getvalue()
+
+
+def _fake_kernel(monkeypatch):
+    """Make rich's own ``_is_jupyter()`` believe it is inside a kernel."""
+    class ZMQInteractiveShell:
+        pass
+
+    monkeypatch.setattr(builtins, "get_ipython", lambda: ZMQInteractiveShell(), raising=False)
+
+
+def _apply_carriage_returns(raw: str) -> tuple[str, str]:
+    r"""
+    Replay a repaint region the way a notebook front-end does.
+
+    Front-ends implement ``\r`` as a raw-index overwrite and strip the
+    erase-line code, so a shorter frame leaves the previous frame's tail
+    behind. Returns the rendered line and the line that was intended.
+    """
+    region = raw.split("\n")[0]
+    line = ""
+    for chunk in region.split("\r"):
+        line = chunk + line[len(chunk):]
+    intended = region.split("\r")[-1]
+    return _ANSI.sub("", line).rstrip(), _ANSI.sub("", intended).rstrip()
+
+
+def test_notebook_reporter_leaves_no_residue_when_frames_shrink():
+    """
+    Verify a short frame still covers the long one before it.
+
+    Visible width is constant, but raw length is not: rich's indeterminate
+    pulse spends ~980 characters on a colour gradient occupying the same
+    columns a determinate frame draws in ~165. Since the overwrite is by raw
+    index, the shortfall would otherwise surface as literal escape-sequence
+    fragments such as ``;112m``.
+    """
+    reporter = RichNotebookProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=("batch",))
+    reporter._progress.refresh()          # the long pulse frame
+    for step in (1, 60, 120):             # then much shorter determinate frames
+        reporter.update(ProgressEvent(source="batch", step=step, total=120, details="batch 2"))
+        reporter._progress.refresh()
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    region = buf.getvalue().split("\n")[0]
+    line = ""
+    for chunk in region.split("\r"):
+        line = chunk + line[len(chunk):]
+    residue = line[len(region.split("\r")[-1]):]
+    # Not "no residue" — residue is unavoidable when frames shrink. What
+    # matters is that it is blank. Asserting only that the ANSI-stripped text
+    # matches would pass or fail on where the byte boundary happens to land,
+    # which is exactly how this bug reached a user once already.
+    assert set(residue) <= {" "}, f"visible residue: {residue!r}"
+
+
+def test_notebook_reporter_padding_is_invisible():
+    """The padding must add raw length only — never colour, never extra columns."""
+    reporter = RichNotebookProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=("batch",))
+    reporter._progress.refresh()
+    reporter.update(ProgressEvent(source="batch", step=120, total=120, details="b"))
+    reporter._progress.refresh()
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    for line in buf.getvalue().split("\n"):
+        for chunk in line.split("\r"):
+            if "\u2501" in chunk:
+                # padding may extend the line, but only ever with blanks
+                assert _ANSI.sub("", chunk)[NOTEBOOK_COLUMNS:].strip() == ""
+
+
+@pytest.mark.parametrize("sources", [("batch",), ("engine",), ("batch", "engine")])
+def test_notebook_reporter_emits_no_cursor_up(sources):
+    """The whole point of the class: notebooks discard cursor motion, so never emit it."""
+    events = [
+        ProgressEvent(source=s, step=i, total=10, details=f"{s} {i}")
+        for i, s in enumerate(sources, 1)
+    ]
+    out = _render(RichNotebookProgressReporter(), sources, events)
+    assert "\x1b[1A" not in out
+    assert "\r" in out  # it still repaints in place
+
+
+def test_notebook_reporter_survives_multiline_engine_details():
+    """``details`` is arbitrary engine payload; one newline would make the bar 2 lines high."""
+    out = _render(RichNotebookProgressReporter(), ("batch", "engine"), [
+        ProgressEvent(source="batch", step=1, total=10, details="b"),
+        ProgressEvent(source="engine", step=1, total=3, details="line1\nline2\nline3 " * 20),
+    ])
+    assert "\x1b[1A" not in out
+
+
+def test_notebook_reporter_frames_are_constant_width():
+    """Front-ends overwrite by length and ignore erase-line, so a short frame leaves residue."""
+    out = _render(RichNotebookProgressReporter(), ("batch", "engine"), [
+        ProgressEvent(source="batch", step=1, total=10, details="b"),
+        ProgressEvent(source="engine", step=9, total=10, details="a much longer detail string"),
+        ProgressEvent(source="batch", step=9, total=10, details="b"),
+    ])
+    # A frame is a \r-delimited chunk *within* one physical line. Each is at
+    # least the console width; anything beyond that is the overwrite padding,
+    # which must be blank.
+    for line in out.split("\n"):
+        for chunk in line.split("\r"):
+            if "\u2501" not in chunk:
+                continue
+            visible = _ANSI.sub("", chunk)
+            assert len(visible) >= NOTEBOOK_COLUMNS
+            assert visible[NOTEBOOK_COLUMNS:].strip() == ""
+
+
+def test_terminal_reporter_still_uses_cursor_up():
+    """Characterization: the terminal reporter keeps its nested layout, cursor codes and all."""
+    reporter = RichProgressReporter(console=_notebook_console())
+    out = _render(reporter, ("batch", "engine"), [
+        ProgressEvent(source="batch", step=1, total=10, details="b"),
+        ProgressEvent(source="engine", step=1, total=3, details="e"),
+    ])
+    assert "\x1b[1A" in out
+
+
+def test_notebook_console_flags():
+    console = RichNotebookProgressReporter()._console
+    assert console.is_jupyter is False
+    assert console.is_terminal is True
+    assert console.legacy_windows is False
+    assert console.width == NOTEBOOK_COLUMNS
+
+
+def test_notebook_console_overrides_rich_jupyter_detection(monkeypatch):
+    """A stock Console would go Jupyter here; ours must not."""
+    _fake_kernel(monkeypatch)
+    from rich.console import Console
+
+    assert Console().is_jupyter is True  # the fake is doing its job
+    assert RichNotebookProgressReporter()._console.is_jupyter is False
+
+
+def test_notebook_reporter_emits_no_ipywidgets_warning(monkeypatch):
+    """End-to-end guard: rich's Jupyter path warns and renders nothing without ipywidgets."""
+    _fake_kernel(monkeypatch)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        out = _render(RichNotebookProgressReporter(), ("batch",), [
+            ProgressEvent(source="batch", step=1, total=2, details="b"),
+        ])
+    assert "Train" in _ANSI.sub("", out)
+
+
+def test_notebook_reporter_uses_one_task_for_both_sources():
+    reporter = RichNotebookProgressReporter()
+    reporter.start("Train", sources=("batch", "engine"))
+    try:
+        assert len(set(reporter._tasks.values())) == 1
+        assert len(reporter._progress.tasks) == 1
+    finally:
+        reporter.finish(success=True, duration=timedelta(seconds=1))
+
+
+def test_notebook_reporter_engine_does_not_move_the_bar():
+    """``batch`` owns the bar; ``engine`` may only contribute text."""
+    reporter = RichNotebookProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch", "engine"))
+    try:
+        reporter.update(ProgressEvent(source="batch", step=5, total=10, details="b"))
+        reporter.update(ProgressEvent(source="engine", step=1, total=3, details="e"))
+        task = reporter._progress.tasks[0]
+        assert (task.completed, task.total) == (5, 10)
+        assert "engine 1/3" in task.fields["details"]
+    finally:
+        reporter.finish(success=True, duration=timedelta(seconds=1))
+
+
+def test_notebook_reporter_engine_only_drives_the_bar():
+    """With no batch source, engine is promoted to owning the bar."""
+    reporter = RichNotebookProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Analyze", sources=("engine",))
+    try:
+        reporter.update(ProgressEvent(source="engine", step=3, total=6, details="computing"))
+        task = reporter._progress.tasks[0]
+        assert (task.completed, task.total) == (3, 6)
+    finally:
+        reporter.finish(success=True, duration=timedelta(seconds=1))
+
+
+def test_notebook_reporter_ignores_undeclared_source():
+    """Same Protocol contract as the other reporters."""
+    reporter = RichNotebookProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Analyze", sources=("engine",))
+    try:
+        reporter.update(ProgressEvent(source="batch", step=9, total=9, details="nope"))
+        assert reporter._progress.tasks[0].completed == 0
+    finally:
+        reporter.finish(success=True, duration=timedelta(seconds=1))
+
+
+def test_notebook_reporter_empty_sources_starts_no_live_region():
+    """No sources: no bar, no FileProxy swap — but still a completion line."""
+    reporter = RichNotebookProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=())
+    assert reporter._progress is None
+    assert not hasattr(sys.stdout, "rich_proxied_file")  # no FileProxy installed
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert "Train complete in" in _ANSI.sub("", buf.getvalue())
+
+
+def test_notebook_reporter_restores_stdio():
+    """A leaked FileProxy in a kernel is sticky, so finish() must always unwind it."""
+    original_out, original_err = sys.stdout, sys.stderr
+    reporter = RichNotebookProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch",))
+    assert hasattr(sys.stdout, "rich_proxied_file")  # rich swapped it in
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert sys.stdout is original_out
+    assert sys.stderr is original_err
+
+
+@pytest.mark.parametrize(("raw", "expected"), [
+    ("plain", "plain"),
+    ("two\nlines", "two lines"),
+    ("tabs\tand\r\nnewlines", "tabs and newlines"),
+    ("  collapses   runs  ", "collapses runs"),
+])
+def test_one_line_flattens_whitespace(raw, expected):
+    assert _one_line(raw) == expected
+
+
+def test_one_line_truncates_with_ellipsis():
+    assert _one_line("x" * 100, limit=10) == "x" * 9 + "\u2026"
+
+
+def test_auto_reporter_notebook_picks_rich_notebook(monkeypatch):
+    monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
+    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
+    assert type(auto_reporter()) is RichNotebookProgressReporter
+
+
+def test_auto_reporter_tty_wins_over_notebook(monkeypatch):
+    """Terminal IPython is a notebook by our heuristic but should keep the full layout."""
+    monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
+    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
+    assert type(auto_reporter()) is RichProgressReporter
+
+
+def test_auto_reporter_simple_env_wins_in_notebook(monkeypatch):
+    """HOWSO_SIMPLE_PROGRESS remains the escape hatch back to the old behavior."""
+    monkeypatch.setenv("HOWSO_SIMPLE_PROGRESS", "1")
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
+    assert type(auto_reporter()) is SimpleProgressReporter
+
+
+class _FakeDisplayHandle:
+    """Stands in for an IPython ``DisplayHandle``, recording every frame."""
+
+    def __init__(self) -> None:  # pyright: ignore[reportMissingSuperCall]
+        self.frames: list[Any] = []
+
+    def update(self, renderable: Any) -> None:
+        self.frames.append(renderable)
+
+
+def _fake_display(monkeypatch) -> _FakeDisplayHandle:
+    """
+    Install a stub ``IPython.display.display`` and return its handle.
+
+    A stub rather than a real kernel: IPython is not a declared dependency, so
+    CI has no ipykernel to render into. The handle records what would have been
+    pushed, which is exactly what these tests assert on.
+    """
+    handle = _FakeDisplayHandle()
+
+    def display(renderable, display_id=None):  # noqa: ARG001
+        handle.frames.append(renderable)
+        return handle
+
+    module = SimpleNamespace(display=display)
+    monkeypatch.setitem(sys.modules, "IPython.display", module)
+    monkeypatch.setitem(sys.modules, "IPython", SimpleNamespace(
+        display=module, get_ipython=lambda: object()))
+    return handle
+
+
+def _rows(renderable) -> list[str]:
+    """Return the visible lines of one pushed frame."""
+    plain = renderable._repr_mimebundle_([], [])["text/plain"]
+    return [line for line in plain.splitlines() if line.strip()]
+
+
+@pytest.mark.parametrize("sources", [(), ("batch",), ("engine",)])
+def test_display_reporter_stays_inline_for_a_single_bar(monkeypatch, sources):
+    """One bar needs no display slot, and claiming one would fragment the cell."""
+    handle = _fake_display(monkeypatch)
+    reporter = RichDisplayProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=sources)
+    for source in sources:
+        reporter.update(ProgressEvent(source=source, step=5, total=5, details="b"))
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert handle.frames == []
+    assert "Train complete in" in _ANSI.sub("", buf.getvalue())
+
+
+def test_overwrite_writer_pads_before_an_embedded_newline():
+    """
+    Verify padding lands on the line being padded, not the one after it.
+
+    A frame's trailing newline is not the last thing in its write — rich
+    appends a show-cursor code after it — so treating the write as one unit put
+    the blanks after the newline, visibly indenting whatever came next.
+    """
+    sink = io.StringIO()
+    writer = _OverwriteSafeWriter(sink)
+    writer.write("\rTHIS-FIRST-FRAME-IS-LONG")     # sets the width to cover
+    writer.write("\rshort\n\x1b[?25h")             # newline is NOT last
+    first_line, _, rest = sink.getvalue().partition("\n")
+    assert first_line.endswith(" ")                # padded, on its own line
+    assert not rest.startswith(" ")                # and nothing spilled over
+
+
+def test_overwrite_writer_pads_only_when_the_frame_shrinks():
+    """A frame at least as long as its predecessor needs no padding at all."""
+    sink = io.StringIO()
+    writer = _OverwriteSafeWriter(sink)
+    writer.write("\rshort")
+    writer.write("\rmuch-longer-frame")
+    assert sink.getvalue() == "\rshort\rmuch-longer-frame"
+
+
+def test_notebook_reporter_keeps_the_writer_through_stop(monkeypatch):
+    """
+    Verify the overwrite-safe writer is still installed when Progress stops.
+
+    ``Progress.stop()`` runs inside ``super().finish()`` and emits one last
+    frame. Restoring the plain file before that call left the final frame
+    unpadded against a much longer predecessor, which is the residue that
+    reached a user. This asserts the ordering directly: with the quiet bar the
+    last frame now happens to be the longest, so the defect no longer shows up
+    in the output it produces, and a test on residue alone would not catch a
+    regression here.
+    """
+    reporter = RichNotebookProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch",))
+    seen: dict[str, str] = {}
+    original = RichProgressReporter.finish
+
+    def spy(self, **kwargs):  # noqa: ANN003
+        seen["file"] = type(self._console.file).__name__
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(RichProgressReporter, "finish", spy)
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert seen["file"] == "_OverwriteSafeWriter"
+
+
+def test_notebook_reporter_bar_never_pulses():
+    """
+    Verify an unknown total renders a static track, not a pulse.
+
+    A pulse frame spends ~980 characters on a colour gradient where the
+    determinate frame replacing it needs ~165, and on a carriage-return
+    repaint that entire disparity has to be padded over as blanks.
+    """
+    reporter = RichNotebookProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=("batch",))
+    reporter._progress.refresh()
+    reporter.update(ProgressEvent(source="batch", step=1, total=120, details="b"))
+    reporter._progress.refresh()
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    # Measure the pulse itself, not its knock-on size: the writer pads every
+    # frame up to the running maximum, so a length comparison would be masked
+    # by the very padding the pulse makes necessary.
+    first = next(c for c in buf.getvalue().split("\r") if "\u2501" in c)
+    colours = set(re.findall(r"\x1b\[([0-9;]+)m", first))
+    assert len(colours) <= 6, f"gradient detected, {len(colours)} colours"
+
+
+@pytest.mark.parametrize("sources", [("batch", "engine")])
+def test_display_reporter_uses_a_slot_for_every_bar(monkeypatch, sources):
+    """
+    Verify even a lone bar is rendered through a display slot.
+
+    Sending a single bar to stdout instead would close the vertical gap between
+    groups, but stdout repaints in place with a carriage return, and rich's
+    frames shrink drastically — a ~980 character pulse frame is replaced by a
+    ~165 character determinate one. The survivors begin mid-escape-sequence and
+    render as literal text. A display slot replaces its content outright, so
+    that cannot happen.
+    """
+    handle = _fake_display(monkeypatch)
+    reporter = RichDisplayProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=sources)
+    for source in sources:
+        reporter.update(ProgressEvent(source=source, step=5, total=5, details="b"))
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert handle.frames                       # a slot was claimed
+    assert len(_rows(handle.frames[-1])) == len(sources) + 1   # bars + completion
+
+
+def test_display_reporter_renders_both_bars(monkeypatch):
+    """The headline feature: the nested layout the ANSI path had to give up."""
+    handle = _fake_display(monkeypatch)
+    reporter = RichDisplayProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch", "engine"))
+    reporter.update(ProgressEvent(source="batch", step=1, total=5, details="batch 1"))
+    reporter.update(ProgressEvent(source="engine", step=2, total=5, details="step 2"))
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    rows = _rows(handle.frames[-1])
+    assert len(rows) == 3               # two bars plus the completion line
+    assert "Train" in rows[0]
+    assert "engine" in rows[1]          # the indented inner track
+    assert "engine" not in rows[0]
+
+
+def test_display_reporter_puts_completion_line_in_the_same_block(monkeypatch):
+    """
+    Verify the summary shares one output block with the bars.
+
+    A notebook renders a stdout stream and an HTML display as two separate
+    outputs, each with its own vertical padding, so printing the line instead
+    of folding it in leaves a conspicuous gap under the bars.
+    """
+    handle = _fake_display(monkeypatch)
+    reporter = RichDisplayProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=("batch", "engine"))
+    reporter.update(ProgressEvent(source="batch", step=5, total=5, details="b"))
+    reporter.finish(success=True, duration=timedelta(seconds=3))
+    rows = _rows(handle.frames[-1])
+    assert "Train complete in" in rows[-1]      # folded into the display slot
+    assert "complete in" not in buf.getvalue()  # and NOT printed to stdout
+
+
+def test_display_reporter_emits_no_control_codes(monkeypatch):
+    """Nothing is repainted in place, so no cursor motion should appear at all."""
+    handle = _fake_display(monkeypatch)
+    reporter = RichDisplayProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=("batch", "engine"))
+    reporter.update(ProgressEvent(source="batch", step=1, total=5, details="b"))
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    payload = "".join(f._repr_mimebundle_([], [])["text/html"] for f in handle.frames)
+    assert "\x1b[" not in payload
+    assert "\x1b[1A" not in buf.getvalue()   # nor on the completion line
+
+
+def test_display_reporter_strips_the_pre_margin(monkeypatch):
+    """
+    Verify the notebook HTML carries no outer margin.
+
+    rich emits a bare ``<pre>``, which browsers default to ``margin: 1em 0``.
+    Each progress group is its own output block, so those margins stack
+    between groups and show up as a large gap.
+    """
+    handle = _fake_display(monkeypatch)
+    reporter = RichDisplayProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch", "engine"))
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert handle.frames                        # guard: not vacuously true
+    for frame in handle.frames:
+        bundle = frame._repr_mimebundle_([], [])
+        assert bundle["text/html"].startswith('<pre style="margin:0;')
+        assert "text/plain" in bundle      # the fallback must survive wrapping
+
+
+def test_display_reporter_throttles_pushes(monkeypatch):
+    """Events arrive far faster than a reader can follow, and each push costs HTML."""
+    handle = _fake_display(monkeypatch)
+    clock = iter([0.0] + [0.01 * i for i in range(1, 60)])
+    monkeypatch.setattr("howso.utilities.progress.monotonic", lambda: next(clock))
+    reporter = RichDisplayProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch", "engine"))
+    for i in range(1, 21):   # 20 events across ~0.2s, well under 1/4s apart
+        reporter.update(ProgressEvent(source="batch", step=i, total=20, details="b"))
+    pushed_during_updates = len(handle.frames)
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert 0 < pushed_during_updates < 20   # throttled, but not silent
+
+
+def test_display_reporter_always_pushes_the_final_frame(monkeypatch):
+    """A last event inside the throttle window must not leave the bar short of 100%."""
+    handle = _fake_display(monkeypatch)
+    reporter = RichDisplayProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch", "engine"))
+    reporter.update(ProgressEvent(source="batch", step=20, total=20, details="done"))
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert "20/20" in _rows(handle.frames[-1])[0]
+
+
+def test_display_reporter_empty_sources_claims_no_slot(monkeypatch):
+    handle = _fake_display(monkeypatch)
+    reporter = RichDisplayProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=())
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert handle.frames == []
+    assert "Train complete in" in _ANSI.sub("", buf.getvalue())
+
+
+def test_display_reporter_keeps_richs_stock_bar_palette():
+    """
+    Verify the bar keeps rich's stock styles.
+
+    The HTML path bakes literal hex, and rich's stock styles bake to exactly
+    the RGB a truecolor terminal shows. Restyling the bar would break that
+    match.
+    """
+    bar = next(c for c in RichDisplayProgressReporter()._make_columns()
+               if isinstance(c, BarColumn))
+    assert (bar.style, bar.complete_style, bar.finished_style, bar.pulse_style) == (
+        "bar.back", "bar.complete", "bar.finished", "bar.pulse",
+    )
+
+
+def test_display_handle_available_requires_a_live_shell(monkeypatch):
+    monkeypatch.setitem(sys.modules, "IPython", SimpleNamespace(get_ipython=lambda: None))
+    assert _display_handle_available() is False
+    monkeypatch.delitem(sys.modules, "IPython", raising=False)
+    assert _display_handle_available() is False
+
+
+def test_auto_reporter_notebook_with_display_picks_display_reporter(monkeypatch):
+    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
+    monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: True)
+    assert type(auto_reporter()) is RichDisplayProgressReporter
+
+
+def test_auto_reporter_notebook_without_display_falls_back_to_ansi(monkeypatch):
+    """A Databricks runtime that never imported IPython still gets a working bar."""
+    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
+    monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: False)
+    assert type(auto_reporter()) is RichNotebookProgressReporter
+
+
+def test_auto_reporter_databricks_picks_rich_notebook(monkeypatch):
+    """Databricks lost its carve-out and is now treated as an ordinary notebook."""
     monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "13.3.x-scala2.12")
-    assert isinstance(auto_reporter(), SimpleProgressReporter)
+    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    assert type(auto_reporter()) is RichNotebookProgressReporter
 
 
 def test_auto_reporter_simple_env_set(monkeypatch):
@@ -289,21 +891,23 @@ def test_auto_reporter_simple_env_zero_is_falsy(monkeypatch):
     monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
     monkeypatch.setenv("HOWSO_SIMPLE_PROGRESS", "0")
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    assert isinstance(auto_reporter(), RichProgressReporter)
+    assert type(auto_reporter()) is RichProgressReporter
 
 
 def test_auto_reporter_non_tty_falls_back_to_simple(monkeypatch):
+    """Neither a tty nor a notebook — a pipe or CI log — still gets plain lines."""
     monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
-    assert isinstance(auto_reporter(), SimpleProgressReporter)
+    monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: False)
+    assert type(auto_reporter()) is SimpleProgressReporter
 
 
 def test_auto_reporter_tty_picks_rich(monkeypatch):
     monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
-    assert isinstance(auto_reporter(), RichProgressReporter)
+    assert type(auto_reporter()) is RichProgressReporter
 
 
 @pytest.fixture(autouse=True)

--- a/howso/utilities/tests/test_progress.py
+++ b/howso/utilities/tests/test_progress.py
@@ -38,8 +38,10 @@ from howso.utilities.monitors import ProgressTimer
 from howso.utilities.progress import (
     _auto_progress_enabled,  # pyright: ignore[reportPrivateUsage]
     _display_handle_available,  # pyright: ignore[reportPrivateUsage]
+    _experimental_notebook_reporter,  # pyright: ignore[reportPrivateUsage]
     _format_eta,  # pyright: ignore[reportPrivateUsage]
     _in_notebook,  # pyright: ignore[reportPrivateUsage]
+    _interactive_frontend,  # pyright: ignore[reportPrivateUsage]
     _notebook_console,  # pyright: ignore[reportPrivateUsage]
     _one_line,  # pyright: ignore[reportPrivateUsage]
     _OverwriteSafeWriter,  # pyright: ignore[reportPrivateUsage]
@@ -556,9 +558,11 @@ def test_one_line_truncates_with_ellipsis():
 
 
 def test_auto_reporter_notebook_picks_rich_notebook(monkeypatch):
+    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
     monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: True)
     monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
     assert type(auto_reporter()) is RichNotebookProgressReporter
 
@@ -620,6 +624,7 @@ def _rows(renderable) -> list[str]:
 @pytest.mark.parametrize("sources", [(), ("batch",), ("engine",)])
 def test_display_reporter_stays_inline_for_a_single_bar(monkeypatch, sources):
     """One bar needs no display slot, and claiming one would fragment the cell."""
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: True)
     handle = _fake_display(monkeypatch)
     reporter = RichDisplayProgressReporter()
     buf = io.StringIO()
@@ -630,6 +635,36 @@ def test_display_reporter_stays_inline_for_a_single_bar(monkeypatch, sources):
     reporter.finish(success=True, duration=timedelta(seconds=1))
     assert handle.frames == []
     assert "Train complete in" in _ANSI.sub("", buf.getvalue())
+
+
+def test_overwrite_writer_drops_cursor_visibility_codes():
+    """
+    Verify the cursor show/hide codes never reach the notebook stream.
+
+    rich emits them because this console forces ``is_terminal``, but a notebook
+    has no cursor to hide. Most front-ends drop them silently; nbconvert's HTML
+    export handles only SGR codes and renders the rest literally, so they show
+    up as a stray ``[?25l`` above the bars.
+    """
+    sink = io.StringIO()
+    writer = _OverwriteSafeWriter(sink)
+    writer.write("\x1b[?25l")
+    writer.write("\rframe")
+    writer.write("\x1b[?25h")
+    assert sink.getvalue() == "\rframe"
+
+
+def test_notebook_reporter_emits_no_cursor_codes():
+    """End-to-end: a full session leaks neither cursor code."""
+    reporter = RichNotebookProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Train", sources=("batch",))
+    reporter._progress.refresh()
+    reporter.update(ProgressEvent(source="batch", step=150, total=150, details="b"))
+    reporter._progress.refresh()
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert "\x1b[?25" not in buf.getvalue()
 
 
 def test_overwrite_writer_pads_before_an_embedded_newline():
@@ -863,7 +898,9 @@ def test_display_handle_available_requires_a_live_shell(monkeypatch):
 
 def test_auto_reporter_notebook_with_display_picks_display_reporter(monkeypatch):
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
+    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: True)
     monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
     monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: True)
     assert type(auto_reporter()) is RichDisplayProgressReporter
@@ -871,8 +908,10 @@ def test_auto_reporter_notebook_with_display_picks_display_reporter(monkeypatch)
 
 def test_auto_reporter_notebook_without_display_falls_back_to_ansi(monkeypatch):
     """A Databricks runtime that never imported IPython still gets a working bar."""
+    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: True)
     monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
     monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: False)
     assert type(auto_reporter()) is RichNotebookProgressReporter
@@ -881,7 +920,7 @@ def test_auto_reporter_notebook_without_display_falls_back_to_ansi(monkeypatch):
 def test_format_eta_drops_sub_second_precision():
     """A timedelta stringifies with microseconds, which is false precision here."""
     assert _format_eta(timedelta(seconds=83, microseconds=456789)) == (
-        "Est. Remaining: 0:01:23"
+        "est. remaining: 0:01:23"
     )
 
 
@@ -898,15 +937,15 @@ def test_format_eta_shortens_the_label_on_a_narrow_console():
     spelled-out form pushes the counter and elapsed time into ellipses, while
     the short form leaves them intact.
     """
-    assert _format_eta(timedelta(seconds=83), long=True) == "Est. Remaining: 0:01:23"
+    assert _format_eta(timedelta(seconds=83), long=True) == "est. remaining: 0:01:23"
     assert _format_eta(timedelta(seconds=83), long=False) == "ETA 0:01:23"
     # and a bar reporter picks between them from its console width
     assert RichProgressReporter(
         console=Console(width=ETA_LABEL_MIN_WIDTH)
-    )._eta_text(timedelta(seconds=83)).startswith("Est. Remaining:")
+    )._eta_text(timedelta(seconds=83)) == _format_eta(timedelta(seconds=83), long=True)
     assert RichProgressReporter(
         console=Console(width=ETA_LABEL_MIN_WIDTH - 1)
-    )._eta_text(timedelta(seconds=83)).startswith("ETA")
+    )._eta_text(timedelta(seconds=83)) == _format_eta(timedelta(seconds=83), long=False)
 
 
 def test_batch_callback_carries_an_estimate():
@@ -931,7 +970,7 @@ def test_batch_callback_withholds_the_estimate_at_tick_zero():
     class _FiresAtTickZero:
         id = "fake-trainee"
 
-        def __init__(self):
+        def __init__(self) -> None:
             self.client = _FakeClient()
 
         def cb_only(self, *, progress_callback=None):
@@ -956,7 +995,7 @@ def test_rich_reporter_renders_the_estimate():
         ProgressEvent(source="batch", step=5, total=10, details="batch 2",
                       eta=timedelta(seconds=83)),
     ])
-    assert "Est. Remaining: 0:01:23" in _ANSI.sub("", out)
+    assert _format_eta(timedelta(seconds=83)) in _ANSI.sub("", out)
 
 
 def test_simple_reporter_renders_the_estimate(capsys):
@@ -966,15 +1005,136 @@ def test_simple_reporter_renders_the_estimate(capsys):
                                   details="batch 3", eta=timedelta(seconds=83)))
     reporter.update(ProgressEvent(source="batch", step=2400, total=10000, details="batch 6"))
     out = capsys.readouterr().out
-    assert "batch 3 · Est. Remaining: 0:01:23" in out
+    assert f"batch 3 · {_format_eta(timedelta(seconds=83))}" in out
     assert "batch 6\n" in out          # no stray separator when there is no estimate
+
+
+def test_experimental_notebook_reporter_is_off_by_default(monkeypatch):
+    monkeypatch.delenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", raising=False)
+    assert _experimental_notebook_reporter() is False
+    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
+    assert _experimental_notebook_reporter() is True
+    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "0")
+    assert _experimental_notebook_reporter() is False
+
+
+def test_interactive_frontend_false_without_ipython(monkeypatch):
+    monkeypatch.delitem(sys.modules, "IPython", raising=False)
+    assert _interactive_frontend() is False
+
+
+@pytest.mark.parametrize(("shell", "expected"), [
+    (SimpleNamespace(kernel=SimpleNamespace(_allow_stdin=True)), True),
+    (SimpleNamespace(kernel=SimpleNamespace(_allow_stdin=False)), False),
+    (SimpleNamespace(kernel=SimpleNamespace()), False),   # field omitted
+    (SimpleNamespace(), False),                           # no kernel at all
+    (None, False),                                        # no shell
+])
+def test_interactive_frontend_reads_allow_stdin(monkeypatch, shell, expected):
+    """
+    Verify headless execution is distinguished from a live front-end.
+
+    ``nbclient`` — and so nbconvert and papermill — hard-codes
+    ``allow_stdin = False``, while JupyterLab's client defaults it to true.
+    A front-end that omits the field reads as False, which degrades to plain
+    lines rather than to corrupted output.
+    """
+    monkeypatch.setitem(sys.modules, "IPython",
+                        SimpleNamespace(get_ipython=lambda: shell))
+    assert _interactive_frontend() is expected
+
+
+def test_auto_reporter_headless_notebook_still_gets_the_display_slot(monkeypatch):
+    """
+    Verify an nbconvert/papermill run keeps the rich bars.
+
+    nbclient's ``_update_display_id`` replaces an output's data in place, so
+    every repaint overwrites the same output and the saved notebook keeps the
+    final frame as ordinary HTML — which exports faithfully.
+    """
+    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
+    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
+    monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: True)
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
+    assert type(auto_reporter()) is RichDisplayProgressReporter
+
+
+def test_auto_reporter_headless_without_display_uses_simple(monkeypatch):
+    """
+    Verify the carriage-return repaint is never chosen headlessly.
+
+    Nothing applies it there, so each frame is committed to the document as its
+    own line.
+    """
+    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
+    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
+    monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
+    assert type(auto_reporter()) is SimpleProgressReporter
+
+
+def test_display_reporter_uses_a_slot_headlessly_even_for_one_bar(monkeypatch):
+    """A lone bar must not take the repaint path when nothing will apply it."""
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
+    handle = _fake_display(monkeypatch)
+    reporter = RichDisplayProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch",))
+    reporter.update(ProgressEvent(source="batch", step=5, total=5, details="b"))
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert reporter._inline is None
+    assert handle.frames
+
+
+def test_auto_reporter_notebook_with_display_but_flag_off_uses_simple(monkeypatch):
+    """
+    Verify the whole rich notebook branch is opt-in, not just the ANSI half.
+
+    Rich progress in a notebook rests on undocumented front-end behavior either
+    way — an in-place repaint, or the display-update protocol — so with the flag
+    unset a notebook takes the path it always did.
+    """
+    monkeypatch.delenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", raising=False)
+    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
+    monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: True)
+    assert type(auto_reporter()) is SimpleProgressReporter
+
+
+def test_auto_reporter_tty_is_unaffected_by_the_flag(monkeypatch):
+    """A real terminal keeps the full reporter whether or not the flag is set."""
+    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    for value in ("1", None):
+        if value is None:
+            monkeypatch.delenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", raising=False)
+        else:
+            monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", value)
+        assert type(auto_reporter()) is RichProgressReporter
+
+
+def test_auto_reporter_notebook_without_display_and_flag_off_uses_simple(monkeypatch):
+    """With no display slot and no opt-in, fall back to plain lines."""
+    monkeypatch.delenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", raising=False)
+    monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
+    monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: False)
+    assert type(auto_reporter()) is SimpleProgressReporter
 
 
 def test_auto_reporter_databricks_picks_rich_notebook(monkeypatch):
     """Databricks lost its carve-out and is now treated as an ordinary notebook."""
+    monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
     monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "13.3.x-scala2.12")
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: True)
     assert type(auto_reporter()) is RichNotebookProgressReporter
 
 

--- a/howso/utilities/tests/test_progress.py
+++ b/howso/utilities/tests/test_progress.py
@@ -13,6 +13,7 @@ from typing import Any
 import warnings
 
 import pytest
+from rich.console import Console
 from rich.progress import BarColumn
 
 from howso.client.configuration import ClientOptions, HowsoConfiguration
@@ -37,11 +38,13 @@ from howso.utilities.monitors import ProgressTimer
 from howso.utilities.progress import (
     _auto_progress_enabled,  # pyright: ignore[reportPrivateUsage]
     _display_handle_available,  # pyright: ignore[reportPrivateUsage]
+    _format_eta,  # pyright: ignore[reportPrivateUsage]
     _in_notebook,  # pyright: ignore[reportPrivateUsage]
     _notebook_console,  # pyright: ignore[reportPrivateUsage]
     _one_line,  # pyright: ignore[reportPrivateUsage]
     _OverwriteSafeWriter,  # pyright: ignore[reportPrivateUsage]
     _parse_tristate,  # pyright: ignore[reportPrivateUsage]
+    ETA_LABEL_MIN_WIDTH,
     NOTEBOOK_COLUMNS,
 )
 
@@ -411,15 +414,18 @@ def test_notebook_reporter_frames_are_constant_width():
         ProgressEvent(source="engine", step=9, total=10, details="a much longer detail string"),
         ProgressEvent(source="batch", step=9, total=10, details="b"),
     ])
-    # A frame is a \r-delimited chunk *within* one physical line. Each is at
-    # least the console width; anything beyond that is the overwrite padding,
-    # which must be blank.
+    # A frame is a \r-delimited chunk *within* one physical line. Frames fill
+    # the console width give or take a column: rich distributes flexible column
+    # widths with integer rounding, and with seven columns the remainder can
+    # leave one unallocated. Exact coverage is not this property's job anyway —
+    # _OverwriteSafeWriter guarantees that by raw length. What matters here is
+    # that no frame is *substantially* short and that any excess is blank.
     for line in out.split("\n"):
         for chunk in line.split("\r"):
             if "\u2501" not in chunk:
                 continue
             visible = _ANSI.sub("", chunk)
-            assert len(visible) >= NOTEBOOK_COLUMNS
+            assert len(visible) >= NOTEBOOK_COLUMNS - 1
             assert visible[NOTEBOOK_COLUMNS:].strip() == ""
 
 
@@ -870,6 +876,98 @@ def test_auto_reporter_notebook_without_display_falls_back_to_ansi(monkeypatch):
     monkeypatch.setattr("howso.utilities.progress._in_notebook", lambda: True)
     monkeypatch.setattr("howso.utilities.progress._display_handle_available", lambda: False)
     assert type(auto_reporter()) is RichNotebookProgressReporter
+
+
+def test_format_eta_drops_sub_second_precision():
+    """A timedelta stringifies with microseconds, which is false precision here."""
+    assert _format_eta(timedelta(seconds=83, microseconds=456789)) == (
+        "Est. Remaining: 0:01:23"
+    )
+
+
+@pytest.mark.parametrize("eta", [None, timedelta(seconds=-5)])
+def test_format_eta_renders_nothing_without_a_usable_estimate(eta):
+    assert _format_eta(eta) == ""
+
+
+def test_format_eta_shortens_the_label_on_a_narrow_console():
+    """
+    Verify the label degrades rather than crowding out real data.
+
+    Measured against the longest label this module generates: at 88 columns the
+    spelled-out form pushes the counter and elapsed time into ellipses, while
+    the short form leaves them intact.
+    """
+    assert _format_eta(timedelta(seconds=83), long=True) == "Est. Remaining: 0:01:23"
+    assert _format_eta(timedelta(seconds=83), long=False) == "ETA 0:01:23"
+    # and a bar reporter picks between them from its console width
+    assert RichProgressReporter(
+        console=Console(width=ETA_LABEL_MIN_WIDTH)
+    )._eta_text(timedelta(seconds=83)).startswith("Est. Remaining:")
+    assert RichProgressReporter(
+        console=Console(width=ETA_LABEL_MIN_WIDTH - 1)
+    )._eta_text(timedelta(seconds=83)).startswith("ETA")
+
+
+def test_batch_callback_carries_an_estimate():
+    """The estimate already exists on ProgressTimer; the event must carry it."""
+    reporter = _RecordingReporter()
+    trainee = _FakeTrainee()
+    with_progress("Train", trainee.cb_only, reporter=reporter)
+    batch_events = [e for e in reporter.events if e.source == "batch"]
+    assert batch_events
+    assert any(e.eta is not None for e in batch_events)
+
+
+def test_batch_callback_withholds_the_estimate_at_tick_zero():
+    """
+    Verify no estimate is reported before the first tick lands.
+
+    ``ProgressTimer.time_remaining`` divides by ``max(current_tick, 1)``, so at
+    tick zero it reports roughly the entire run as still remaining — a number
+    worse than showing nothing. ``_FakeTrainee.cb_only`` ticks before it fires
+    the callback and so can never reach this state; this fake fires first.
+    """
+    class _FiresAtTickZero:
+        id = "fake-trainee"
+
+        def __init__(self):
+            self.client = _FakeClient()
+
+        def cb_only(self, *, progress_callback=None):
+            with ProgressTimer(10) as timer:
+                progress_callback(timer)      # current_tick is still 0
+                timer.update(1)
+                progress_callback(timer)      # now there is a measurement
+            return "done"
+
+    reporter = _RecordingReporter()
+    with_progress("Train", _FiresAtTickZero().cb_only, reporter=reporter)
+    events = [e for e in reporter.events if e.source == "batch"]
+    assert len(events) == 2
+    assert events[0].step == 0
+    assert events[0].eta is None      # withheld
+    assert events[1].eta is not None  # reported once measurable
+
+
+def test_rich_reporter_renders_the_estimate():
+    reporter = RichProgressReporter(console=_notebook_console())
+    out = _render(reporter, ("batch",), [
+        ProgressEvent(source="batch", step=5, total=10, details="batch 2",
+                      eta=timedelta(seconds=83)),
+    ])
+    assert "Est. Remaining: 0:01:23" in _ANSI.sub("", out)
+
+
+def test_simple_reporter_renders_the_estimate(capsys):
+    reporter = SimpleProgressReporter()
+    reporter.start("Train", sources=("batch",))
+    reporter.update(ProgressEvent(source="batch", step=1200, total=10000,
+                                  details="batch 3", eta=timedelta(seconds=83)))
+    reporter.update(ProgressEvent(source="batch", step=2400, total=10000, details="batch 6"))
+    out = capsys.readouterr().out
+    assert "batch 3 · Est. Remaining: 0:01:23" in out
+    assert "batch 6\n" in out          # no stray separator when there is no estimate
 
 
 def test_auto_reporter_databricks_picks_rich_notebook(monkeypatch):

--- a/howso/utilities/tests/test_progress.py
+++ b/howso/utilities/tests/test_progress.py
@@ -1,4 +1,4 @@
-"""Tests for ``howso.utilities.progress``."""
+# pyright: reportMissingParameterType=false
 from __future__ import annotations
 
 import builtins
@@ -7,6 +7,7 @@ import inspect
 import io
 import re
 import sys
+import threading
 import time
 from types import SimpleNamespace
 from typing import Any
@@ -14,7 +15,7 @@ import warnings
 
 import pytest
 from rich.console import Console
-from rich.progress import BarColumn
+from rich.progress import BarColumn, Progress
 
 from howso.client.configuration import ClientOptions, HowsoConfiguration
 from howso.utilities import (
@@ -46,6 +47,8 @@ from howso.utilities.progress import (
     _one_line,  # pyright: ignore[reportPrivateUsage]
     _OverwriteSafeWriter,  # pyright: ignore[reportPrivateUsage]
     _parse_tristate,  # pyright: ignore[reportPrivateUsage]
+    _SolidBar,  # pyright: ignore[reportPrivateUsage]
+    BAR_WIDTH,
     ETA_LABEL_MIN_WIDTH,
     NOTEBOOK_COLUMNS,
 )
@@ -54,7 +57,7 @@ from howso.utilities.progress import (
 class _FakeClient:
     """Minimal client double exposing the subset ``with_progress`` touches."""
 
-    def __init__(self, progress_payloads=None, library_type="mt"):  # pyright: ignore[reportMissingSuperCall]
+    def __init__(self, progress_payloads=None, library_type="mt") -> None:  # pyright: ignore[reportMissingSuperCall]
         self._payloads = list(progress_payloads or [
             {"step": 1, "total": 3, "details": "step 1"},
         ])
@@ -104,7 +107,7 @@ class _FakeTrainee:
 
     id = "fake-trainee"
 
-    def __init__(self, client=None):  # pyright: ignore[reportMissingSuperCall]
+    def __init__(self, client=None) -> None:  # pyright: ignore[reportMissingSuperCall]
         self.client = client or _FakeClient()
         self.received_task_id = None
         self.received_progress_callback = None
@@ -169,7 +172,7 @@ def test_simple_reporter_single_source_no_indent(capsys):
     assert "  [1/6] Analyzing" in out
     assert "  [2/6] Computing" in out
     assert "    [" not in out  # no double-indent in single-source mode
-    assert "Analyze complete in 0:00:01.500000" in out
+    assert "Analyze complete in 0:00:01" in out
 
 
 def test_simple_reporter_both_sources_engine_indented(capsys):
@@ -296,6 +299,23 @@ def test_reporter_flushes_at_both_session_boundaries(reporter_cls, monkeypatch, 
 _ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 
 
+def _require_progress(reporter: RichProgressReporter) -> Progress:
+    """
+    Return a reporter's live ``Progress``, asserting it exists.
+
+    Typed against ``RichProgressReporter`` because that is the class declaring
+    ``_progress``; the notebook and display reporters inherit it, while
+    ``SimpleProgressReporter`` prints lines and has none. The attribute is
+    ``Progress | None`` because a session with no sources never starts one.
+    Every caller here has just started a session that does, so the assertion
+    narrows the type and states that precondition rather than letting the test
+    fail later with an opaque ``NoneType`` error.
+    """
+    progress = reporter._progress
+    assert progress is not None
+    return progress
+
+
 def _render(reporter, sources, events) -> str:
     """
     Drive a full session and return the raw bytes the console received.
@@ -311,7 +331,7 @@ def _render(reporter, sources, events) -> str:
     for event in events:
         reporter.update(event)
         if reporter._progress is not None:
-            reporter._progress.refresh()
+            _require_progress(reporter).refresh()
     reporter.finish(success=True, duration=timedelta(seconds=4))
     return buf.getvalue()
 
@@ -321,23 +341,37 @@ def _fake_kernel(monkeypatch):
     class ZMQInteractiveShell:
         pass
 
-    monkeypatch.setattr(builtins, "get_ipython", lambda: ZMQInteractiveShell(), raising=False)
+    monkeypatch.setattr(builtins, "get_ipython", ZMQInteractiveShell, raising=False)
 
 
-def _apply_carriage_returns(raw: str) -> tuple[str, str]:
+def _bar_color(frame: str) -> list[str]:
+    """
+    Return the first SGR color code applied to a bar glyph in ``frame``.
+
+    A list rather than a scalar so an unstyled frame compares as ``[]`` instead
+    of raising, which keeps a failure message readable.
+    """
+    return re.findall(r"\x1b\[([0-9;]+)m\u2501", frame)[:1]
+
+
+def _overwrite_residue(raw: str) -> str:
     r"""
-    Replay a repaint region the way a notebook front-end does.
+    Replay a repaint region and return whatever outlives the final frame.
 
     Front-ends implement ``\r`` as a raw-index overwrite and strip the
-    erase-line code, so a shorter frame leaves the previous frame's tail
-    behind. Returns the rendered line and the line that was intended.
+    erase-line code, so a frame shorter than its predecessor leaves that
+    predecessor's tail on screen.
+
+    The assertion to build on this is that the residue is *blank*, not that
+    there is none — residue is unavoidable whenever frames shrink. Comparing
+    ANSI-stripped text instead would pass or fail on where the byte boundary
+    happens to land, which is exactly how this bug once reached a user.
     """
-    region = raw.split("\n")[0]
+    region = raw.split("\n", maxsplit=1)[0]
     line = ""
     for chunk in region.split("\r"):
         line = chunk + line[len(chunk):]
-    intended = region.split("\r")[-1]
-    return _ANSI.sub("", line).rstrip(), _ANSI.sub("", intended).rstrip()
+    return line[len(region.split("\r")[-1]):]
 
 
 def test_notebook_reporter_leaves_no_residue_when_frames_shrink():
@@ -345,7 +379,7 @@ def test_notebook_reporter_leaves_no_residue_when_frames_shrink():
     Verify a short frame still covers the long one before it.
 
     Visible width is constant, but raw length is not: rich's indeterminate
-    pulse spends ~980 characters on a colour gradient occupying the same
+    pulse spends ~980 characters on a color gradient occupying the same
     columns a determinate frame draws in ~165. Since the overwrite is by raw
     index, the shortfall would otherwise surface as literal escape-sequence
     fragments such as ``;112m``.
@@ -354,32 +388,24 @@ def test_notebook_reporter_leaves_no_residue_when_frames_shrink():
     buf = io.StringIO()
     reporter._console.file = buf
     reporter.start("Train", sources=("batch",))
-    reporter._progress.refresh()          # the long pulse frame
+    _require_progress(reporter).refresh()          # the long pulse frame
     for step in (1, 60, 120):             # then much shorter determinate frames
         reporter.update(ProgressEvent(source="batch", step=step, total=120, details="batch 2"))
-        reporter._progress.refresh()
+        _require_progress(reporter).refresh()
     reporter.finish(success=True, duration=timedelta(seconds=1))
-    region = buf.getvalue().split("\n")[0]
-    line = ""
-    for chunk in region.split("\r"):
-        line = chunk + line[len(chunk):]
-    residue = line[len(region.split("\r")[-1]):]
-    # Not "no residue" — residue is unavoidable when frames shrink. What
-    # matters is that it is blank. Asserting only that the ANSI-stripped text
-    # matches would pass or fail on where the byte boundary happens to land,
-    # which is exactly how this bug reached a user once already.
+    residue = _overwrite_residue(buf.getvalue())
     assert set(residue) <= {" "}, f"visible residue: {residue!r}"
 
 
 def test_notebook_reporter_padding_is_invisible():
-    """The padding must add raw length only — never colour, never extra columns."""
+    """The padding must add raw length only — never color, never extra columns."""
     reporter = RichNotebookProgressReporter()
     buf = io.StringIO()
     reporter._console.file = buf
     reporter.start("Train", sources=("batch",))
-    reporter._progress.refresh()
+    _require_progress(reporter).refresh()
     reporter.update(ProgressEvent(source="batch", step=120, total=120, details="b"))
-    reporter._progress.refresh()
+    _require_progress(reporter).refresh()
     reporter.finish(success=True, duration=timedelta(seconds=1))
     for line in buf.getvalue().split("\n"):
         for chunk in line.split("\r"):
@@ -409,7 +435,7 @@ def test_notebook_reporter_survives_multiline_engine_details():
     assert "\x1b[1A" not in out
 
 
-def test_notebook_reporter_frames_are_constant_width():
+def test_notebook_reporter_frames_fit_the_console():
     """Front-ends overwrite by length and ignore erase-line, so a short frame leaves residue."""
     out = _render(RichNotebookProgressReporter(), ("batch", "engine"), [
         ProgressEvent(source="batch", step=1, total=10, details="b"),
@@ -422,12 +448,20 @@ def test_notebook_reporter_frames_are_constant_width():
     # leave one unallocated. Exact coverage is not this property's job anyway —
     # _OverwriteSafeWriter guarantees that by raw length. What matters here is
     # that no frame is *substantially* short and that any excess is blank.
+    # Frames no longer fill the console: ``expand`` is off, because letting rich
+    # redistribute slack is what made labels and bars land in different columns
+    # from one session to the next. What still has to hold is that a frame never
+    # exceeds the console width and never carries visible trailing padding.
     for line in out.split("\n"):
         for chunk in line.split("\r"):
             if "\u2501" not in chunk:
                 continue
             visible = _ANSI.sub("", chunk)
-            assert len(visible) >= NOTEBOOK_COLUMNS - 1
+            # The writer pads by *raw* length, and escapes occupy raw length
+            # without occupying columns, so trailing blanks can run a little
+            # past the console width. What must hold is that the content fits
+            # and everything past it is blank.
+            assert len(visible.rstrip()) <= NOTEBOOK_COLUMNS
             assert visible[NOTEBOOK_COLUMNS:].strip() == ""
 
 
@@ -452,7 +486,7 @@ def test_notebook_console_flags():
 def test_notebook_console_overrides_rich_jupyter_detection(monkeypatch):
     """A stock Console would go Jupyter here; ours must not."""
     _fake_kernel(monkeypatch)
-    from rich.console import Console
+    from rich.console import Console  # noqa: PLC0415
 
     assert Console().is_jupyter is True  # the fake is doing its job
     assert RichNotebookProgressReporter()._console.is_jupyter is False
@@ -474,7 +508,7 @@ def test_notebook_reporter_uses_one_task_for_both_sources():
     reporter.start("Train", sources=("batch", "engine"))
     try:
         assert len(set(reporter._tasks.values())) == 1
-        assert len(reporter._progress.tasks) == 1
+        assert len(_require_progress(reporter).tasks) == 1
     finally:
         reporter.finish(success=True, duration=timedelta(seconds=1))
 
@@ -487,7 +521,7 @@ def test_notebook_reporter_engine_does_not_move_the_bar():
     try:
         reporter.update(ProgressEvent(source="batch", step=5, total=10, details="b"))
         reporter.update(ProgressEvent(source="engine", step=1, total=3, details="e"))
-        task = reporter._progress.tasks[0]
+        task = _require_progress(reporter).tasks[0]
         assert (task.completed, task.total) == (5, 10)
         assert "engine 1/3" in task.fields["details"]
     finally:
@@ -501,7 +535,7 @@ def test_notebook_reporter_engine_only_drives_the_bar():
     reporter.start("Analyze", sources=("engine",))
     try:
         reporter.update(ProgressEvent(source="engine", step=3, total=6, details="computing"))
-        task = reporter._progress.tasks[0]
+        task = _require_progress(reporter).tasks[0]
         assert (task.completed, task.total) == (3, 6)
     finally:
         reporter.finish(success=True, duration=timedelta(seconds=1))
@@ -514,7 +548,7 @@ def test_notebook_reporter_ignores_undeclared_source():
     reporter.start("Analyze", sources=("engine",))
     try:
         reporter.update(ProgressEvent(source="batch", step=9, total=9, details="nope"))
-        assert reporter._progress.tasks[0].completed == 0
+        assert _require_progress(reporter).tasks[0].completed == 0
     finally:
         reporter.finish(success=True, duration=timedelta(seconds=1))
 
@@ -611,7 +645,7 @@ def _fake_display(monkeypatch) -> _FakeDisplayHandle:
     module = SimpleNamespace(display=display)
     monkeypatch.setitem(sys.modules, "IPython.display", module)
     monkeypatch.setitem(sys.modules, "IPython", SimpleNamespace(
-        display=module, get_ipython=lambda: object()))
+        display=module, get_ipython=object))
     return handle
 
 
@@ -621,9 +655,16 @@ def _rows(renderable) -> list[str]:
     return [line for line in plain.splitlines() if line.strip()]
 
 
-@pytest.mark.parametrize("sources", [(), ("batch",), ("engine",)])
-def test_display_reporter_stays_inline_for_a_single_bar(monkeypatch, sources):
-    """One bar needs no display slot, and claiming one would fragment the cell."""
+@pytest.mark.parametrize("sources", [(), ("batch",), ("engine",), ("batch", "engine")])
+def test_display_reporter_stays_inline_when_watched(monkeypatch, sources):
+    """
+    Verify a watched notebook never claims a display slot, even for two sources.
+
+    A notebook merges consecutive stdout writes into one block but never merges
+    display blocks, so a display group is fenced off from the lines around it by
+    the notebook's padding. The stdout reporter folds the engine into the outer
+    bar's details rather than paying that for a second bar.
+    """
     monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: True)
     handle = _fake_display(monkeypatch)
     reporter = RichDisplayProgressReporter()
@@ -660,9 +701,9 @@ def test_notebook_reporter_emits_no_cursor_codes():
     buf = io.StringIO()
     reporter._console.file = buf
     reporter.start("Train", sources=("batch",))
-    reporter._progress.refresh()
+    _require_progress(reporter).refresh()
     reporter.update(ProgressEvent(source="batch", step=150, total=150, details="b"))
-    reporter._progress.refresh()
+    _require_progress(reporter).refresh()
     reporter.finish(success=True, duration=timedelta(seconds=1))
     assert "\x1b[?25" not in buf.getvalue()
 
@@ -699,7 +740,7 @@ def test_notebook_reporter_keeps_the_writer_through_stop(monkeypatch):
 
     ``Progress.stop()`` runs inside ``super().finish()`` and emits one last
     frame. Restoring the plain file before that call left the final frame
-    unpadded against a much longer predecessor, which is the residue that
+    un-padded against a much longer predecessor, which is the residue that
     reached a user. This asserts the ordering directly: with the quiet bar the
     last frame now happens to be the longest, so the defect no longer shows up
     in the output it produces, and a test on residue alone would not catch a
@@ -724,7 +765,7 @@ def test_notebook_reporter_bar_never_pulses():
     """
     Verify an unknown total renders a static track, not a pulse.
 
-    A pulse frame spends ~980 characters on a colour gradient where the
+    A pulse frame spends ~980 characters on a color gradient where the
     determinate frame replacing it needs ~165, and on a carriage-return
     repaint that entire disparity has to be padded over as blanks.
     """
@@ -732,16 +773,16 @@ def test_notebook_reporter_bar_never_pulses():
     buf = io.StringIO()
     reporter._console.file = buf
     reporter.start("Train", sources=("batch",))
-    reporter._progress.refresh()
+    _require_progress(reporter).refresh()
     reporter.update(ProgressEvent(source="batch", step=1, total=120, details="b"))
-    reporter._progress.refresh()
+    _require_progress(reporter).refresh()
     reporter.finish(success=True, duration=timedelta(seconds=1))
     # Measure the pulse itself, not its knock-on size: the writer pads every
     # frame up to the running maximum, so a length comparison would be masked
     # by the very padding the pulse makes necessary.
     first = next(c for c in buf.getvalue().split("\r") if "\u2501" in c)
-    colours = set(re.findall(r"\x1b\[([0-9;]+)m", first))
-    assert len(colours) <= 6, f"gradient detected, {len(colours)} colours"
+    colors = set(re.findall(r"\x1b\[([0-9;]+)m", first))
+    assert len(colors) <= 6, f"gradient detected, {len(colors)} colors"
 
 
 @pytest.mark.parametrize("sources", [("batch", "engine")])
@@ -765,6 +806,25 @@ def test_display_reporter_uses_a_slot_for_every_bar(monkeypatch, sources):
     reporter.finish(success=True, duration=timedelta(seconds=1))
     assert handle.frames                       # a slot was claimed
     assert len(_rows(handle.frames[-1])) == len(sources) + 1   # bars + completion
+
+
+def test_two_sources_merge_onto_one_bar_when_inline(monkeypatch):
+    """The engine rides in the details text rather than getting its own line."""
+    monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: True)
+    reporter = RichNotebookProgressReporter()
+    sink = io.StringIO()          # keep our own handle: start() wraps the file
+    reporter._console.file = sink
+    reporter.start("React", sources=("batch", "engine"))
+    try:
+        reporter.update(ProgressEvent(source="batch", step=12, total=30, details="batch 3"))
+        reporter.update(ProgressEvent(source="engine", step=1, total=3, details="reacting"))
+        _require_progress(reporter).refresh()
+        assert len(_require_progress(reporter).tasks) == 1
+        line = _ANSI.sub("", [f for f in sink.getvalue().split("\r") if "\u2501" in f][-1])
+        assert "12/30" in line          # the batch owns the bar
+        assert "engine 1/3" in line     # the engine rides along
+    finally:
+        reporter.finish(success=True, duration=timedelta(seconds=1))
 
 
 def test_display_reporter_renders_both_bars(monkeypatch):
@@ -874,7 +934,7 @@ def test_display_reporter_empty_sources_claims_no_slot(monkeypatch):
     assert "Train complete in" in _ANSI.sub("", buf.getvalue())
 
 
-def test_display_reporter_keeps_richs_stock_bar_palette():
+def test_display_reporter_keeps_rich_stock_bar_palette():
     """
     Verify the bar keeps rich's stock styles.
 
@@ -920,7 +980,7 @@ def test_auto_reporter_notebook_without_display_falls_back_to_ansi(monkeypatch):
 def test_format_eta_drops_sub_second_precision():
     """A timedelta stringifies with microseconds, which is false precision here."""
     assert _format_eta(timedelta(seconds=83, microseconds=456789)) == (
-        "est. remaining: 0:01:23"
+        "est. rem.: 0:01:23"
     )
 
 
@@ -937,7 +997,7 @@ def test_format_eta_shortens_the_label_on_a_narrow_console():
     spelled-out form pushes the counter and elapsed time into ellipses, while
     the short form leaves them intact.
     """
-    assert _format_eta(timedelta(seconds=83), long=True) == "est. remaining: 0:01:23"
+    assert _format_eta(timedelta(seconds=83), long=True) == "est. rem.: 0:01:23"
     assert _format_eta(timedelta(seconds=83), long=False) == "ETA 0:01:23"
     # and a bar reporter picks between them from its console width
     assert RichProgressReporter(
@@ -974,10 +1034,14 @@ def test_batch_callback_withholds_the_estimate_at_tick_zero():
             self.client = _FakeClient()
 
         def cb_only(self, *, progress_callback=None):
+            # ``with_progress`` always supplies the callback; assert rather
+            # than guard with ``if``, so a harness that stopped wiring it fails
+            # here instead of quietly reporting no events.
+            assert progress_callback is not None
             with ProgressTimer(10) as timer:
-                progress_callback(timer)      # current_tick is still 0
+                progress_callback(timer)  # current_tick is still 0
                 timer.update(1)
-                progress_callback(timer)      # now there is a measurement
+                progress_callback(timer)  # now there is a measurement
             return "done"
 
     reporter = _RecordingReporter()
@@ -1040,7 +1104,7 @@ def test_interactive_frontend_reads_allow_stdin(monkeypatch, shell, expected):
     lines rather than to corrupted output.
     """
     monkeypatch.setitem(sys.modules, "IPython",
-                        SimpleNamespace(get_ipython=lambda: shell))
+                        SimpleNamespace(get_ipython=lambda: shell))  # pyright: ignore[reportUnknownLambdaType]
     assert _interactive_frontend() is expected
 
 
@@ -1128,6 +1192,362 @@ def test_auto_reporter_notebook_without_display_and_flag_off_uses_simple(monkeyp
     assert type(auto_reporter()) is SimpleProgressReporter
 
 
+class _NoHooks:
+    """A trainee whose only progress hook disappears when engine polling is off."""
+
+    id = "fake-trainee"
+
+    def __init__(self, sleep: float = 0.0) -> None:
+        self.client = _FakeClient()
+        self._sleep = sleep
+
+    def neither(self):
+        if self._sleep:
+            time.sleep(self._sleep)
+        return "neither-done"
+
+
+def test_engine_events_never_carry_an_estimate():
+    """
+    Verify engine work never claims a time to completion.
+
+    Engine step durations vary enough that an estimate derived from them would
+    mislead, so the field must stay empty at every step and total.
+    """
+    trainee = _FakeTrainee()
+    reporter = _RecordingReporter()
+    with_progress("React", trainee.both, reporter=reporter, polling_interval=0.01)
+    engine = [e for e in reporter.events if e.source == "engine"]
+    assert engine
+    assert all(e.eta is None for e in engine)
+
+
+def test_stepped_engine_still_fills_proportionally():
+    """A known total is real information about steps, even without a time claim."""
+    reporter = RichProgressReporter(console=_notebook_console())
+    reporter._console.file = io.StringIO()
+    reporter.start("Analyze", sources=("engine",))
+    try:
+        reporter.update(ProgressEvent(source="engine", step=12, total=30, details="k-fold"))
+        task = _require_progress(reporter).tasks[0]
+        assert (task.completed, task.total) == (12, 30)
+    finally:
+        reporter.finish(success=True, duration=timedelta(seconds=1))
+
+
+def test_indeterminate_declares_an_activity_source():
+    reporter = _RecordingReporter()
+    with_progress("Analyze", _NoHooks().neither, reporter=reporter, indeterminate=True)
+    assert reporter.started_sources == ("activity",)
+
+
+def test_without_the_flag_a_hookless_method_declares_no_sources():
+    reporter = _RecordingReporter()
+    with_progress("Analyze", _NoHooks().neither, reporter=reporter)
+    assert reporter.started_sources == ()
+
+
+def test_activity_ticker_reports_before_completion():
+    """
+    Verify something reaches the reporter while the call is still running.
+
+    Two of the four reporters emit only on ``update``, so without the ticker a
+    long call would stay silent until it finished — the whole point here.
+    """
+    reporter = _RecordingReporter()
+    with_progress("Analyze", _NoHooks(sleep=0.25).neither, reporter=reporter,
+                  indeterminate=True, polling_interval=0.02)
+    assert [e for e in reporter.events if e.source == "activity"]
+
+
+def test_activity_ticker_does_not_outlive_the_call():
+    before = threading.active_count()
+    with_progress("Analyze", _NoHooks(sleep=0.05).neither, reporter=_RecordingReporter(),
+                  indeterminate=True, polling_interval=0.01)
+    assert threading.active_count() <= before
+
+
+def _indeterminate_frames(reporter, *, success: bool = True) -> list[str]:
+    """Render a source-less session and return its bar frames."""
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Analyze", sources=("activity",))
+    for _ in range(3):
+        time.sleep(0.11)
+        _require_progress(reporter).refresh()
+    reporter.finish(success=success, duration=timedelta(seconds=1))
+    return [f for f in buf.getvalue().split("\r") if "\u2501" in f]
+
+
+@pytest.mark.parametrize(("sources", "event"), [
+    (("batch",), ProgressEvent(source="batch", step=2, total=2, details="batch 1")),
+    (("engine",), ProgressEvent(source="engine", step=3, total=0, details="k-fold")),
+    (("activity",), None),
+])
+def test_every_bar_is_the_same_width(sources, event):
+    """
+    Verify a bar is the same length whatever the session type.
+
+    The activity layout drops the counter and estimate columns, so a bar that
+    filled the space available would absorb what they freed and render visibly
+    longer than a batch bar in the same notebook. ``BarColumn.bar_width``
+    governs the determinate case; the solid bar has to honor it too.
+    """
+    reporter = RichProgressReporter(console=_notebook_console())
+    reporter._console.file = io.StringIO()
+    reporter.start("React aggregate", sources=sources)
+    try:
+        if event is not None:
+            reporter.update(event)
+        _require_progress(reporter).refresh()
+        frame = [f for f in reporter._console.file.getvalue().split("\r") if "\u2501" in f][-1]
+    finally:
+        reporter.finish(success=True, duration=timedelta(seconds=1))
+    assert len(re.findall(r"[\u2501\u257a\u2578]", _ANSI.sub("", frame))) == BAR_WIDTH
+
+
+def test_completed_indeterminate_session_stops_spinning():
+    """
+    Verify the spinner stops once the session ends.
+
+    rich blanks its spinner on ``task.finished``, which is ``completed >=
+    total`` and so never true while the total is ``None``. Left alone, a
+    finished ``analyze`` keeps a spinner frame beside its own completion line
+    and reads as though it were still running.
+    """
+    frames = _indeterminate_frames(RichProgressReporter(console=_notebook_console()))
+    assert _ANSI.sub("", frames[0]).strip()[:1] not in {"", "A"}   # spinning during
+    assert _ANSI.sub("", frames[-1]).lstrip().startswith("Analyze")  # blank after
+
+
+@pytest.mark.parametrize("eta", [
+    timedelta(seconds=0),
+    timedelta(microseconds=400),
+    timedelta(milliseconds=999),
+])
+def test_spent_estimate_renders_as_nothing(eta):
+    """A bar that has just filled must not advertise "est. remaining: 0:00:00"."""
+    assert _format_eta(eta) == ""
+
+
+def test_engine_bar_completes_when_the_call_succeeds():
+    """
+    Verify a short-reporting engine still ends on a full bar.
+
+    The poll thread stops the moment the wrapped call returns, so the engine's
+    last reported step is usually below its total. Left alone the bar sits
+    part-filled — reading as still running directly above its own "complete"
+    line.
+    """
+    reporter = RichNotebookProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Analyze", sources=("engine",))
+    reporter.update(ProgressEvent(source="engine", step=2, total=3, details=""))
+    _require_progress(reporter).refresh()
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    final = _ANSI.sub("", [f for f in reporter._console.file.getvalue().split("\r")
+                           if "\u2501" in f][-1])
+    assert "3/3" in final
+    assert "2/3" not in final
+
+
+def test_failed_engine_bar_stays_where_it_stopped():
+    """A failure must not be dressed up as a completed run."""
+    reporter = RichNotebookProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Analyze", sources=("engine",))
+    reporter.update(ProgressEvent(source="engine", step=2, total=3, details=""))
+    _require_progress(reporter).refresh()
+    reporter.finish(success=False, duration=timedelta(seconds=1))
+    final = _ANSI.sub("", [f for f in reporter._console.file.getvalue().split("\r")
+                           if "\u2501" in f][-1])
+    assert "2/3" in final
+
+
+def test_completed_batch_drops_its_details_with_no_gap():
+    """
+    Verify the chunk index goes on completion, leaving exactly one space.
+
+    ``batch 7`` is only the last chunk index; once the counter reads 120/120 it
+    says nothing. Clearing it must not leave a hole: the details share the
+    counter's column precisely because an empty column of their own would cost
+    padding on both sides and show as two spaces before the elapsed time.
+    """
+    reporter = RichNotebookProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch",))
+    reporter.update(ProgressEvent(source="batch", step=120, total=120, details="batch 7"))
+    _require_progress(reporter).refresh()
+    reporter.finish(success=True, duration=timedelta(seconds=8))
+    final = _ANSI.sub("", [f for f in reporter._console.file.getvalue().split("\r")
+                           if "\u2501" in f][-1])
+    assert "batch 7" not in final
+    elapsed = re.search(r"\d+:\d\d:\d\d", final)
+    assert elapsed
+    before = final[:elapsed.start()]
+    assert len(before) - len(before.rstrip()) == 1
+
+
+def test_failed_batch_keeps_its_details():
+    """On a failure the last detail says where it stopped, which is worth keeping."""
+    reporter = RichNotebookProgressReporter()
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch",))
+    reporter.update(ProgressEvent(source="batch", step=60, total=120, details="batch 4"))
+    _require_progress(reporter).refresh()
+    reporter.finish(success=False, duration=timedelta(seconds=8))
+    final = _ANSI.sub("", [f for f in reporter._console.file.getvalue().split("\r")
+                           if "\u2501" in f][-1])
+    assert "batch 4" in final
+
+
+def test_completed_batch_bar_drops_its_estimate():
+    """The estimate is cleared at session end, not left reading zero."""
+    reporter = RichProgressReporter(console=_notebook_console())
+    reporter._console.file = io.StringIO()
+    reporter.start("Train", sources=("batch",))
+    reporter.update(ProgressEvent(source="batch", step=1000, total=2000,
+                                  details="batch 3", eta=timedelta(seconds=45)))
+    _require_progress(reporter).refresh()
+    during = _ANSI.sub("", reporter._console.file.getvalue())
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    final = _ANSI.sub("", reporter._console.file.getvalue().split("\r")[-2])
+    assert "est. rem.: 0:00:45" in during
+    assert "remaining" not in final
+
+
+def test_solid_bar_measures_itself_exactly():
+    """
+    Verify the indeterminate bar reports its own width.
+
+    Without a measurement rich hands the column all the space left over; the
+    bar draws short inside it and the blank remainder shoves every following
+    column to the right. Only tracks with an unknown total were affected, since
+    a determinate bar is rich's own ``ProgressBar``, which measures itself.
+    """
+    console = _notebook_console()
+    bar = _SolidBar("red", BAR_WIDTH)
+    options = console.options.update(width=NOTEBOOK_COLUMNS)
+    measurement = bar.__rich_measure__(console, options)
+    assert (measurement.minimum, measurement.maximum) == (BAR_WIDTH, BAR_WIDTH)
+
+
+def test_indeterminate_row_left_aligns_its_trailing_columns():
+    """A row with no counter must not leave a gulf between bar and elapsed."""
+    reporter = RichProgressReporter(console=_notebook_console())
+    reporter._console.file = io.StringIO()
+    reporter.start("Analyze", sources=("activity",))
+    try:
+        reporter.update(ProgressEvent(source="activity", step=0, total=0))
+        _require_progress(reporter).refresh()
+        line = _ANSI.sub("", [f for f in reporter._console.file.getvalue().split("\r")
+                              if "\u2501" in f][-1])
+    finally:
+        reporter.finish(success=True, duration=timedelta(seconds=1))
+    bar_end = line.rindex("\u2501") + 1
+    elapsed = re.search(r"\d+:\d\d:\d\d", line)
+    assert elapsed is not None
+    # Exactly one space, the same as a batch row. An empty column still costs
+    # its padding on both sides, so a details column that never has content
+    # shows up as a second space between the bar and the elapsed time.
+    assert elapsed.start() - bar_end == 1, f"gap of {elapsed.start() - bar_end} columns"
+
+
+def test_indeterminate_bar_is_no_costlier_than_a_normal_one():
+    """
+    Verify the indeterminate bar stays cheap.
+
+    rich's pulse colors every cell of a 20-step gradient — ~980 characters a
+    frame against ~160 — and on the carriage-return path that entire gulf has
+    to be padded over as blanks. A solid single-run bar holds the length flat.
+    """
+    reporter = RichProgressReporter(console=_notebook_console())
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Analyze", sources=("engine",))
+    try:
+        _require_progress(reporter).refresh()                      # total unknown
+        indeterminate = [f for f in buf.getvalue().split("\r") if "\u2501" in f][-1]
+        reporter.update(ProgressEvent(source="engine", step=5, total=10, details=""))
+        _require_progress(reporter).refresh()                      # total known
+        determinate = [f for f in buf.getvalue().split("\r") if "\u2501" in f][-1]
+    finally:
+        reporter.finish(success=True, duration=timedelta(seconds=1))
+    # Constant length is not the property to assert — rich's pulse frames are
+    # constant too, just uniformly enormous. What matters is that the
+    # indeterminate frame costs no more than an ordinary one, since the gulf
+    # between them is what _OverwriteSafeWriter has to pad over.
+    assert len(indeterminate) < len(determinate) * 1.5, (
+        f"indeterminate={len(indeterminate)} determinate={len(determinate)}"
+    )
+
+
+@pytest.mark.parametrize(("success", "final"), [(True, "32"), (False, "31")])
+def test_indeterminate_bar_shows_state_by_color(success, final):
+    """Red while pending, green once done — and a failure never turns green."""
+    frames = _indeterminate_frames(
+        RichProgressReporter(console=_notebook_console()), success=success)
+    assert _bar_color(frames[0]) == ["31"]
+    assert _bar_color(frames[-1]) == [final]
+
+
+def test_indeterminate_spinner_animates():
+    """
+    Verify the spinner is what conveys liveness.
+
+    The bar is deliberately static, so a frozen spinner would leave the session
+    looking hung while every length and color assertion still passed.
+    """
+    frames = _indeterminate_frames(RichProgressReporter(console=_notebook_console()))
+    glyphs = {_ANSI.sub("", f).strip()[:1] for f in frames}
+    assert len(glyphs) > 1
+
+
+def test_activity_track_drops_the_counter_and_estimate():
+    """An activity track measures nothing, so "0/?" would be noise."""
+    frames = _indeterminate_frames(RichProgressReporter(console=_notebook_console()))
+    rendered = _ANSI.sub("", "".join(frames))
+    assert "0/?" not in rendered
+    assert "0:00:0" in rendered      # elapsed is still shown
+
+
+def test_notebook_reporter_renders_an_activity_session():
+    """
+    Verify the stdout reporter does not ignore an activity-only session.
+
+    Its primary-track selection knows ``batch`` and ``engine``; without a
+    fallback, ``activity`` matched neither and the reporter started no Progress
+    at all, leaving the very sessions this exists for completely blank.
+    """
+    reporter = RichNotebookProgressReporter()
+    buf = io.StringIO()
+    reporter._console.file = buf
+    reporter.start("Analyze", sources=("activity",))
+    assert reporter._progress is not None
+    reporter.update(ProgressEvent(source="activity", step=0, total=0))
+    _require_progress(reporter).refresh()
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    frames = [f for f in buf.getvalue().split("\r") if "\u2501" in f]
+    assert frames
+    # The property that matters is the same one the other repaint tests assert:
+    # whatever the writer leaves behind must be blank. Equal frame lengths would
+    # be stricter than necessary — the closing frame is longer, which needs no
+    # padding at all.
+    residue = _overwrite_residue(buf.getvalue())
+    assert set(residue) <= {" "}, f"visible residue: {residue!r}"
+
+
+def test_simple_reporter_activity_line(capsys, monkeypatch):
+    monkeypatch.setattr("howso.utilities.progress.HEARTBEAT_INTERVAL", 0.0)
+    reporter = SimpleProgressReporter()
+    reporter.start("Analyze", sources=("activity",))
+    reporter.update(ProgressEvent(source="activity", step=0, total=0))
+    reporter.finish(success=True, duration=timedelta(seconds=1))
+    out = capsys.readouterr().out
+    assert "elapsed" in out
+    assert "0/?" not in out
+
+
 def test_auto_reporter_databricks_picks_rich_notebook(monkeypatch):
     """Databricks lost its carve-out and is now treated as an ordinary notebook."""
     monkeypatch.setenv("HOWSO_EXPERIMENTAL_NOTEBOOK_REPORTER", "1")
@@ -1197,7 +1617,7 @@ def test_gating_re_entrancy_short_circuits_even_when_forced(monkeypatch):  # noq
     t = _trainee_with_cfg(None)
     enable_auto_progress()
     # Simulate "we're already inside one wrapped call".
-    from howso.utilities.progress import _state  # pyright: ignore[reportPrivateUsage]
+    from howso.utilities.progress import _state  # pyright: ignore[reportPrivateUsage]  # noqa: PLC0415
     _state.depth = 1
     try:
         assert _auto_progress_enabled(t) is False
@@ -1324,7 +1744,7 @@ def test_auto_progress_scope_restores_prior_state(monkeypatch):
 class _RecordingReporter:
     """Capture every event sent to the reporter for inspection in assertions."""
 
-    def __init__(self):  # pyright: ignore[reportMissingSuperCall]
+    def __init__(self) -> None:  # pyright: ignore[reportMissingSuperCall]
         self.events = []
         self.started_sources = None
         self.finished_success = None
@@ -1452,7 +1872,7 @@ def test_engine_polling_supported_runtime_missing_library_type():
 
 
 def test_engine_polling_supported_runtime_raises_is_fail_closed():
-    client = _FakeClient(library_type=RuntimeError("boom"))
+    client = _FakeClient(library_type=RuntimeError("boom"))  # pyright: ignore[reportArgumentType]
     assert engine_polling_supported(client, "fake-trainee") is False
 
 
@@ -1521,7 +1941,7 @@ def test_with_progress_single_threaded_keeps_batch_source():
 
 
 def test_with_progress_runtime_lookup_failure_skips_engine_source():
-    t = _FakeTrainee(_FakeClient(library_type=OSError("unreachable")))
+    t = _FakeTrainee(_FakeClient(library_type=OSError("unreachable")))  # pyright: ignore[reportArgumentType]
     r = _RecordingReporter()
     result = with_progress("Task", t.task_only, reporter=r, polling_interval=0.01)
     assert result == "task_only-done"
@@ -1546,7 +1966,7 @@ def test_simple_reporter_empty_sources_prints_label_and_completion(capsys):
     reporter.finish(success=True, duration=timedelta(seconds=1.5))
     out = capsys.readouterr().out
     assert "Analyze" in out
-    assert "Analyze complete in 0:00:01.500000" in out
+    assert "Analyze complete in 0:00:01" in out
     assert "[" not in out  # the undeclared source produced no track line
 
 
@@ -1579,7 +1999,7 @@ def test_with_progress_honors_caller_supplied_callback():
     t = _FakeTrainee()
     r = _RecordingReporter()
     captured = []
-    def my_cb(p, *a, **k):
+    def my_cb(p, *a, **k):  # noqa: ANN002, ANN003
         captured.append(p.current_tick)
     with_progress("CB", t.cb_only, reporter=r, progress_callback=my_cb)
     assert captured == [1, 2]
@@ -1606,7 +2026,7 @@ def test_decorator_preserves_metadata():
 
     assert my_method.__name__ == "my_method"
     assert "Add five" in (my_method.__doc__ or "")
-    assert my_method.__wrapped__.__name__ == "my_method"
+    assert my_method.__wrapped__.__name__ == "my_method"  # pyright: ignore[reportFunctionMemberAccess]
     sig = inspect.signature(my_method)
     assert list(sig.parameters) == ["self", "x"]
 
@@ -1615,14 +2035,16 @@ def test_decorator_factory_form_uses_explicit_label():
     @auto_progress("Custom Label")
     def m(self):  # noqa: ARG001
         return 1
-    assert m._auto_progress_label == "Custom Label"
+    assert getattr(m, "_auto_progress_label", None) == "Custom Label"
 
 
 def test_decorator_bare_form_derives_label_from_method_name():
     @auto_progress
     def react_series_stationary(self):  # noqa: ARG001
         return 1
-    assert react_series_stationary._auto_progress_label == "React series stationary"
+    assert getattr(react_series_stationary, "_auto_progress_label", None) == (
+        "React series stationary"
+    )
 
 
 def test_decorator_passes_through_when_disabled(monkeypatch):
@@ -1632,7 +2054,7 @@ def test_decorator_passes_through_when_disabled(monkeypatch):
     calls = []
     class T(_FakeTrainee):
         @auto_progress("Cb")
-        def cb_only(self, *, progress_callback=None):
+        def cb_only(self, *, progress_callback=None):  # pyright: ignore[reportIncompatibleMethodOverride]
             calls.append(progress_callback)
             return "ok"
     t = T()
@@ -1676,7 +2098,7 @@ def test_decorator_nested_calls_do_not_stack(capsys, monkeypatch):  # noqa: ARG0
     assert "Inner" not in out
 
 
-@pytest.mark.parametrize("name,label", [
+@pytest.mark.parametrize(("name", "label"), [
     ("train", "Train"),
     ("analyze", "Analyze"),
     ("react", "React"),
@@ -1688,7 +2110,7 @@ def test_decorator_nested_calls_do_not_stack(capsys, monkeypatch):  # noqa: ARG0
     ("impute", "Impute"),
 ])
 def test_trainee_methods_decorated_with_expected_labels(name, label):
-    from howso.engine import Trainee
+    from howso.engine import Trainee  # noqa: PLC0415
     method = getattr(Trainee, name)
     assert getattr(method, "_auto_progress_label", None) == label
     # functools.wraps preserves original signature for with_progress's
@@ -1698,7 +2120,7 @@ def test_trainee_methods_decorated_with_expected_labels(name, label):
 
 def test_predict_is_not_decorated():
     """Verify ``predict`` is not wrapped — it has no progress hooks."""
-    from howso.engine import Trainee
+    from howso.engine import Trainee  # noqa: PLC0415
     assert not hasattr(Trainee.predict, "_auto_progress_label")
 
 

--- a/howso/utilities/tests/test_progress.py
+++ b/howso/utilities/tests/test_progress.py
@@ -40,6 +40,7 @@ from howso.utilities.progress import (
     _auto_progress_enabled,  # pyright: ignore[reportPrivateUsage]
     _display_handle_available,  # pyright: ignore[reportPrivateUsage]
     _experimental_notebook_reporter,  # pyright: ignore[reportPrivateUsage]
+    _format_duration,  # pyright: ignore[reportPrivateUsage]
     _format_eta,  # pyright: ignore[reportPrivateUsage]
     _in_notebook,  # pyright: ignore[reportPrivateUsage]
     _interactive_frontend,  # pyright: ignore[reportPrivateUsage]
@@ -297,6 +298,9 @@ def test_reporter_flushes_at_both_session_boundaries(reporter_cls, monkeypatch, 
 
 
 _ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+# Every duration renders as H:MM:SS, hours running past a day.
+_DURATION = re.compile(r"\d+:\d\d:\d\d")
 
 
 def _require_progress(reporter: RichProgressReporter) -> Progress:
@@ -1330,6 +1334,81 @@ def test_spent_estimate_renders_as_nothing(eta):
     assert _format_eta(eta) == ""
 
 
+def test_every_color_is_theme_mappable():
+    """
+    Verify nothing is painted in a colour the notebook theme cannot remap.
+
+    Only ANSI palette indices 0-15 are themed. rich's stock track is
+    ``grey23`` — a 256-cube index around #3a3a3a, which no theme touches and
+    which reads as *filled* against a light background.
+    """
+    reporter = RichNotebookProgressReporter()
+    sink = io.StringIO()
+    reporter._console.file = sink
+    reporter.start("Train", sources=("batch",))
+    reporter.update(ProgressEvent(source="batch", step=40, total=120,
+                                  details="batch 2", eta=timedelta(seconds=83)))
+    _require_progress(reporter).refresh()
+    reporter.finish(success=True, duration=timedelta(seconds=20))
+    fixed = {
+        code for code in re.findall(r"\x1b\[([0-9;]+)m", sink.getvalue())
+        if "38" in code.split(";") and {"2", "5"} & set(code.split(";"))
+    }
+    assert fixed == set(), f"not theme-mappable: {sorted(fixed)}"
+
+
+@pytest.mark.parametrize(("success", "final_color"), [(True, "32"), (False, "31")])
+def test_stepped_bar_stays_red_until_the_session_ends(success, final_color):
+    """
+    Verify a full bar does not turn green while the call is still running.
+
+    rich switches to its finished style as soon as ``completed >= total``, but
+    the engine reporting its last step is not the call returning — the same
+    mistake that froze the elapsed clock. A bar going green beside a still
+    ticking timer says the opposite of what the timer says.
+    """
+    reporter = RichNotebookProgressReporter()
+    sink = io.StringIO()
+    reporter._console.file = sink
+    reporter.start("Analyze", sources=("engine",))
+    reporter.update(ProgressEvent(source="engine", step=1, total=1, details=""))
+    _require_progress(reporter).refresh()
+    during = [f for f in sink.getvalue().split("\r") if "\u2501" in f][-1]
+    assert _bar_color(during) == ["31"], "a running session must not look finished"
+    reporter.finish(success=success, duration=timedelta(seconds=20))
+    final = [f for f in sink.getvalue().split("\r") if "\u2501" in f][-1]
+    assert _bar_color(final) == [final_color]
+
+
+def test_elapsed_keeps_running_after_the_engine_reports_its_last_step():
+    """
+    Verify the clock tracks the session, not the engine's last step.
+
+    rich sets ``finished_time`` the instant ``completed >= total`` and
+    ``TimeElapsedColumn`` freezes on it. But the engine reporting its final
+    step is not the call returning: an ``analyze`` whose engine reported 1/1
+    after a second went on working for another seventeen, and the bar sat at
+    ``0:00:01`` beside a completion line reading ``0:00:18``.
+    """
+    reporter = RichNotebookProgressReporter()
+    sink = io.StringIO()
+    reporter._console.file = sink
+    reporter.start("Analyze", sources=("engine",))
+    reporter.update(ProgressEvent(source="engine", step=1, total=1, details=""))
+    # Wind the start back rather than sleep: the task is now 20 seconds old
+    # while the engine has already reported everything it is going to.
+    task = _require_progress(reporter).tasks[0]
+    assert task.start_time is not None
+    task.start_time -= 20
+    _require_progress(reporter).refresh()
+    reporter.finish(success=True, duration=timedelta(seconds=20))
+    # Only the bar row: the last chunk also carries the completion line, whose
+    # duration comes from finish() and would satisfy this assertion on its own.
+    bar_row = _ANSI.sub("", [f for f in sink.getvalue().split("\r")
+                             if "\u2501" in f][-1]).split("\n")[0]
+    assert "0:00:20" in bar_row, bar_row
+
+
 def test_engine_bar_completes_when_the_call_succeeds():
     """
     Verify a short-reporting engine still ends on a full bar.
@@ -1364,6 +1443,24 @@ def test_failed_engine_bar_stays_where_it_stopped():
     assert "2/3" in final
 
 
+@pytest.mark.parametrize(("seconds", "expected"), [
+    (0.987, "0:00:00"),
+    (9.5, "0:00:09"),
+    (83, "0:01:23"),
+    (3600, "1:00:00"),
+    (360000, "100:00:00"),
+])
+def test_durations_render_as_a_clock(seconds, expected):
+    """
+    Verify one duration format throughout, hours accumulating past a day.
+
+    ``str(timedelta)`` switches to ``"4 days, 4:00:00"`` past 24 hours, which
+    is 15 characters where the same value was 7 — enough to shift or clip a
+    pinned column on a run of the length these routinely reach.
+    """
+    assert _format_duration(timedelta(seconds=seconds)) == expected
+
+
 def test_completed_batch_drops_its_details_with_no_gap():
     """
     Verify the chunk index goes on completion, leaving exactly one space.
@@ -1382,7 +1479,7 @@ def test_completed_batch_drops_its_details_with_no_gap():
     final = _ANSI.sub("", [f for f in reporter._console.file.getvalue().split("\r")
                            if "\u2501" in f][-1])
     assert "batch 7" not in final
-    elapsed = re.search(r"\d+:\d\d:\d\d", final)
+    elapsed = _DURATION.search(final)
     assert elapsed
     before = final[:elapsed.start()]
     assert len(before) - len(before.rstrip()) == 1
@@ -1445,7 +1542,7 @@ def test_indeterminate_row_left_aligns_its_trailing_columns():
     finally:
         reporter.finish(success=True, duration=timedelta(seconds=1))
     bar_end = line.rindex("\u2501") + 1
-    elapsed = re.search(r"\d+:\d\d:\d\d", line)
+    elapsed = _DURATION.search(line)
     assert elapsed is not None
     # Exactly one space, the same as a batch row. An empty column still costs
     # its padding on both sides, so a details column that never has content
@@ -1508,7 +1605,7 @@ def test_activity_track_drops_the_counter_and_estimate():
     frames = _indeterminate_frames(RichProgressReporter(console=_notebook_console()))
     rendered = _ANSI.sub("", "".join(frames))
     assert "0/?" not in rendered
-    assert "0:00:0" in rendered      # elapsed is still shown
+    assert _DURATION.search(rendered)      # elapsed is still shown
 
 
 def test_notebook_reporter_renders_an_activity_session():

--- a/howso/utilities/tests/test_progress.py
+++ b/howso/utilities/tests/test_progress.py
@@ -169,7 +169,7 @@ def test_simple_reporter_single_source_no_indent(capsys):
     reporter.update(ProgressEvent(source="engine", step=1, total=6, details="Analyzing"))
     reporter.update(ProgressEvent(source="engine", step=2, total=6, details="Computing"))
     reporter.finish(success=True, duration=timedelta(seconds=1.5))
-    out = capsys.readouterr().out
+    out = _captured(capsys)
     assert "Analyze" in out
     assert "  [1/6] Analyzing" in out
     assert "  [2/6] Computing" in out
@@ -183,7 +183,7 @@ def test_simple_reporter_both_sources_engine_indented(capsys):
     reporter.update(ProgressEvent(source="batch", step=10, total=100, details="batch 1"))
     reporter.update(ProgressEvent(source="engine", step=1, total=3, details="step 1"))
     reporter.finish(success=True, duration=timedelta(seconds=2.0))
-    out = capsys.readouterr().out
+    out = _captured(capsys)
     assert "  [ 10/100] batch 1" in out      # batch: 2-space prefix
     assert "    [1/3] step 1" in out          # engine: 4-space prefix (nested)
 
@@ -194,7 +194,7 @@ def test_simple_reporter_numerator_padded_to_denominator_width(capsys):
     reporter.update(ProgressEvent(source="batch", step=0, total=1999, details="batch 0"))
     reporter.update(ProgressEvent(source="batch", step=100, total=1999, details="batch 1"))
     reporter.update(ProgressEvent(source="batch", step=1999, total=1999, details="batch 6"))
-    out = capsys.readouterr().out
+    out = _captured(capsys)
     assert "  [   0/1999] batch 0" in out
     assert "  [ 100/1999] batch 1" in out
     assert "  [1999/1999] batch 6" in out
@@ -204,7 +204,7 @@ def test_simple_reporter_failure_marker(capsys):
     reporter = SimpleProgressReporter()
     reporter.start("Train", sources=("batch",))
     reporter.finish(success=False, duration=timedelta(seconds=0.1))
-    out = capsys.readouterr().out
+    out = _captured(capsys)
     assert "Train failed in" in out
 
 
@@ -219,7 +219,7 @@ def test_simple_reporter_heartbeat_fires_when_step_stalls(capsys, monkeypatch):
     # Same step a second time → should print a heartbeat line containing 'elapsed'.
     reporter.update(ProgressEvent(source="engine", step=3, total=6, details="Computing"))
     reporter.finish(success=True, duration=timedelta(seconds=1.0))
-    out = capsys.readouterr().out
+    out = _captured(capsys)
     assert "elapsed" in out
 
 
@@ -227,7 +227,7 @@ def test_simple_reporter_unknown_total_renders_question_mark(capsys):
     reporter = SimpleProgressReporter()
     reporter.start("Analyze", sources=("engine",))
     reporter.update(ProgressEvent(source="engine", step=0, total=0, details=""))
-    out = capsys.readouterr().out
+    out = _captured(capsys)
     assert "[0/?]" in out
 
 
@@ -944,9 +944,28 @@ def _slot_reporter(**kwargs: Any) -> RichDisplayProgressReporter:
 
 
 def _rows(renderable) -> list[str]:
-    """Return the visible lines of one pushed frame."""
+    """
+    Return the visible lines of one pushed frame, without color.
+
+    ``text/plain`` is rendered through rich's *global* console, which decides
+    on its own whether to emit SGR codes — ``FORCE_COLOR`` in the environment
+    is enough to turn them on. Asserting on raw text therefore passes locally
+    and fails in CI, so strip them: every caller here is asking what a reader
+    sees, not how it was colored.
+    """
     plain = renderable._repr_mimebundle_([], [])["text/plain"]
-    return [line for line in plain.splitlines() if line.strip()]
+    return [_ANSI.sub("", line) for line in plain.splitlines() if line.strip()]
+
+
+def _captured(capsys) -> str:
+    """
+    Return captured stdout with any color stripped.
+
+    A reporter builds its own :class:`Console`, which picks up ``FORCE_COLOR``
+    from the environment like any other. Tests that assert on the *text* must
+    not depend on whether the run happened to be colored.
+    """
+    return _ANSI.sub("", capsys.readouterr().out)
 
 
 @pytest.mark.parametrize("sources", [(), ("batch",), ("engine",), ("batch", "engine")])
@@ -1116,6 +1135,45 @@ _PARITY_EVENTS = (
 )
 
 
+# rich draws a bar in box characters, falling back to ASCII when the console is
+# legacy-Windows or its encoding is not UTF-8 (``ascii = options.legacy_windows
+# or options.ascii_only``). The parity tests run in both.
+_BAR_GLYPHS = ("\u2501", "-")
+
+
+def _pinned_console(*, legacy: bool = False) -> Console:
+    """
+    Build a console whose rendering is fully determined, in the chosen glyph set.
+
+    Everything a machine could otherwise decide is pinned: width, color system,
+    and — via a ``StringIO``, which reports no encoding and so counts as UTF-8 —
+    the encoding. ``legacy`` is the one variable left, and it is the switch rich
+    uses to pick between box characters and ASCII.
+    """
+    return Console(
+        file=io.StringIO(), force_terminal=True, force_jupyter=False,
+        color_system="truecolor", legacy_windows=legacy, width=NOTEBOOK_COLUMNS,
+    )
+
+
+def _require_comparable_consoles(*consoles: Console) -> None:
+    """
+    Fail with a diagnosis of the rig rather than of the product.
+
+    Every route renders the same bar; whether it lands box-drawn or ASCII is a
+    property of the console it lands in, not of the delivery. Consoles that
+    disagree about that make a parity assertion compare consoles instead of
+    routes, and it then fails far from the cause — which is precisely how the
+    Windows runner reported it, as a bar of hyphens beside a bar of box
+    characters with nothing to say why.
+    """
+    flavors = {(c.options.ascii_only, c.options.legacy_windows) for c in consoles}
+    assert len(flavors) == 1, (
+        f"the consoles under test disagree on glyph set: {flavors}. This test "
+        "compares delivery routes, so they must all render the same way."
+    )
+
+
 def _stdout_bar_row(reporter) -> str:
     """Replay the parity session on a stdout-delivering reporter, returning its last bar row."""
     sink = io.StringIO()
@@ -1124,13 +1182,15 @@ def _stdout_bar_row(reporter) -> str:
     for event in _PARITY_EVENTS:
         reporter.update(event)
     _require_progress(reporter).refresh()
-    frames = [f for f in sink.getvalue().split("\r") if "\u2501" in f]
+    frames = [f for f in sink.getvalue().split("\r")
+              if any(glyph in f for glyph in _BAR_GLYPHS)]
     reporter.finish(success=True, duration=timedelta(seconds=9))
     assert frames, "no bar was ever painted"
     return _ANSI.sub("", frames[-1]).split("\n")[0].rstrip()
 
 
-def test_every_reporter_renders_the_same_bar(monkeypatch):
+@pytest.mark.parametrize("legacy", [False, True], ids=["box-drawing", "ascii"])
+def test_every_reporter_renders_the_same_bar(monkeypatch, legacy):
     """
     Verify one session looks identical however it is delivered.
 
@@ -1141,26 +1201,23 @@ def test_every_reporter_renders_the_same_bar(monkeypatch):
     sees is a bug in one of them. The display reporter had already drifted to
     a two-bar layout once, silently, for want of this.
 
-    The terminal reporter is given the notebook console so all three are
-    measuring the same width; that is the one thing they are *meant* to
-    disagree about.
+    All three are given the same console, since width and glyph set are
+    properties of where a frame lands rather than of how it got there. Run in
+    both glyph sets: rich draws ASCII bars on a legacy-Windows console, and the
+    routes have to agree there too.
     """
-    terminal = _stdout_bar_row(RichProgressReporter(console=_notebook_console()))
-    notebook = _stdout_bar_row(RichNotebookProgressReporter())
-
-    # ``_repr_mimebundle_`` renders through rich's *global* console, which this
-    # process leaves colorless and 80 wide. A kernel's is a Jupyter console, so
-    # pin an equivalent or the comparison measures the test rig, not the code.
     import rich  # noqa: PLC0415
 
-    monkeypatch.setattr(
-        rich, "_console",
-        Console(force_terminal=True, color_system="truecolor", width=NOTEBOOK_COLUMNS),
-        raising=False,
-    )
+    consoles = [_pinned_console(legacy=legacy) for _ in range(3)]
+    _require_comparable_consoles(*consoles)
+    terminal = _stdout_bar_row(RichProgressReporter(console=consoles[0]))
+    notebook = _stdout_bar_row(RichNotebookProgressReporter(console=consoles[1]))
+
+    # The slot renders through the *global* console, so pin that one to match.
+    monkeypatch.setattr(rich, "_console", _pinned_console(legacy=legacy), raising=False)
     monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
     handle = _fake_display(monkeypatch)
-    display = _slot_reporter()
+    display = _slot_reporter(console=consoles[2])
     display._console.file = io.StringIO()
     display.start("React", sources=("batch", "engine"))
     for event in _PARITY_EVENTS:
@@ -1174,22 +1231,20 @@ def test_every_reporter_renders_the_same_bar(monkeypatch):
     # Guard against the whole comparison passing on three empty strings.
     assert "2/4" in terminal            # the batch source drives the bar
     assert "engine 1/3" in terminal     # and the engine is folded in beside it
+    # And against the environment not actually differing between the two runs.
+    assert ("\u2501" in terminal) is not legacy, f"wrong glyph set for legacy={legacy}"
 
 
-def _slot_closing_rows(monkeypatch, *, success: bool) -> list[str]:
+def _slot_closing_rows(monkeypatch, *, success: bool, legacy: bool = False) -> list[str]:
     """Run the parity session on the display slot and return the rows it is left holding."""
     import rich  # noqa: PLC0415
 
-    # JupyterMixin renders through the *global* console; a kernel's is a Jupyter
-    # console, so pin an equivalent or this measures the test rig.
-    monkeypatch.setattr(
-        rich, "_console",
-        Console(force_terminal=True, color_system="truecolor", width=NOTEBOOK_COLUMNS),
-        raising=False,
-    )
+    # The slot renders through the *global* console, so that is the one whose
+    # glyph set has to match the streams it will be compared against.
+    monkeypatch.setattr(rich, "_console", _pinned_console(legacy=legacy), raising=False)
     monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
     handle = _fake_display(monkeypatch)
-    reporter = _slot_reporter()
+    reporter = _slot_reporter(console=_pinned_console(legacy=legacy))
     reporter._console.file = io.StringIO()
     reporter.start("React", sources=("batch", "engine"))
     for event in _PARITY_EVENTS:
@@ -1198,8 +1253,9 @@ def _slot_closing_rows(monkeypatch, *, success: bool) -> list[str]:
     return [_ANSI.sub("", row).rstrip() for row in _rows(handle.frames[-1])]
 
 
+@pytest.mark.parametrize("legacy", [False, True], ids=["box-drawing", "ascii"])
 @pytest.mark.parametrize("success", [True, False])
-def test_every_reporter_closes_the_same_way(monkeypatch, success):
+def test_every_reporter_closes_the_same_way(monkeypatch, success, legacy):
     """
     Verify all three routes leave the reader with the same thing.
 
@@ -1207,6 +1263,10 @@ def test_every_reporter_closes_the_same_way(monkeypatch, success):
     survives the close, which is a separate code path per route — clearing the
     region, repainting it, printing the final state once, or replacing a
     display slot's contents.
+
+    Run in both glyph sets. rich draws ASCII bars on a legacy-Windows console,
+    and the routes have to agree there too — the slot in particular reaches the
+    reader through a ``Table.grid``, whose sizing is measured, not fixed.
 
     That gap was not theoretical. The slot stacks a failed bar above its summary
     in a ``Table.grid``, and a grid sizes its column to the child's *maximum*
@@ -1223,11 +1283,13 @@ def test_every_reporter_closes_the_same_way(monkeypatch, success):
         reporter.finish(success=success, duration=timedelta(seconds=9))
         return view(buf.getvalue())
 
-    terminal = close(RichProgressReporter(console=_notebook_console()), _terminal_view)
-    notebook = close(RichNotebookProgressReporter(), _notebook_view)
+    consoles = [_pinned_console(legacy=legacy) for _ in range(3)]
+    _require_comparable_consoles(*consoles)
+    terminal = close(RichProgressReporter(console=consoles[0]), _terminal_view)
+    notebook = close(RichNotebookProgressReporter(console=consoles[1]), _notebook_view)
     monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
-    headless = close(RichDisplayProgressReporter(), _notebook_view)
-    slot = _slot_closing_rows(monkeypatch, success=success)
+    headless = close(RichDisplayProgressReporter(console=consoles[2]), _notebook_view)
+    slot = _slot_closing_rows(monkeypatch, success=success, legacy=legacy)
 
     assert notebook == terminal, f"notebook {notebook} != terminal {terminal}"
     assert headless == terminal, f"headless stdout {headless} != terminal {terminal}"
@@ -1235,6 +1297,9 @@ def test_every_reporter_closes_the_same_way(monkeypatch, success):
     # Guard against all three agreeing on nothing.
     expected = 1 if success else 2
     assert len(terminal) == expected, f"expected {expected} line(s), got {terminal}"
+    if not success:
+        # And against the environment not actually differing between the runs.
+        assert ("\u2501" in terminal[0]) is not legacy, f"wrong glyph set for legacy={legacy}"
 
 
 @pytest.mark.parametrize("sources", [("batch",), ("batch", "engine")])
@@ -1393,15 +1458,6 @@ def test_display_reporter_bakes_the_same_palette_the_other_routes_emit(monkeypat
     because ``_StateBarColumn`` picks its style per frame from the session's
     state — the constructor defaults never reach the screen.
     """
-    import rich  # noqa: PLC0415
-
-    # JupyterMixin renders through the *global* console; a kernel's is a Jupyter
-    # console, so pin an equivalent or this measures the test rig.
-    monkeypatch.setattr(
-        rich, "_console",
-        Console(force_terminal=True, color_system="truecolor", width=NOTEBOOK_COLUMNS),
-        raising=False,
-    )
     monkeypatch.setattr("howso.utilities.progress._interactive_frontend", lambda: False)
     handle = _fake_display(monkeypatch)
     reporter = _slot_reporter()
@@ -1536,7 +1592,7 @@ def test_simple_reporter_renders_the_estimate(capsys):
     reporter.update(ProgressEvent(source="batch", step=1200, total=10000,
                                   details="batch 3", eta=timedelta(seconds=83)))
     reporter.update(ProgressEvent(source="batch", step=2400, total=10000, details="batch 6"))
-    out = capsys.readouterr().out
+    out = _captured(capsys)
     assert f"batch 3 · {_format_eta(timedelta(seconds=83))}" in out
     assert "batch 6\n" in out          # no stray separator when there is no estimate
 
@@ -2168,7 +2224,7 @@ def test_simple_reporter_activity_line(capsys, monkeypatch):
     reporter.start("Analyze", sources=("activity",))
     reporter.update(ProgressEvent(source="activity", step=0, total=0))
     reporter.finish(success=True, duration=timedelta(seconds=1))
-    out = capsys.readouterr().out
+    out = _captured(capsys)
     assert "elapsed" in out
     assert "0/?" not in out
 
@@ -2210,6 +2266,36 @@ def test_auto_reporter_tty_picks_rich(monkeypatch):
     monkeypatch.delenv("HOWSO_SIMPLE_PROGRESS", raising=False)
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     assert type(auto_reporter()) is RichProgressReporter
+
+
+@pytest.fixture(autouse=True)
+def _pin_global_console(monkeypatch):
+    """
+    Pin rich's global console, which is what renders a display frame's mimebundle.
+
+    Three of its properties vary with the machine, and none of them is what
+    these tests are about: whether it emits color (``FORCE_COLOR`` alone turns
+    that on), how wide it is, and whether it draws bars in box characters or
+    falls back to ASCII. rich picks ASCII when ``legacy_windows`` is set or the
+    stream encoding is not UTF-8 — both true on the Windows CI runner, where a
+    slot frame arrived as ``------------`` beside the box-drawn stream frames it
+    is compared against. The streams render into a ``StringIO``, which reports
+    no encoding and so counts as UTF-8; the global console had the runner's real
+    stdout. Two different consoles, never going to agree.
+
+    This pins the rig, not the product. A Windows user still gets whatever their
+    console supports — rich adapting is correct, and the terminal reporter keeps
+    a stock ``Console`` so it detects that, per
+    ``test_terminal_reporter_measures_its_console``.
+    """
+    import rich  # noqa: PLC0415
+
+    monkeypatch.setattr(
+        rich, "_console",
+        Console(file=io.StringIO(), force_terminal=True, color_system="truecolor",
+                legacy_windows=False, width=NOTEBOOK_COLUMNS),
+        raising=False,
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -2588,7 +2674,7 @@ def test_simple_reporter_empty_sources_prints_label_and_completion(capsys):
     reporter.start("Analyze", sources=())
     reporter.update(ProgressEvent(source="engine", step=1, total=6, details="Analyzing"))
     reporter.finish(success=True, duration=timedelta(seconds=1.5))
-    out = capsys.readouterr().out
+    out = _captured(capsys)
     assert "Analyze" in out
     assert "Analyze complete in 0:00:01" in out
     assert "[" not in out  # the undeclared source produced no track line
@@ -2599,7 +2685,7 @@ def test_rich_reporter_empty_sources_completes_lifecycle(capsys):
     reporter.start("Analyze", sources=())
     reporter.update(ProgressEvent(source="engine", step=1, total=6, details="Analyzing"))
     reporter.finish(success=True, duration=timedelta(seconds=1.5))
-    assert "Analyze complete in" in capsys.readouterr().out
+    assert "Analyze complete in" in _captured(capsys)
 
 
 def test_with_progress_neither_method_still_runs():
@@ -2716,7 +2802,7 @@ def test_decorator_nested_calls_do_not_stack(capsys, monkeypatch):  # noqa: ARG0
             return self.inner()  # nested decorated call
     t = T()
     assert t.outer() == "inner"
-    out = capsys.readouterr().out
+    out = _captured(capsys)
     # Outer label appears; Inner label must NOT (re-entrancy guard).
     assert "Outer" in out
     assert "Inner" not in out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "python-dateutil",
     "pyyaml~=6.0",
     "requests>=2.32.4,<3.0",
-    "rich>=12.5.1",
+    "rich~=15.0",
     "sacremoses",
     "semantic-version~=2.0",
     "typing-extensions~=4.9",

--- a/requirements-3.11-dev.txt
+++ b/requirements-3.11-dev.txt
@@ -32,7 +32,7 @@ dill==0.4.1
     #   pylint
 execnet==2.1.2
     # via pytest-xdist
-faker==40.37.0
+faker==40.38.0
     # via howso-engine (pyproject.toml)
 flake8==3.9.2
     # via

--- a/requirements-3.11.txt
+++ b/requirements-3.11.txt
@@ -16,7 +16,7 @@ click==8.5.0
     # via sacremoses
 cloudpickle==3.1.2
     # via joblib
-faker==40.37.0
+faker==40.38.0
     # via howso-engine (pyproject.toml)
 humanize==4.16.0
     # via howso-engine (pyproject.toml)

--- a/requirements-3.12-dev.txt
+++ b/requirements-3.12-dev.txt
@@ -32,7 +32,7 @@ dill==0.4.1
     #   pylint
 execnet==2.1.2
     # via pytest-xdist
-faker==40.37.0
+faker==40.38.0
     # via howso-engine (pyproject.toml)
 flake8==3.9.2
     # via

--- a/requirements-3.12.txt
+++ b/requirements-3.12.txt
@@ -16,7 +16,7 @@ click==8.5.0
     # via sacremoses
 cloudpickle==3.1.2
     # via joblib
-faker==40.37.0
+faker==40.38.0
     # via howso-engine (pyproject.toml)
 humanize==4.16.0
     # via howso-engine (pyproject.toml)

--- a/requirements-3.13-dev.txt
+++ b/requirements-3.13-dev.txt
@@ -32,7 +32,7 @@ dill==0.4.1
     #   pylint
 execnet==2.1.2
     # via pytest-xdist
-faker==40.37.0
+faker==40.38.0
     # via howso-engine (pyproject.toml)
 flake8==3.9.2
     # via

--- a/requirements-3.13.txt
+++ b/requirements-3.13.txt
@@ -16,7 +16,7 @@ click==8.5.0
     # via sacremoses
 cloudpickle==3.1.2
     # via joblib
-faker==40.37.0
+faker==40.38.0
     # via howso-engine (pyproject.toml)
 humanize==4.16.0
     # via howso-engine (pyproject.toml)

--- a/requirements-3.14-dev.txt
+++ b/requirements-3.14-dev.txt
@@ -32,7 +32,7 @@ dill==0.4.1
     #   pylint
 execnet==2.1.2
     # via pytest-xdist
-faker==40.37.0
+faker==40.38.0
     # via howso-engine (pyproject.toml)
 flake8==3.9.2
     # via

--- a/requirements-3.14.txt
+++ b/requirements-3.14.txt
@@ -16,7 +16,7 @@ click==8.5.0
     # via sacremoses
 cloudpickle==3.1.2
     # via joblib
-faker==40.37.0
+faker==40.38.0
     # via howso-engine (pyproject.toml)
 humanize==4.16.0
     # via howso-engine (pyproject.toml)


### PR DESCRIPTION
Consistent progress rendering everywhere, plus fixes to what the reporters displayed.

**One rendering, four delivery routes.** A progress-session is now one, merged bar, whatever
its progress sources: `batch` owns it and `engine` folds into the details text.
`RichProgressReporter` owns the model and lifecycle; subclasses vary only in how
a frame reaches the reader. A cross-route test asserts all four produce identical
output, which is what keeps them from drifting.

- **Terminal** — live region, cursor hidden, console measured.
- **Notebook** (`RichNotebookProgressReporter`) — repaints stdout using only the
  control codes that notebook front-ends can honor, so a whole cell stays in one output block.
- **Headless** (`RichDisplayProgressReporter`) — for `nbconvert`/`papermill`/etc. Writes
  the final state to stdout in one go: nobody watches a headless run and
  `nbconvert` can't animate intermediate frames, while every display block carries
  its own padding. Set `_slot_when_headless = True` for the old
  display-slot repaint, worth it when the `allow_stdin` headless heuristic is
  wrong about whether someone is watching.
- **Fallback** — a kernel passing neither probe still gets the `SimpleProgressReporter`.

**The bar and the summary share a line.** The bar owns it while the call runs,
then the summary takes it over — a terminal clears the region and prints, a
notebook repaints the summary into it. `transient` is now a class member
selecting between those, not a visible difference.

**A failed session keeps its bar**, on every route, so you can see which sub-step
raised — `batch 7`, `engine 2/5`. The summary can't carry that.

**Fixes**
- `rich` treats `completed >= total` as done, but the engine reporting its last
  step is not the call returning. This froze the elapsed clock, turned the bar
  green and stopped the spinner while work continued. All three now key off the
  session ending.
- A call fast enough to finish before the first repaint left its whole bar
  standing behind the summary. `rich` emits its first frame with no carriage
  return, and the overwrite-safe writer only tracked lines that had one.
- Stacking a failed bar above its summary in a display slot wrapped the details
  onto a second row; a grid sizes to the child's *maximum* measurement.

**Also**
- Estimated remaining time for batched calls, from `ProgressTimer.time_remaining`.
- `auto_progress` applied to `reduce_data` and `combine_trainee_with_subtrainees`.
- `indeterminate=True` where the only progress hook disappears on a
  single-threaded engine: `analyze`, `impute`, `react_group`,
  `react_into_features`, `combine_trainee_with_subtrainees`.
- Every color is a named ANSI palette index, so the theme controls appearance.
- The label column sizes to its own label — one bar is on screen at a time, so
  nothing has to line up across sessions.
- `stdout`/`stderr` flushed at session boundaries so buffered output can't
  surface mid-render.
- `ERROR_MESSAGES` is now an immutable `Mapping`.
- New env vars: `HOWSO_PROGRESS_COLUMNS` (notebook width, default 120) and
  `HOWSO_PROGRESS_FPS` (notebook refresh, default 4).

272 progress tests, all mutation-checked.